### PR TITLE
Add a toggle-able dropdown to the metadata view that allows someone t…

### DIFF
--- a/src/css/metacatui-common.css
+++ b/src/css/metacatui-common.css
@@ -4777,3 +4777,37 @@ CSS library fixes
   background-image:      -o-linear-gradient(45deg, rgba(255, 255, 255, .15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, .15) 50%, rgba(255, 255, 255, .15) 75%, transparent 75%, transparent);
   background-image:         linear-gradient(45deg, rgba(255, 255, 255, .15) 25%, transparent 25%, transparent 50%, rgba(255, 255, 255, .15) 50%, rgba(255, 255, 255, .15) 75%, transparent 75%, transparent);
 }
+
+.dropdown.btn.btn-secondary.dropdown-toggle .icon-bar-chart
+{
+    margin-right: 10px;
+}
+
+.dropdown.btn.btn-secondary.dropdown-toggle .analyze-text {
+    margin-right:10px;
+    font-weight: 600;
+}
+
+div.analyze.dropdown{
+    display: inline-block;
+}
+
+div.analyze.dropdown.open button.dropdown.btn.btn-secondary.dropdown-toggle{
+    display: inline-block;
+    color:white;
+    text-shadow: 0;
+    background-color: #1C6E84;
+    border-width: 0px;
+}
+
+div.controls.btn-toolbar{
+    font-size: 1em;
+}
+
+.analyze.dropdown-menu {
+    border: none;
+    border-radius: 10px;
+    padding: 0px;
+    margin: 0px;
+}
+

