### PR TITLE
Add PANGAEA-specific override to CitationView

### DIFF
--- a/src/js/views/CitationView.js
+++ b/src/js/views/CitationView.js
@@ -205,7 +205,13 @@ define(['jquery', 'underscore', 'backbone', 'models/SolrResult'],
 			//The ID
 			var idEl = $(document.createElement("span")).addClass("id");
 			if (seriesId) {
-				$(idEl).text(seriesId + ", version: " + id + ". ");
+				// Begin PANGAEA-specific override (this is temporary)
+				if (typeof datasource !== "undefined" && datasource !== null && datasource === "urn:node:PANGAEA") {
+					$(idEl).text(seriesId +". ");
+				// End PANGAEA-specific override
+				} else {
+					$(idEl).text(seriesId + ", version: " + id + ". ");
+				}
 			}
 			else {
 				$(idEl).text("" + id + ". ");


### PR DESCRIPTION
This modifies the look of the CitationView when the `datasoruce`
is `urn:node:PANGAEA` and the metadata Object has a SID. When that
is the case, only the SID will be displayed.

@laurenwalker does this conflict with your work on making URIs in the CitationView clickable? 

I did a minor amount of testing and this appears to work as intended.