### PR TITLE
Selectively remove alerts on validation

### DIFF
--- a/src/js/views/metadata/EML211EditorView.js
+++ b/src/js/views/metadata/EML211EditorView.js
@@ -858,7 +858,7 @@ define(['underscore',
           this.$(".notification.error").empty();
           this.$(".side-nav-item .icon").hide();
           this.$("#metadata-container .error").removeClass("error");
-          $(".alert-container").remove();
+          $(".alert-container:not(:has(.temporary-message))").remove();
 
 
           var errors = this.model.validationError;


### PR DESCRIPTION
In order to not remove the temporary message when removing all validation alerts, a selective css selector is used to exclude alerts with temporary message.

closes #1534