### PR TITLE
Feature: Analyze Button

### DIFF
--- a/src/css/metacatui-common.css
+++ b/src/css/metacatui-common.css
@@ -1596,11 +1596,11 @@ body > .alert-container {
 }
 
 /* ---- Analyze Button ---- */
-.dropdown.btn.btn-secondary.dropdown-toggle .icon-bar-chart
+div.dropdown.btn.btn-secondary.dropdown-toggle .icon-bar-chart
 {
 	margin-right: 10px;
 }
-.dropdown.btn.btn-secondary.dropdown-toggle .analyze-text {
+div.dropdown.btn.btn-secondary.dropdown-toggle .analyze-text {
 	margin-right:10px;
 	font-weight: 600;
 }
@@ -1614,10 +1614,10 @@ div.analyze.dropdown.open button.dropdown.btn.btn-secondary.dropdown-toggle{
 	background-color: #1C6E84;
 	border-width: 0px;
 }
- div.controls.btn-toolbar{
+.controls.btn-toolbar{
 	font-size: 1em;
 }
- .analyze.dropdown-menu {
+.analyze.dropdown-menu {
 	border: none;
 	border-radius: 10px;
 	padding: 0px;

--- a/src/css/metacatui-common.css
+++ b/src/css/metacatui-common.css
@@ -1594,6 +1594,36 @@ body > .alert-container {
 .taxonomicCoverage .controls {
 	margin-left: 0px;
 }
+
+/* ---- Analyze Button ---- */
+.dropdown.btn.btn-secondary.dropdown-toggle .icon-bar-chart
+{
+	margin-right: 10px;
+}
+.dropdown.btn.btn-secondary.dropdown-toggle .analyze-text {
+	margin-right:10px;
+	font-weight: 600;
+}
+div.analyze.dropdown{
+	display: inline-block;
+}
+div.analyze.dropdown.open button.dropdown.btn.btn-secondary.dropdown-toggle{
+	display: inline-block;
+	color:white;
+	text-shadow: 0;
+	background-color: #1C6E84;
+	border-width: 0px;
+}
+ div.controls.btn-toolbar{
+	font-size: 1em;
+}
+ .analyze.dropdown-menu {
+	border: none;
+	border-radius: 10px;
+	padding: 0px;
+	margin: 0px;
+}
+
 /**----------------------------------------**/
 .metadata-view .citation{
 	margin-bottom: 20px;

--- a/src/js/models/AppModel.js
+++ b/src/js/models/AppModel.js
@@ -33,7 +33,12 @@ define(['jquery', 'underscore', 'backbone'],
 			maxDownloadSize: 3000000000,
 
 			// set this variable to true, if the content being published is moderated by the data team.
-			contentIsModerated: false,
+      contentIsModerated: false,
+      
+      // Flag which, when true shows Whole Tale features in the UI
+      showWholeTaleFeatures: false,
+      taleEnvironments: ["RStudio", "Jupyter Notebook", "OpenRefine"],
+      dashboardUrl: 'https://dashboard.dev.wholetale.org/',
 
 			/*
 			 * emlEditorRequiredFields is a hash map of all the required fields in the EML Editor.

--- a/src/js/templates/metadataControls.html
+++ b/src/js/templates/metadataControls.html
@@ -3,6 +3,18 @@
 <div class="controls btn-toolbar">
 	<a class="btn copy" data-clipboard-text="<%=citation%>"><i class="icon icon-copy"></i> Copy Citation</a>
 
+  <% if (showWholetale){ %>
+    <div class="analyze dropdown">
+      <button class="dropdown btn btn-secondary dropdown-toggle" type="button" data-toggle="dropdown">
+          <i class="icon-bar-chart"></i>
+          <span class="analyze-text">Analyze</span>
+          <span class="caret"></span>
+      </button>
+      <ul class="analyze dropdown-menu">
+      </ul>
+    </div>
+  <% } %>
+  
 	<% if (mdqUrl){ %>
 		<a href="<%= MetacatUI.root %>/quality/<%=encodeURIComponent(model.id)%>" class="btn"><i class="icon icon-dashboard"></i> Quality report</a>
 	<% } %>

--- a/src/js/themes/arctic/models/AppModel.js
+++ b/src/js/themes/arctic/models/AppModel.js
@@ -35,6 +35,11 @@ define(['jquery', 'underscore', 'backbone'],
 			// set this variable to true, if the content being published is moderated by the data team.
 			contentIsModerated: true,
 
+      // Flag which, when true shows Whole Tale features in the UI
+      showWholeTaleFeatures: false,
+      taleEnvironments: ["RStudio", "Jupyter Notebook", "OpenRefine"],
+      dashboardUrl: 'https://dashboard.dev.wholetale.org/',
+
 			/*
 			 * emlEditorRequiredFields is a hash map of all the required fields in the EML Editor.
 			 * Any field set to true will prevent the user from saving the Editor until a value has been given

--- a/src/js/themes/dataone/models/AppModel.js
+++ b/src/js/themes/dataone/models/AppModel.js
@@ -34,6 +34,11 @@ define(['jquery', 'underscore', 'backbone'],
 
 			// set this variable to true, if the content being published is moderated by the data team.
 			contentIsModerated: false,
+      
+      // Flag which, when true shows Whole Tale features in the UI
+      showWholeTaleFeatures: false,
+      taleEnvironments: ["RStudio", "Jupyter Notebook", "OpenRefine"],
+      dashboardUrl: 'https://dashboard.dev.wholetale.org/',
 
 			baseUrl: window.location.origin || (window.location.protocol + "//" + window.location.host),
 			// the most likely item to change is the Metacat deployment context

--- a/src/js/themes/knb/models/AppModel.js
+++ b/src/js/themes/knb/models/AppModel.js
@@ -35,6 +35,11 @@ define(['jquery', 'underscore', 'backbone'],
 			// set this variable to true, if the content being published is moderated by the data team.
 			contentIsModerated: false,
 
+      // Flag which, when true shows Whole Tale features in the UI
+      showWholeTaleFeatures: false,
+      taleEnvironments: ["RStudio", "Jupyter Notebook", "OpenRefine"],
+      dashboardUrl: 'https://dashboard.dev.wholetale.org/',
+
 			/*
 			 * emlEditorRequiredFields is a hash map of all the required fields in the EML Editor.
 			 * Any field set to true will prevent the user from saving the Editor until a value has been given

--- a/src/js/themes/nceas/models/AppModel.js
+++ b/src/js/themes/nceas/models/AppModel.js
@@ -22,6 +22,11 @@ define(['jquery', 'underscore', 'backbone'],
 			// set this variable to true, if the content being published is moderated by the data team.
 			contentIsModerated: false,
 
+      // Flag which, when true shows Whole Tale features in the UI
+      showWholeTaleFeatures: false,
+      taleEnvironments: ["RStudio", "Jupyter Notebook", "OpenRefine"],
+      dashboardUrl: 'https://dashboard.dev.wholetale.org/',
+
 			/*
 			 * emlEditorRequiredFields is a hash map of all the required fields in the EML Editor.
 			 * Any field set to true will prevent the user from saving the Editor until a value has been given

--- a/src/js/views/MetadataView.js
+++ b/src/js/views/MetadataView.js
@@ -951,7 +951,8 @@ define(['jquery',
 			var controlsContainer = this.controlsTemplate({
 					citation: $(this.citationContainer).text(),
 					url: window.location,
-					mdqUrl: MetacatUI.appModel.get("mdqBaseUrl"),
+          mdqUrl: MetacatUI.appModel.get("mdqBaseUrl"),
+          showWholetale: MetacatUI.appModel.get("showWholeTaleFeatures"),
 					model: this.model.toJSON()
 				});
 
@@ -964,6 +965,10 @@ define(['jquery',
 			metricsWell.append( this.infoIconsTemplate({
 				model: this.model.toJSON()
 			}) );
+
+			if(MetacatUI.appModel.get("showWholeTaleFeatures")) {
+        this.createWholeTaleButton ();
+      }
 
 			//Create clickable "Copy" buttons to copy text (e.g. citation) to the user's clipboard
 			var copyBtns = $(this.controlsContainer).find(".copy");
@@ -1020,6 +1025,26 @@ define(['jquery',
 			});
 			this.$(".tooltip-this").tooltip();
 		},
+
+        /**
+     *Creates a button which the user can click to launch the package in Whole Tale
+    */
+   createWholeTaleButton: function() {
+    let self=this;
+    MetacatUI.appModel.get('taleEnvironments').forEach(function(environment){
+      var queryParams=
+      '?data_location='+ self.model.id +
+      '&data_title='+encodeURIComponent(self.model.get("title"))+
+      '&data_api='+encodeURIComponent(MetacatUI.appModel.get('d1CNBaseUrl'))+
+      '&environment='+environment;
+      var composeUrl = MetacatUI.appModel.get('dashboardUrl')+'compose'+queryParams;
+      $('.analyze.dropdown-menu').append(
+          $('<li>').append(
+            $('<a>').attr('href',composeUrl).append(
+              $('<span>').attr('class', 'tab').append(environment))));
+      });
+    },
+
 
 		// Inserting the Metric Stats
 		insertMetricsControls: function() {

--- a/src/js/views/MetadataView.js
+++ b/src/js/views/MetadataView.js
@@ -1026,11 +1026,12 @@ define(['jquery',
 			this.$(".tooltip-this").tooltip();
 		},
 
-        /**
-     *Creates a button which the user can click to launch the package in Whole Tale
+    /**
+     * Creates a button which the user can click to launch the package in Whole Tale
     */
    createWholeTaleButton: function() {
     let self=this;
+    // Loop over each environment and add it to the dropdown menu
     MetacatUI.appModel.get('taleEnvironments').forEach(function(environment){
       var queryParams=
       '?data_location='+ self.model.id +
@@ -1038,13 +1039,15 @@ define(['jquery',
       '&data_api='+encodeURIComponent(MetacatUI.appModel.get('d1CNBaseUrl'))+
       '&environment='+environment;
       var composeUrl = MetacatUI.appModel.get('dashboardUrl')+'compose'+queryParams;
+
+      // Add a row to the dropdown for this environment
       $('.analyze.dropdown-menu').append(
           $('<li>').append(
             $('<a>').attr('href',composeUrl).append(
-              $('<span>').attr('class', 'tab').append(environment))));
+              $('<span>').attr('class', 'tab').append(environment)
+              ).attr('target', '_blank')));
       });
     },
-
 
 		// Inserting the Metric Stats
 		insertMetricsControls: function() {


### PR DESCRIPTION
# Whole Tale Environments

This PR is for a feature that allows a user to come from DataONE to Whole Tale with the intent on using a data package. To do this I added a dropdown menu next to the copy button in the metadata view.

## Whole Tale Flag

I added a flag to the appmodels so we can easily toggle the feature on and off. You can see where the application uses this in `src/js/views/MetadataView.js`

## Dropdown Menu

I added the dropdown menu to `src/js/templates/metadataControls.html`. It uses the result from above to check if it should render the content.

## Links For Each Menu Item

I construct the links for each compute environment in `src/js/views/MetadataView.js`