### PR TITLE
Locally reference jquery.1.9.1.min.js

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -34,7 +34,7 @@ require.config({
   map: MetacatUI.themeMap,
   urlArgs: "v=" + MetacatUI.metacatUIVersion,
   paths: {
-    jquery: 'https://code.jquery.com/jquery-1.9.1.min',
+    jquery: '../components/jquery-1.9.1.min',
     jqueryui: '../components/jquery-ui.min',
     jqueryform: '../components/jquery.form',
     underscore: '../components/underscore-min',


### PR DESCRIPTION
Closes #575 

This morning `https://code.jquery.com/jquery-1.9.1.min` is unavailable for a time which made ESS-DIVE available. 

Since [`jquery.1.9.1.min.js`](https://github.com/NCEAS/metacatui/blob/master/src/components/jquery-1.9.1.min.js) is already checked into the metacatui code base I propose referencing it in `app.js` [here](https://github.com/NCEAS/metacatui/blob/403baccb4af080aecc33512c2c2a3962b080582c/src/js/app.js#L37).

