### PR TITLE
Scroll the variables (attributes) list when needed

### DIFF
--- a/src/css/metacatui-common.css
+++ b/src/css/metacatui-common.css
@@ -1538,6 +1538,8 @@ body > .alert-container {
   min-width: 130px;
   max-width: 150px;
   max-width: calc(165px - 2.127659574468085%);
+  max-height: 700px;
+  overflow-y: scroll;
 }
 .tab-content,
 .row-fluid .tab-content.span10{


### PR DESCRIPTION
Prior to this fix, an entity with many (~50+) attributes wouldn't display in a user-friendly manner. See #511 for a demo. I chose a max-height of 700px because that's about what size the attribute detail pane (on the right) gets automatically set to by the my browser for a simple attribute.

Partially addresses #511

I've tested this out with the arctic and dataone themes.