### PR TITLE
Fixes checkboxes filters alignment

### DIFF
--- a/src/css/metacatui-common.css
+++ b/src/css/metacatui-common.css
@@ -5306,7 +5306,6 @@ body.mapMode{
 	margin-right: -3px;
 }
 .filter-input-contain input.filter{
-	min-width: 120px;
 	margin-right: -3px;
 	margin-left: 0px;
 	border-radius: 5px 0px 0px 5px;


### PR DESCRIPTION
This is a small css change that was breaking the alignment for checkboxes filters. 