### PR TITLE
Add support for Highwire Press bibliographic meta tags

### DIFF
--- a/src/js/routers/router.js
+++ b/src/js/routers/router.js
@@ -47,6 +47,10 @@ function ($, _, Backbone) {
 			this.route(/^view\/(.*)$/, "renderMetadata");
 
 			this.on("route", this.trackHash);
+			
+			// Clear stale JSONLD and meta tags
+			this.on("route", this.clearJSONLD);
+			this.on("route", this.clearHighwirePressMetaTags);
 		},
 
 		//Keep track of navigation movements
@@ -539,6 +543,17 @@ function ($, _, Backbone) {
 				MetacatUI.appView.statsView.onClose();
 			else if(lastRoute == "profile")
 				MetacatUI.appView.userView.onClose();
+		},
+
+		clearJSONLD: function() {
+			$("#jsonld").remove();
+		},
+
+		clearHighwirePressMetaTags: function() {
+			$("head > meta[name='citation_title']").remove()
+			$("head > meta[name='citation_authors']").remove()
+			$("head > meta[name='citation_publisher']").remove()
+			$("head > meta[name='citation_date']").remove()
 		}
 
 	});

--- a/src/js/templates/metaTagsHighwirePress.html
+++ b/src/js/templates/metaTagsHighwirePress.html
@@ -1,0 +1,4 @@
+<meta name="citation_title" content="<%= title %>">
+<meta name="citation_authors" content="<%= authors %>">
+<meta name="citation_publisher" content="<%= publisher %>">
+<meta name="citation_date" content="<%= date %>">

--- a/src/js/themes/arctic/routers/router.js
+++ b/src/js/themes/arctic/routers/router.js
@@ -39,6 +39,10 @@ function ($, _, Backbone) {
 
 			//Track the history of hashes
 			this.on("route", this.trackHash);
+			
+			// Clear stale JSONLD and meta tags
+			this.on("route", this.clearJSONLD);
+			this.on("route", this.clearHighwirePressMetaTags);
 		},
 
 		//Keep track of navigation movements
@@ -405,6 +409,17 @@ function ($, _, Backbone) {
 				MetacatUI.appView.statsView.onClose();
 			else if(lastRoute == "profile")
 				MetacatUI.appView.userView.onClose();
+		},
+
+		clearJSONLD: function() {
+			$("#jsonld").remove();
+		},
+
+		clearHighwirePressMetaTags: function() {
+			$("head > meta[name='citation_title']").remove()
+			$("head > meta[name='citation_authors']").remove()
+			$("head > meta[name='citation_publisher']").remove()
+			$("head > meta[name='citation_date']").remove()
 		}
 
 	});

--- a/src/js/themes/dataone/routers/router.js
+++ b/src/js/themes/dataone/routers/router.js
@@ -39,6 +39,10 @@ function ($, _, Backbone) {
 			
 			//Track the history of hashes
 			this.on("route", this.trackHash);
+			
+			// Clear stale JSONLD and meta tags
+			this.on("route", this.clearJSONLD);
+			this.on("route", this.clearHighwirePressMetaTags);
 		},
 
 		//Keep track of navigation movements
@@ -356,6 +360,17 @@ function ($, _, Backbone) {
 				MetacatUI.appView.statsView.onClose();
 			else if(lastRoute == "profile")
 				MetacatUI.appView.userView.onClose();
+		},
+
+		clearJSONLD: function() {
+			$("#jsonld").remove();
+		},
+
+		clearHighwirePressMetaTags: function() {
+			$("head > meta[name='citation_title']").remove()
+			$("head > meta[name='citation_authors']").remove()
+			$("head > meta[name='citation_publisher']").remove()
+			$("head > meta[name='citation_date']").remove()
 		}
 
 	});

--- a/src/js/themes/goa/routers/router.js
+++ b/src/js/themes/goa/routers/router.js
@@ -42,6 +42,10 @@ function ($, _, Backbone) {
 			this.route(/^view\/(.*)$/, "renderMetadata");
 
 			this.on("route", this.trackHash);
+			
+			// Clear stale JSONLD and meta tags
+			this.on("route", this.clearJSONLD);
+			this.on("route", this.clearHighwirePressMetaTags);
 		},
 
 		//Keep track of navigation movements
