### PR TITLE
Add copy-on-click support to the DOM returned by the view service

### DIFF
--- a/src/js/views/MetadataView.js
+++ b/src/js/views/MetadataView.js
@@ -121,6 +121,13 @@ define(['jquery',
 				this.pid = MetacatUI.appModel.get("pid");
 
 			this.listenTo(MetacatUI.appUserModel, "change:loggedIn", this.render);
+
+			// Injects Clipboard objects into DOM elements returned from the View
+			// Service
+			this.on("metadataLoaded", function() {
+				this.insertCopiables();
+			})
+
 			this.getModel();
             
 			return this;
@@ -875,6 +882,44 @@ define(['jquery',
 				packageModel.checkAuthority();
 			});
 			this.model.checkAuthority();
+		},
+
+		/*
+		 * Injects Clipboard objects onto DOM elements returned from the Metacat
+		 * View Service. This code depends on the implementation of the Metacat
+		 * View Service in that it depends on elements with the class "copy" being
+		 * contained in the HTML returned from the View Service.
+		 * 
+		 * To add more copiable buttons (or other elements) to a View Service XSLT,
+		 * you should be able to just add something like:
+		 * 
+		 *   <button class="btn copy" data-clipboard-text="your-text-to-copy">
+		 * 	   Copy
+		 *   </button>
+		 * 
+		 * to your XSLT and this should pick it up automatically.
+		*/
+		insertCopiables: function(){
+			var container = $("#Metadata");
+			var copiables = $(container).find(".copy");
+
+			_.each(copiables, function(copiable) {
+				var clipboard = new Clipboard(copiable);
+
+				clipboard.on("success", function(e) {
+					var el = $(e.trigger),
+							oldInner = $(el).html();
+				
+					$(el).html("✔");
+
+					// Use setTimeout instead of jQuery's built-in Events system because
+					// it didn't look flexible enough to allow me update innerHTML in 
+					// a chain
+					setTimeout(function() {
+						$(el).html(oldInner);
+					}, 500)
+				});
+			});
 		},
 
 		/*


### PR DESCRIPTION
This behavior is slightly different than the Copy Citation in that it just replaces the innerHTML with a ✔ and, after 500ms, returns the old button (or other element) innerHTML. This'll also work if someone needs copiables in other areas of the view service later on.

Preview:

![kapture 2018-04-30 at 16 56 31](https://user-images.githubusercontent.com/563/39457177-6bda5e1e-4c98-11e8-9797-0660f86f3def.gif)


Closes #591