### PR TITLE
Fix bug where formatId is set to application/vnd.ms-excel for csvs 

### DIFF
--- a/src/js/models/DataONEObject.js
+++ b/src/js/models/DataONEObject.js
@@ -645,8 +645,8 @@ define(['jquery', 'underscore', 'backbone', 'uuid', 'he', 'collections/AccessPol
             xml.find("serialversion").text(this.get("serialVersion") || "0");
             xml.find("identifier").text((this.get("newPid") || this.get("id")));
             xml.find("submitter").text(this.get("submitter") || MetacatUI.appUserModel.get("username"));
-            xml.find("formatid").text(this.get("formatId") || this.getFormatId());
-
+            var formatId = this.sanitizeFormatId(this.get("formatId") || this.getFormatId());
+            xml.find("formatid").text(formatId);
             //If there is no size, get it
             if( !this.get("size") && this.get("uploadFile")){
               this.set("size", this.get("uploadFile").size);
@@ -1629,7 +1629,21 @@ define(['jquery', 'underscore', 'backbone', 'uuid', 'he', 'collections/AccessPol
     			}
 
     			return false;
-    		}
+        },
+        sanitizeFormatId: function(formatId) {
+          if (formatId !== "application/vnd.ms-excel") {
+            return formatId;
+          }
+
+          var fileName = this.get("fileName"); 
+          if ( typeof fileName !== "undefined" && fileName !== null) {
+            ext = fileName.substring(fileName.lastIndexOf(".") + 1, fileName.length);
+            if (ext === "csv" && formatId === "application/vnd.ms-excel") {
+              return "text/csv";
+            }
+          }
+          return formatId;
+        }
     },
     {
       /* Generate a unique identifier to be used as an XML id attribute */

--- a/src/js/models/DataONEObject.js
+++ b/src/js/models/DataONEObject.js
@@ -645,8 +645,8 @@ define(['jquery', 'underscore', 'backbone', 'uuid', 'he', 'collections/AccessPol
             xml.find("serialversion").text(this.get("serialVersion") || "0");
             xml.find("identifier").text((this.get("newPid") || this.get("id")));
             xml.find("submitter").text(this.get("submitter") || MetacatUI.appUserModel.get("username"));
-            var formatId = this.sanitizeFormatId(this.get("formatId") || this.getFormatId());
-            xml.find("formatid").text(formatId);
+            xml.find("formatid").text(this.get("formatId") || this.getFormatId());
+
             //If there is no size, get it
             if( !this.get("size") && this.get("uploadFile")){
               this.set("size", this.get("uploadFile").size);
@@ -768,61 +768,54 @@ define(['jquery', 'underscore', 'backbone', 'uuid', 'he', 'collections/AccessPol
            * Get the object format identifier for this object
            */
           getFormatId: function() {
+            var formatId = "application/octet-stream", // default to untyped data
+              objectFormats = {
+                "mediaTypes": [],  // The list of potential formatIds based on mediaType matches
+                "extensions": []   // The list of possible formatIds based onextension matches
+              },
+              fileName = this.get("fileName"),  // the fileName for this object 
+              ext;  // The extension of the filename for this object
 
-              var formatId = "application/octet-stream", // default to untyped data
-              objectFormats = [],  // The list of potential format matches
-              ext; // The extension of the filename for this object
+            objectFormats["mediaTypes"] = MetacatUI.objectFormats.where({formatId: this.get("mediaType")});
+            if ( typeof fileName !== "undefined" && fileName !== null && fileName.length > 1) {
+              ext = fileName.substring(fileName.lastIndexOf(".") + 1, fileName.length);
+              objectFormats["extensions"] = MetacatUI.objectFormats.where({extension: ext});
+            }
 
-              if ( MetacatUI.objectFormats.length > 0 ) {
-
-                  // Does the media type match the object format id?
-                  objectFormats = MetacatUI.objectFormats.where({formatId: this.get("mediaType")});
-
-                  if ( objectFormats.length > 0 ) {
-                      formatId = objectFormats[0].get("formatId");
-                      objectFormats = [];
-                      return formatId;
-
-                  }
-
-                  // Does the media type match the media type name?
-                  objectFormats = MetacatUI.objectFormats.where({mediaType: {_name: this.get("mediaType")}});
-
-                  if ( objectFormats.length > 0 ) {
-                      formatId = objectFormats[0].get("formatId");
-                      objectFormats = [];
-                      return formatId;
-
-                  }
-
-                  // Does the extension match the extension?
-                  // TODO: multiple formats have the same extension - need to discern them, but how?
-                  if ( typeof this.get("fileName") !== "undefined" &&
-                     this.get("fileName") !== null && this.get("fileName").length > 1 ) {
-
-                      ext = this.get("fileName").substring(
-                                  this.get("fileName").lastIndexOf(".") + 1,
-                                  this.get("fileName").length);
-                      objectFormats = MetacatUI.objectFormats.where({extension: ext});
-
-                      if ( objectFormats.length > 0 ) {
-
-                        //If this is a "nc" file, assume it is a netCDF-3 file.
-                        if( ext == "nc" ){
-                          formatId = "netCDF-3";
-                        }
-                        else{
-                              formatId = objectFormats[0].get("formatId");
-                              objectFormats = [];
-                        }
-
-                          return formatId;
-
-                      }
-                  }
+            if (objectFormats["mediaTypes"].length > 0 && objectFormats["extensions"].length > 0) {
+              var firstMediaType = objectFormats["mediaTypes"][0].get("formatId");
+              var firstExtension = objectFormats["extensions"][0].get("formatId");
+              // Check if they're equal 
+              if (firstMediaType === firstExtension) {
+                formatId = firstMediaType;
+                return formatId;
               }
+              // Handle mismatched mediaType and extension cases - additional cases can be added below
+              if (firstMediaType === 'application/vnd.ms-excel' && firstExtension === 'text/csv') {
+                formatId = firstExtension;
+                return formatId;
+              }
+            }
 
+            if (objectFormats["mediaTypes"].length > 0) {
+              formatId = objectFormats["mediaTypes"][0].get("formatId");
+              console.log('returning default mediaType');
+              console.log(formatId);
               return formatId;
+            }
+
+            if (objectFormats["extensions"].length > 0 ) {
+              //If this is a "nc" file, assume it is a netCDF-3 file.
+              if (ext == "nc") {
+                formatId = "netCDF-3";
+              } else {
+                formatId = objectFormats["extensions"][0].get("formatId");
+              }
+              return formatId;
+            }
+
+            return formatId;
+
           },
 
           /*
@@ -1629,20 +1622,6 @@ define(['jquery', 'underscore', 'backbone', 'uuid', 'he', 'collections/AccessPol
     			}
 
     			return false;
-        },
-        sanitizeFormatId: function(formatId) {
-          if (formatId !== "application/vnd.ms-excel") {
-            return formatId;
-          }
-
-          var fileName = this.get("fileName"); 
-          if ( typeof fileName !== "undefined" && fileName !== null) {
-            ext = fileName.substring(fileName.lastIndexOf(".") + 1, fileName.length);
-            if (ext === "csv" && formatId === "application/vnd.ms-excel") {
-              return "text/csv";
-            }
-          }
-          return formatId;
         }
     },
     {


### PR DESCRIPTION
Bug fix where the editor sets the `formatId` to `application/vnd.ms-excel` for csv files with their mime type set as excel (only occurs for excel-exported csvs in windows).  

I decided to add a new method because `DataONEObject.getFormatId` [returns](https://github.com/NCEAS/metacatui/blob/9d4490b7a908f818db6301e4560fe6d8203e58ac/src/js/models/DataONEObject.js#L784) the first `formatId` that matches an object's mediatype.  The body of `sanitizeFormatId` would need to be inserted before that first return, so an additional method seemed cleaner.  

Some possible changes: 

1. This could be condensed into one line - I thought this was more readable. 
```
var formatId = this.sanitizeFormatId(this.get("formatId") || this.getFormatId());
xml.find("formatid").text(formatId);
```

2. I grabbed this [block of code](https://github.com/NCEAS/metacatui/blob/9d4490b7a908f818db6301e4560fe6d8203e58ac/src/js/models/DataONEObject.js#L800) to extract the extension from the fileName and modified it so it only calls `this.get("fileName")` once, but I can revert that to maintain consistency if needed. 

3.  This block could be removed without affecting the function, but I thought it would improve the speed to skip all non `application/vnd.ms-excel` files.  
```
         if (formatId !== "application/vnd.ms-excel") {
            return formatId;
          }
```