@@ -408,6 +412,17 @@ function ($, _, Backbone) {
 				MetacatUI.appView.statsView.onClose();
 			else if(lastRoute == "profile")
 				MetacatUI.appView.userView.onClose();
+		},
+
+		clearJSONLD: function() {
+			$("#jsonld").remove();
+		},
+
+		clearHighwirePressMetaTags: function() {
+			$("head > meta[name='citation_title']").remove()
+			$("head > meta[name='citation_authors']").remove()
+			$("head > meta[name='citation_publisher']").remove()
+			$("head > meta[name='citation_date']").remove()
 		}
 
 	});

--- a/src/js/themes/nceas/routers/router.js
+++ b/src/js/themes/nceas/routers/router.js
@@ -29,6 +29,10 @@ function ($, _, Backbone) {
 
 			//Track the history of hashes
 			this.on("route", this.trackHash);
+
+			// Clear stale JSONLD and meta tags
+			this.on("route", this.clearJSONLD);
+			this.on("route", this.clearHighwirePressMetaTags);
 		},
 
 		//Keep track of navigation movements
@@ -227,6 +231,17 @@ function ($, _, Backbone) {
 		closeLastView: function(){
 			//Get the last route and close the view
 			var lastRoute = _.last(this.routeHistory);
+		},
+
+		clearJSONLD: function() {
+			$("#jsonld").remove();
+		},
+
+		clearHighwirePressMetaTags: function() {
+			$("head > meta[name='citation_title']").remove()
+			$("head > meta[name='citation_authors']").remove()
+			$("head > meta[name='citation_publisher']").remove()
+			$("head > meta[name='citation_date']").remove()
 		}
 
 	});

