### PR TITLE
Metrics chart tweaks

### DIFF
--- a/src/css/metacatui-common.css
+++ b/src/css/metacatui-common.css
@@ -1852,7 +1852,7 @@ a.btn.metrics:hover, a.btn.metrics:click {
     text-align: center;
     vertical-align: middle;
     line-height: 150px;
-    
+
 }
 
 #metric-modal .metric-chart text.no-data {
@@ -1884,7 +1884,7 @@ a.btn.metrics:hover, a.btn.metrics:click {
 
 #metric-modal .metric-chart path.area {
 	fill: black; /* default, changed in each theme */
-	opacity: 0.35;
+	opacity: 0.6;
 	clip-path: url(#clip);
 }
 
@@ -1898,7 +1898,7 @@ a.btn.metrics:hover, a.btn.metrics:click {
 
 #metric-modal .metric-chart .x.axis line {
 	stroke: white;
-	opacity: 0.8;
+	opacity: 0.4;
 }
 
 #metric-modal .metric-chart .context .x.axis line {
@@ -1907,9 +1907,6 @@ a.btn.metrics:hover, a.btn.metrics:click {
 
 #metric-modal .metric-chart .y.axis .domain{
 	display: none;
-	/* fill:none;
-	stroke: #565656;
-	stroke-width: 1px; */
 }
 
 #metric-modal .metric-chart .y.axis.title{

--- a/src/js/views/CitationListView.js
+++ b/src/js/views/CitationListView.js
@@ -38,21 +38,21 @@ define(['jquery', 'underscore', 'backbone', 'collections/Citations', 'views/Cita
             if ($.isEmptyObject(this.citationsCollection.get("models"))) {
                 var $emptyList = $(document.createElement("div"))
                                             .addClass("empty-citation-list");
-                                            
+
                 var $emptyDataElement = $(document.createElement("p"))
-                                            .text("No data to display yet.")
+                                            .text("This data hasn't been cited yet.")
                                             .addClass("empty-citation-list-text");
-                
+
                 $emptyList.append($emptyDataElement);
                 this.$el.append($emptyList);
             }
             else {
-                
+
                 var $table = $(document.createElement("table"))
                                             .addClass("metric-table table table-striped table-condensed");
-                                            
+
                 var $tableBody = $(document.createElement("tbody"));
-                
+
                 this.citationsCollection.each(
                     function(model) {
                         var citationView = new CitationView({model:model});
@@ -64,13 +64,13 @@ define(['jquery', 'underscore', 'backbone', 'collections/Citations', 'views/Cita
                         $tableBody.append($tableRow);
                     }
                 );
-                
+
                 $table.append($tableBody);
                 this.$el.append($table);
             }
-            
+
         }
     });
-     
+
      return CitationListView;
   });

--- a/src/js/views/MetricsChartView.js
+++ b/src/js/views/MetricsChartView.js
@@ -191,7 +191,6 @@ define(['jquery', 'underscore', 'backbone', 'd3'],
             	.range([height_context, 0])
                 .domain(y.domain());
 
-                //doi:10.18739/A2QR4NQ1J
             var xAxis_context = d3.svg.axis()
                 .scale(x2)
                 .orient("bottom")


### PR DESCRIPTION
This PR includes the changes mentioned in the MDC call today, specifically this update:
- changes the "No data to display yet" text to "This dataset hasn’t been [cited/downloaded/viewed] yet."
- changes the date range of the slider/context chart to match the date range of the data. In addition, the zoom to: "year" button will now only appear if there is at least 1 year of data to show (the "month" and "data" buttons remain in any case).
- increases the opacity of the fill area in an attempt to make the chart appear more consistent with the overall colour scheme. The most recent commit can be `reset` if this isn't the desired look.