--- a/src/js/models/AppModel.js
+++ b/src/js/models/AppModel.js
@@ -33,8 +33,12 @@ define(['jquery', 'underscore', 'backbone'],
 			maxDownloadSize: 3000000000,
 
 			// set this variable to true, if the content being published is moderated by the data team.
-			contentIsModerated: false,
+      contentIsModerated: false, 
 
+      // Flag which, when true shows Whole Tale features in the UI
+      showWholeTaleFeatures: false,
+      taleEnvironments: ["RStudio", "Jupyter Notebook", "OpenRefine"],
+      dashboardUrl: 'https://dashboard.dev.wholetale.org/',
 			/*
 			 * emlEditorRequiredFields is a hash map of all the required fields in the EML Editor.
 			 * Any field set to true will prevent the user from saving the Editor until a value has been given

--- a/src/js/templates/metadataControls.html
+++ b/src/js/templates/metadataControls.html
@@ -1,6 +1,18 @@
 <div class="metrics-container btn-toolbar"></div>
 
 <div class="controls btn-toolbar">
+  <% if (showWholetale){ %>
+    <div class="analyze dropdown">
+      <button class="dropdown btn btn-secondary dropdown-toggle" type="button" data-toggle="dropdown">
+          <i class="icon-bar-chart"></i>
+          <span class="analyze-text">Analyze</span>
+          <span class="caret"></span>
+      </button>
+      <ul class="analyze dropdown-menu">
+      </ul>
+    </div>
+  <% } %>
+
 	<a class="btn copy" data-clipboard-text="<%=citation%>"><i class="icon icon-copy"></i> Copy Citation</a>
 
 	<% if (mdqUrl){ %>

--- a/src/js/themes/arctic/models/AppModel.js
+++ b/src/js/themes/arctic/models/AppModel.js
@@ -35,6 +35,10 @@ define(['jquery', 'underscore', 'backbone'],
 			// set this variable to true, if the content being published is moderated by the data team.
 			contentIsModerated: true,
 
+      // Flag which, when true shows Whole Tale features in the UI
+      showWholeTaleFeatures: false,
+      taleEnvironments: ["RStudio", "Jupyter Notebook", "OpenRefine"],
+      dashboardUrl: 'https://dashboard.dev.wholetale.org/',
 			/*
 			 * emlEditorRequiredFields is a hash map of all the required fields in the EML Editor.
 			 * Any field set to true will prevent the user from saving the Editor until a value has been given
@@ -69,7 +73,7 @@ define(['jquery', 'underscore', 'backbone'],
 
 			baseUrl: window.location.origin || (window.location.protocol + "//" + window.location.host),
 			// the most likely item to change is the Metacat deployment context
-			context: '/metacat',
+      context: '/metacat',
 			d1Service: '/d1/mn/v2',
 			d1CNBaseUrl: "https://cn.dataone.org/",
 			d1CNService: "cn/v2",

--- a/src/js/themes/dataone/models/AppModel.js
+++ b/src/js/themes/dataone/models/AppModel.js
@@ -35,6 +35,11 @@ define(['jquery', 'underscore', 'backbone'],
 			// set this variable to true, if the content being published is moderated by the data team.
 			contentIsModerated: false,
 
+      // Flag which, when true shows Whole Tale features in the UI
+      showWholeTaleFeatures: false,
+      taleEnvironments: ["RStudio", "Jupyter Notebook", "OpenRefine"],
+      dashboardUrl: 'https://dashboard.dev.wholetale.org/',
+            
 			baseUrl: window.location.origin || (window.location.protocol + "//" + window.location.host),
 			// the most likely item to change is the Metacat deployment context
 			context: '',

--- a/src/js/themes/knb/models/AppModel.js
+++ b/src/js/themes/knb/models/AppModel.js
@@ -35,6 +35,10 @@ define(['jquery', 'underscore', 'backbone'],
 			// set this variable to true, if the content being published is moderated by the data team.
 			contentIsModerated: false,
 
+      // Flag which, when true shows Whole Tale features in the UI
+      showWholeTaleFeatures: false,
+      taleEnvironments: ["RStudio", "Jupyter Notebook", "OpenRefine"],
+      dashboardUrl: 'https://dashboard.dev.wholetale.org/',
 			/*
 			 * emlEditorRequiredFields is a hash map of all the required fields in the EML Editor.
 			 * Any field set to true will prevent the user from saving the Editor until a value has been given

--- a/src/js/views/MetadataView.js
+++ b/src/js/views/MetadataView.js
@@ -951,7 +951,8 @@ define(['jquery',
 			var controlsContainer = this.controlsTemplate({
 					citation: $(this.citationContainer).text(),
 					url: window.location,
-					mdqUrl: MetacatUI.appModel.get("mdqUrl"),
+                    mdqUrl: MetacatUI.appModel.get("mdqUrl"),
+                    showWholetale: MetacatUI.appModel.get("showWholeTaleFeatures"),
 					model: this.model.toJSON()
 				});
 
@@ -965,6 +966,10 @@ define(['jquery',
 				model: this.model.toJSON()
 			}) );
 
+            if(MetacatUI.appModel.get("showWholeTaleFeatures")) {
+                this.createWholeTaleButton ();
+            }
+            
 			//Create clickable "Copy" buttons to copy text (e.g. citation) to the user's clipboard
 			var copyBtns = $(this.controlsContainer).find(".copy");
 			_.each(copyBtns, function(btn){
@@ -1014,12 +1019,31 @@ define(['jquery',
 					textarea.focusout(function(){
 						textarea.animate({ width: "0px" }, function(){
 							textarea.remove();
-						})
+						});
 					});
 				});
 			});
 			this.$(".tooltip-this").tooltip();
 		},
+
+    /**
+     *Creates a button which the user can click to launch the package in Whole Tale
+    */
+    createWholeTaleButton: function() {
+      let self=this;
+      MetacatUI.appModel.get('taleEnvironments').forEach(function(environment){
+        var queryParams=
+        '?data_location='+ self.model.id +
+        '&data_title='+encodeURIComponent(self.model.get("title"))+
+        '&data_api='+encodeURIComponent(MetacatUI.appModel.get('d1CNBaseUrl'))+
+        '&environment='+environment;
+        var composeUrl = MetacatUI.appModel.get('dashboardUrl')+'compose'+queryParams;
+        $('.analyze.dropdown-menu').append(
+            $('<li>').append(
+              $('<a>').attr('href',composeUrl).append(
+                $('<span>').attr('class', 'tab').append(environment))));
+        });
+      },
 
 		// Inserting the Metric Stats
 		insertMetricsControls: function() {


### PR DESCRIPTION
# Whole Tale Environments

This PR is for a feature that allows a user to come from DataONE to Whole Tale with the intent on using a data package. To do this I added a dropdown menu next to the copy button in the metadata view.

## Whole Tale Flag

I added a flag to the appmodels so we can easily toggle the feature on and off. You can see where the application uses this on line 955 in `src/js/views/MetadataView.js`

## Dropdown Menu

I added the dropdown menu to `src/js/templates/metadataControls.html`. It uses the result from above to check if it should render the content.

## Links For Each Menu Item

I construct the links for each compute environment at line 1032 `src/js/views/MetadataView.js`