--- a/src/js/views/MetadataView.js
+++ b/src/js/views/MetadataView.js
@@ -35,14 +35,15 @@ define(['jquery',
 		'text!templates/map.html',
 		'text!templates/annotation.html',
 		'uuid',
-        'views/MetricView'
+				'views/MetricView',
+		'text!templates/metaTagsHighwirePress.html',
 		],
 	function($, $ui, _, Backbone, gmaps, fancybox, Clipboard, DataPackage, DataONEObject, Package, NodeModel, SolrResult, ScienceMetadata,
 			 MetricsModel, DownloadButtonView, ProvChart, MetadataIndex, ExpandCollapseList, ProvStatement, PackageTable,
 			 AnnotatorView, CitationView, MetadataTemplate, DataSourceTemplate, PublishDoiTemplate,
 			 VersionTemplate, LoadingTemplate, ControlsTemplate, UsageTemplate,
 			 DownloadContentsTemplate, AlertTemplate, EditMetadataTemplate, DataDisplayTemplate,
-			 MapTemplate, AnnotationTemplate, uuid, MetricView) {
+			 MapTemplate, AnnotationTemplate, uuid, MetricView, metaTagsHighwirePressTemplate) {
 	'use strict';
 
 
@@ -85,6 +86,7 @@ define(['jquery',
 		editMetadataTemplate: _.template(EditMetadataTemplate),
 		dataDisplayTemplate: _.template(DataDisplayTemplate),
 		mapTemplate: _.template(MapTemplate),
+		metaTagsHighwirePressTemplate: _.template(metaTagsHighwirePressTemplate),
 
 		objectIds: [],
 
@@ -314,6 +316,8 @@ define(['jquery',
 				var json = this.generateJSONLD();
 				this.insertJSONLD(json);
 			}
+
+			this.insertCitationMetaTags();
 		},
 
 		/* If there is no view service available, then display the metadata fields from the index */
@@ -2122,25 +2126,12 @@ define(['jquery',
 		},
 
 		/**
-		 * Generate Schema.org-compliant JSONLD for the model bound to the view into
-		 *  the head tag of the page by `insertJSONLD`.
-		 *
-		 * Note: `insertJSONLD` should be called to do the actual inserting into the
-		 * DOM.
+		 * Generate a string appropriate to go into the author/creator portion of
+		 * a dataset citation from the value stored in the underlying model's 
+		 * origin field.
 		 */
-		generateJSONLD: function () {
-			var model = this.model;
-
-			// Determine the path (either #view or view, depending on router
-			// configuration) for use in the 'url' property
-			var href = document.location.href,
-					route = href.replace(document.location.origin + "/", "")
-					            .split("/")[0];
-
-			// Logic for formatting Author's text for the citation
-			// Copied and re-formatted from CitationView.js
-			// TODO: Maybe put this in a shared helper function somewhere
-			var authors = model.get("origin"),
+		getAuthorText: function() {
+			var authors = this.model.get("origin"),
 				count = 0,
 				authorText = "";
 
@@ -2171,34 +2162,60 @@ define(['jquery',
 				authorText += author;
 			});
 
-			// Dataset/datePublished
-			// Prefer pubDate, fall back to dateUploaded so we have something to show
-			var datePublished = null;
+			return authorText;
+		},
 
-			if (model.get("pubDate") !== "") {
-				datePublished = model.get("pubDate")
-			} else {
-				datePublished = model.get("dateUploaded")
-			}
-
-			// Dataset/publisher
-			// Copied and lightly modified from CitationView
-			var publisher = "",
-				datasource = this.model.get("datasource"),
+		/**
+		 * Generate a string appropriate to be used in the publisher portion of a 
+		 * dataset citation. This method falls back to the node ID when the proper
+		 * node name cannot be fetched from the app's NodeModel instance.
+		 */
+		getPublisherText: function() {
+			var datasource = this.model.get("datasource"),
 				memberNode = MetacatUI.nodeModel.getMember(datasource);
 
 			if (memberNode) {
-				publisher = memberNode.name;
+				return memberNode.name;
 			} else {
-				publisher = datasource;
+				return datasource;
 			}
+		},
 
+		/**
+		 * Generate a string appropriate to be used as the publication date in a 
+		 * dataset citation.
+		 */
+		getDatePublishedText() {
+			// Dataset/datePublished
+			// Prefer pubDate, fall back to dateUploaded so we have something to show
+			if (this.model.get("pubDate") !== "") {
+				return this.model.get("pubDate")
+			} else {
+				return this.model.get("dateUploaded")
+			}
+		},
+
+		/**
+		 * Generate Schema.org-compliant JSONLD for the model bound to the view into
+		 *  the head tag of the page by `insertJSONLD`.
+		 *
+		 * Note: `insertJSONLD` should be called to do the actual inserting into the
+		 * DOM.
+		 */
+		generateJSONLD: function () {
+			var model = this.model;
+
+			// Determine the path (either #view or view, depending on router
+			// configuration) for use in the 'url' property
+			var href = document.location.href,
+					route = href.replace(document.location.origin + "/", "")
+					            .split("/")[0];
 			// Citation
 			var citationParts = [
-						authorText,
-						new Date(datePublished).getUTCFullYear().toString(),
+						this.getAuthorText(),
+						new Date(this.getDatePublishedText()).getUTCFullYear().toString(),
 						model.get("title"),
-						publisher,
+						this.getPublisherText(),
 						model.get("id")],
 				  citationText = citationParts.join(". ") + ".";
 
@@ -2212,8 +2229,8 @@ define(['jquery',
 				"@type": "Dataset",
 				"@id": "https://dataone.org/datasets/" +
 					encodeURIComponent(model.get("id")),
-				"datePublished" : datePublished,
-				"publisher": publisher,
+				"datePublished" : this.getDatePublishedText(),
+				"publisher": this.getPublisherText(),
 				"identifier": model.get("id"),
 				"url": "https://dataone.org/datasets/" +
 					encodeURIComponent(model.get("id")),
@@ -2446,8 +2463,38 @@ define(['jquery',
 			var postamble = "]]}}";
 
 			return preamble + inner + postamble;
-		}
+		},
 
+		/**
+		 * Insert citation information as meta tags into the head of the page
+		 * 
+		 * Currently supports Highwire Press style tags (citation_) which is 
+		 * supposedly what Google (Scholar), Mendeley, and Zotero support.
+		 */
+		insertCitationMetaTags: function() {
+			// Generate template data to use for all templates
+			var title = this.model.get("title"),
+				authors = this.getAuthorText(),
+				publisher = this.getPublisherText(),
+				date = new Date(this.getDatePublishedText()).getUTCFullYear().toString();
+
+			// Generate HTML strings from each template
+			var hwpt = this.metaTagsHighwirePressTemplate({
+				title: title,
+				authors: authors,
+				publisher: publisher,
+				date: date
+			});
+
+			// Clear any that are already in the document.
+			$("meta[name='citation_title']").remove();
+			$("meta[name='citation_authors']").remove();
+			$("meta[name='citation_publisher']").remove();
+			$("meta[name='citation_date']").remove();
+			
+			// Insert
+			document.head.insertAdjacentHTML("beforeend", hwpt);
+		}
 	});
 
 	return MetadataView;


### PR DESCRIPTION
This change required a refactor of the JSONLD work to DRY up code that needed similar logic between the JSONLD and Highwire Press code.

While I was in here, I realized we weren't properly removing stale JSONLD so I added a method that is attached to all routers' 'route' event that clears the stale JSONLD and also the Highwire Press meta tags.

Resolves #491 if we think this is enough for now.