### PR TITLE
FGDC format cannot be viewed by SID

### DIFF
--- a/src/js/views/MetadataIndexView.js
+++ b/src/js/views/MetadataIndexView.js
@@ -61,7 +61,8 @@ define(['jquery',
 			var view = this;
 						
 			//Get all the fields from the Solr index
-			var query = 'q=id:"' + encodeURIComponent(this.pid) + '"&rows=1&start=0&fl=*&wt=json';
+			var query = 'q=(id:"' + encodeURIComponent(this.pid) + '"+OR+seriesId:"'+
+									encodeURIComponent(this.pid)+'")&rows=1&start=0&fl=*&wt=json';
 			var requestSettings = {
 				url: MetacatUI.appModel.get('queryServiceUrl') + query, 
 				success: function(data, textStatus, xhr){ 


### PR DESCRIPTION
Closes #453

Fixed issue where FGDC SID not viewing

The solution to this was to add `seriesId` to the
query in `MetadataIndexView.render()`.