### PR TITLE
Add the ability to re-order parties

### DIFF
--- a/src/js/models/metadata/eml211/EML211.js
+++ b/src/js/models/metadata/eml211/EML211.js
@@ -1782,6 +1782,44 @@ define(['jquery', 'underscore', 'backbone', 'uuid',
        *
        * @param {EMLParty} partyModel: The EMLParty model we're moving
        */
+      movePartyUp: function(partyModel) {
+        var possibleAttr = ["creator", "contact", "metadataProvider", "publisher", "associatedParty"];
+
+        // Iterate over each possible attribute
+        _.each(possibleAttr, function(attr){
+          if (!_.contains(this.get(attr), partyModel)) {
+            return;
+          }
+          // Make a clone because we're going to use splice
+          var models = _.clone(this.get(attr));
+
+          // Find the index of the model we're moving
+          var index = _.findIndex(models, function(m) {
+            return m === partyModel;
+          });
+
+          if (index === 0) {
+            // Already first
+            return;
+          }
+
+          if (index === -1) {
+            // Couldn't find the model
+            return;
+          }
+
+          // Do the move using splice and update the model
+          models.splice(index - 1, 0, models.splice(index, 1)[0])
+          this.set(attr, models);
+          this.trigger("change:" + attr);
+        }, this);
+      },
+
+      /**
+       * Attempt to move a party one index forward within its sibling models
+       *
+       * @param {EMLParty} partyModel: The EMLParty model we're moving
+       */
       movePartyDown: function(partyModel) {
         var possibleAttr = ["creator", "contact", "metadataProvider", "publisher", "associatedParty"];
 
@@ -1811,6 +1849,7 @@ define(['jquery', 'underscore', 'backbone', 'uuid',
           // Do the move using splice and update the model
           models.splice(newIndex, 0, models.splice(index, 1)[0])
           this.set(attr, models);
+          this.trigger("change:" + attr);
         }, this);
       },
 

--- a/src/js/models/metadata/eml211/EML211.js
+++ b/src/js/models/metadata/eml211/EML211.js
@@ -1777,6 +1777,43 @@ define(['jquery', 'underscore', 'backbone', 'uuid',
         }, this);
       },
 
+      /**
+       * Attempt to move a party one index forward within its sibling models
+       *
+       * @param {EMLParty} partyModel: The EMLParty model we're moving
+       */
+      movePartyDown: function(partyModel) {
+        var possibleAttr = ["creator", "contact", "metadataProvider", "publisher", "associatedParty"];
+
+        // Iterate over each possible attribute
+        _.each(possibleAttr, function(attr){
+          if (!_.contains(this.get(attr), partyModel)) {
+            return;
+          }
+          // Make a clone because we're going to use splice
+          var models = _.clone(this.get(attr));
+
+          // Find the index of the model we're moving
+          var index = _.findIndex(models, function(m) {
+            return m === partyModel;
+          });
+
+          if (index === -1) {
+            // Couldn't find the model
+            return;
+          }
+
+          // Figure out where to put the new model
+          //   Leave it in the same place if the next index doesn't exist
+          //   Move one forward if it does
+          var newIndex = (models.length <= index + 1) ? index : index + 1;
+
+          // Do the move using splice and update the model
+          models.splice(newIndex, 0, models.splice(index, 1)[0])
+          this.set(attr, models);
+        }, this);
+      },
+
       /*
       * Adds the given EMLParty model to this EML211 model in the
       * appropriate role array in the given position

--- a/src/js/templates/metadata/EMLParty.html
+++ b/src/js/templates/metadata/EMLParty.html
@@ -1,11 +1,6 @@
 <div class="notification row-fluid">
 </div>
 <div class="row-fluid party-details">
-	<div>
-		<button class="move-up">Up</button>
-		<button class="move-down">Down</button>
-	</div>
-	</div>
 	<div class="span4">
 		<div class="row-fluid">
 			<label class="hidden" for="<%=uniqueId%>-givenName">First Name</label>

--- a/src/js/templates/metadata/EMLParty.html
+++ b/src/js/templates/metadata/EMLParty.html
@@ -67,7 +67,9 @@
 	</div>
 </div>
 <nav class="party-menu btn-group subtle-btn-group">
-    <button class="btn dropdown-toggle" data-toggle="dropdown">
+		<button class="move-up">Move Up</button>
+		<button class="move-down">Move Down</button>
+		<button class="btn dropdown-toggle" data-toggle="dropdown">
     	<img src="<%= MetacatUI.root %>/img/ellipsis-menu-icon.png" title="Copy, remove, and other actions for this person" />
     </button>
     <ul class="dropdown-menu">

--- a/src/js/templates/metadata/EMLParty.html
+++ b/src/js/templates/metadata/EMLParty.html
@@ -1,6 +1,11 @@
 <div class="notification row-fluid">
 </div>
 <div class="row-fluid party-details">
+	<div>
+		<button class="move-up">Up</button>
+		<button class="move-down">Down</button>
+	</div>
+	</div>
 	<div class="span4">
 		<div class="row-fluid">
 			<label class="hidden" for="<%=uniqueId%>-givenName">First Name</label>

--- a/src/js/views/metadata/EML211View.js
+++ b/src/js/views/metadata/EML211View.js
@@ -809,17 +809,42 @@ define(['underscore', 'jquery', 'backbone',
 
 			},
 
+      /**
+       * Attempt to move the current person (Party) one index backward (up).
+       *
+       * @param {EventHandler} e: The click event handler
+       */
 			movePersonUp: function(e){
 	    	e.preventDefault();
 
-				// TODO
+	    	// Get the party view el, view, and model
+	    	var partyEl = $(e.target).parents(".eml-party"),
+            model = partyEl.data("model"),
+            next = $(partyEl).prev().not(".new");
 
+        if (next.length === 0) {
+          return;
+        }
+
+				// Remove current view, create and insert a new one for the model
+        $(partyEl).remove();
+
+        var newView = new EMLPartyView({
+          model: model,
+          edit: this.edit
+        });
+
+        $(next).before(newView.render().el);
+
+        // Move the party down within the model too
+				this.model.movePartyUp(model);
+				this.model.trickleUpChange();
 			},
 
       /**
        * Attempt to move the current person (Party) one index forward (down).
        *
-       * @param {EventHandler} e: The click event handle
+       * @param {EventHandler} e: The click event handler
        */
 	    movePersonDown: function(e){
 				e.preventDefault();
@@ -830,8 +855,6 @@ define(['underscore', 'jquery', 'backbone',
             next = $(partyEl).next().not(".new");
 
         if (next.length === 0) {
-          console.log("Not moving down because we're last.");
-
           return;
         }
 
@@ -847,8 +870,8 @@ define(['underscore', 'jquery', 'backbone',
 
         // Move the party down within the model too
 	    	this.model.movePartyDown(model);
+				this.model.trickleUpChange();
 	    },
-
 
 	    /*
          * Renders the Dates section of the page

--- a/src/js/views/metadata/EML211View.js
+++ b/src/js/views/metadata/EML211View.js
@@ -77,6 +77,8 @@ define(['underscore', 'jquery', 'backbone',
         	"click .eml-party .copy"   : "showCopyPersonMenu",
         	"click #copy-party-save"   : "copyPerson",
         	"click .eml-party .remove" : "removePerson",
+        	"click .eml-party .move-up" : "movePersonUp",
+        	"click .eml-party .move-down" : "movePersonDown",
 
 			    "click  .remove" : "handleRemove"
         },
@@ -805,7 +807,48 @@ define(['underscore', 'jquery', 'backbone',
 	    	//Let the EMLPartyView remove itself
 	    	partyView.remove();
 
+			},
+
+			movePersonUp: function(e){
+	    	e.preventDefault();
+
+				// TODO
+
+			},
+
+      /**
+       * Attempt to move the current person (Party) one index forward (down).
+       *
+       * @param {EventHandler} e: The click event handle
+       */
+	    movePersonDown: function(e){
+				e.preventDefault();
+
+	    	// Get the party view el, view, and model
+	    	var partyEl = $(e.target).parents(".eml-party"),
+            model = partyEl.data("model"),
+            next = $(partyEl).next().not(".new");
+
+        if (next.length === 0) {
+          console.log("Not moving down because we're last.");
+
+          return;
+        }
+
+				// Remove current view, create and insert a new one for the model
+        $(partyEl).remove();
+
+        var newView = new EMLPartyView({
+          model: model,
+          edit: this.edit
+        });
+
+        $(next).after(newView.render().el);
+
+        // Move the party down within the model too
+	    	this.model.movePartyDown(model);
 	    },
+
 
 	    /*
          * Renders the Dates section of the page


### PR DESCRIPTION
Closes https://github.com/NCEAS/metacatui/issues/521

As decided in #521, the initial implementation adds simple up/down buttons alongside each party view. Clicking either button moves the party up or down on the page and also updates the underlying EML model so the serialized document reflects the change. When re-ordering creators, the citation preview automatically updates to reflect the changes.

Three things I'd appreciate an extra look at are:

1. I don't let you move a party down below the new/placeholder party so the placeholder is always the last item in the group. It made sense to me to leave the placeholder at the bottom.
2. I didn't wanna to get too fancy with the up/down buttons so I just put them to the left of the party menu. Very much open to feedback here.
3. I wanted to disable the up or down button when it would have no effect (i.e., the Up button would be disabled on the first item) but was having trouble finding a clean way to do it. Right now, you can click the button but it does nothing.