### PR TITLE
Fix bug in MetadataView.insertCopiables

### DIFF
--- a/src/js/views/MetadataView.js
+++ b/src/js/views/MetadataView.js
@@ -899,8 +899,7 @@ define(['jquery',
 				var clipboard = new Clipboard(copiable);
 
 				clipboard.on("success", function(e) {
-					var el = $(e.trigger),
-							oldInner = $(el).html();
+					var el = $(e.trigger);
 
 					$(el).html( $(document.createElement("span")).addClass("icon icon-ok success") );
 
@@ -908,7 +907,7 @@ define(['jquery',
 					// it didn't look flexible enough to allow me update innerHTML in
 					// a chain
 					setTimeout(function() {
-						$(el).html(oldInner);
+						$(el).html("Copy");
 					}, 500)
 				});
 			});


### PR DESCRIPTION
I had some bad logic in my initial implementation that caused the button text to permanently become a ✔️ if the user clicks the button fast. This was because the callback that re-sets the text back to its original value picks up the termporary value. Now the button will always return to "Copy".