### PR TITLE
Refactor AnnotationView to show two separate popovers instead of a single one

### DIFF
--- a/src/css/metacatui-common.css
+++ b/src/css/metacatui-common.css
@@ -2739,8 +2739,7 @@ section#user-citations {
 }
 /** Annotation pills **/
 .annotation .annotation-property,
-.annotation .annotation-value,
-.annotation .annotation-findmore {
+.annotation .annotation-value {
   padding: 3px 6px;
 }
 
@@ -2757,21 +2756,11 @@ section#user-citations {
   border-width: 1px 0px 1px 0px;
   border-style: solid;
   border-color: #337ab7;
-  color: white;
-}
-
-.annotation .annotation-findmore {
-  background-color: #EEE;
-  border-width: 1px 1px 1px 0px;
-  border-style: solid;
-  border-color: #CCC;
   border-radius: 0px 3px 3px 0px;
-	padding: 0 10px;
 }
 
-.annotation .annotation-findmore div {
-	transform: rotate(45deg);
-	margin: 2px;
+.annotation .annotation-value .annotation-value-text {
+  color: white;
 }
 
  .annotation-popover-definition {
@@ -2781,6 +2770,7 @@ section#user-citations {
 
 .annotation-popover-definition {
 	border-top: 1px solid #CCC;
+	border-bottom: 1px solid #CCC;
 }
 /** Hide the search when in the dropdown menu **/
 .dropdown-menu .ncboAutocomplete {

--- a/src/js/templates/bioportalAnnotationTemplate.html
+++ b/src/js/templates/bioportalAnnotationTemplate.html
@@ -2,16 +2,12 @@
     <%= context %> <em><a href="<%= propertyURI %>"><%= propertyLabel %></a></em> <strong><a href="<%= valueURI %>"><%= valueLabel %></a></strong>
 </div>
 <div class="annotation-popover-definition">
-    <% if (!valueResolved && MetacatUI.appModel.get("bioportalAPIKey")) { %>
-        Looking for more information about <a href="<%= valueURI %>"><%= valueLabel %></a>.
-    <% } else if (valueResolved && valueDefinition === null) { %>
-        No extra information could be found for <a href="<%= valueURI %>"><%= valueLabel %></a>.
-    <% } else if(valueDefinition) { %>
-        <i class="icon-link"></i> <strong><a href="<%= valueURI %>"><%= valueLabel %></a></strong> is defined as "<%= valueDefinition %>".
+    <% if (definition) { %>
+        <i class="icon-link"></i> <strong><a href="<%= uri %>"><%= label %></a></strong> is defined as "<%= definition %>".
     <% } %>
 
-    Find more information about this term at <a href="<%= valueURI %>"><%= valueURI %></a>.
+    Find more information about this term at <a href="<%= uri %>"><%= uri %></a>.
 </div>
 <div class="annotation-popover-findmore">
-    <i class="icon-search"></i> Find more datasets with measurements of <strong><a href="#" data-uri="<%= valueURI %>"><%= valueLabel %></a></strong>.
+    <i class="icon-search"></i> Find more datasets with annotations of <strong><a href="#" data-uri="<%= uri %>"><%= label %></a></strong>.
 </div>

--- a/src/js/templates/bioportalAnnotationTemplate.html
+++ b/src/js/templates/bioportalAnnotationTemplate.html
@@ -1,12 +1,12 @@
 <div clas="annotation-popover-context">
-    <%= context %> <em><a href="<%= propertyURI %>"><%= propertyLabel %></a></em> <strong><a href="<%= valueURI %>"><%= valueLabel %></a></strong>
+    <%= context %> <em><a href="<%= propertyURI %>" target="_blank"><%= propertyLabel %></a></em> <strong><a href="<%= valueURI %>" target="_blank"><%= valueLabel %></a></strong>
 </div>
 <div class="annotation-popover-definition">
     <% if (definition) { %>
-        <i class="icon-link"></i> <strong><a href="<%= uri %>"><%= label %></a></strong> is defined as "<%= definition %>".
+        <i class="icon-link"></i> <strong><a href="<%= uri %>" target="_blank"><%= label %></a></strong> is defined as "<%= definition %>".
     <% } %>
 
-    Find more information about this term at <a href="<%= uri %>"><%= uri %></a>.
+    Find more information about this term at <a href="<%= uri %>" target="_blank"><%= uri %></a>.
 </div>
 <div class="annotation-popover-findmore">
     <i class="icon-search"></i> Find more datasets with annotations of <strong><a href="#" data-uri="<%= uri %>"><%= label %></a></strong>.

--- a/src/js/views/AnnotationView.js
+++ b/src/js/views/AnnotationView.js
@@ -12,68 +12,142 @@ define(['jquery',
         annotationPopoverTemplate: _.template(AnnotationPopoverTemplate),
 
         el: null,
-        context: null,
-        propertyLabel: null,
-        propertyURI: null,
-        valueLabel: null,
-        valueURI: null,
-        valueDefinition: null,
-        valueOntology: null,
-        valueOntologyName: null,
-
-        // Stores a reference to the child .annotation el which is handy but
-        // I'm no sure it's needed
-        // TODO: Rename to popoverReference or something or remove entirley
-        popoverSource: null,
-
-        // Helps track visibility of the popover so we know when it's safe to
-        // destroy it and update it with new content
-        visible: null,
-
-        // Stores whether we successfully looked and did or did not find the
-        // definition of the annotation value, either from cache or from
-        // Bioportal
-        valueResolved: null,
 
         events: {
-            "click" : "onClick",
+            "click" : "handleClick",
             "click .annotation-popover-findmore" : "findMore",
-            "click .annotation-findmore" : "findMore"
         },
 
+        /**
+         * Context string is a human-readable bit of text that comes out of the
+         * Metacat view service and describes the context of the annotation
+         * i.e., what entity, or which attribute within which entity the
+         * annotation is on
+         */
+        context: null,
+
+        // State. See initialize(), we store a bunch of info in these
+        property: null,
+        value: null,
+
         initialize: function () {
-            this.context = this.$el.data('context');
-            this.propertyLabel = this.$el.data('propertyLabel');
-            this.propertyURI = this.$el.data('propertyUri');
-            this.valueLabel = this.$el.data('valueLabel');
-            this.valueURI = this.$el.data('valueUri');
+            this.property = {
+                type: "property",
+                el: null,
+                popover: null,
+                label: null,
+                uri: null,
+                definition: null,
+                ontology: null,
+                ontologyName: null,
+                resolved: false
+            };
+
+            this.value = {
+                type: "value",
+                el: null,
+                popover: null,
+                label: null,
+                uri: null,
+                definition: null,
+                ontology: null,
+                ontologyName: null,
+                resolved: false
+            };
+
+            this.property.el = this.$el.children(".annotation-property");
+            this.value.el = this.$el.children(".annotation-value");
+
+            // Bail now if things aren't set up right
+            if (!this.property.el || !this.value.el) {
+                return;
+            }
+
+            this.context = this.$el.data("context");
+            this.property.label = this.property.el.data("label");
+            this.property.uri = this.property.el.data("uri");
+            this.value.label = this.value.el.data("label");
+            this.value.uri = this.value.el.data("uri");
 
             // Decode HTML tags in the context string, which is passed in as
             // an HTML attribute from the XSLT so it needs encoding of some sort
             // Note: Only supports < and > at this point
-            if( this.context ){
+            if (this.context) {
               this.context = this.context.replace("&lt;", "<").replace("&gt;", ">");
             }
-
-            this.valueResolved = false;
         },
 
-        // Helps us fetch data from the API on first interaction
-        onClick: function () {
-            if (!this.popoverSource) {
-                this.createPopover();
-                this.popoverSource.popover("show");
-            }
+        /**
+         * Click handler for when the user clicks either the property or the
+         * value portion of the pill.
+         *
+         * If the popover hasn't yet been created for either, we create the
+         * popover and query BioPortal for more information. Otherwise, we do
+         * nothing and Bootstrap's default popover handling is triggered,
+         * showing the popover.
+         *
+         * @param {Event} e - Click event
+         */
+        handleClick: function (e) {
+            if (e.target.className === "annotation-property") {
+                if (this.property.popover) {
+                    return;
+                }
 
-            this.queryAndUpdateValue();
+                this.createPopover(this.property);
+                this.property.popover.popover("show");
+                this.queryAndUpdate(this.property);
+            } else if (e.target.className === "annotation-value" ||
+                e.target.className === "annotation-value-text") {
+                if (this.value.popover) {
+                    return;
+                }
+
+                this.createPopover(this.value);
+                this.value.popover.popover("show");
+                this.queryAndUpdate(this.value);
+            }
+        },
+
+        /**
+         * Update the value popover with the current state
+         *
+         * @param {Object} which - Which popover to create. Either this.property
+         * or this.value.
+         */
+        createPopover: function (which) {
+            var new_content = this.annotationPopoverTemplate({
+                context: this.context,
+                label: which.label,
+                uri: which.uri,
+                definition: which.definition,
+                ontology: which.ontology,
+                ontologyName: which.ontologyName,
+                resolved: which.resolved,
+                propertyURI: this.property.uri,
+                propertyLabel: this.property.label,
+                valueURI: this.value.uri,
+                valueLabel: this.value.label
+            });
+
+            which.el.data("content", new_content);
+
+            which.popover = which.el.popover({
+                container: which.el,
+                delay: 500,
+                trigger: "click"
+            });
         },
 
         /**
          * Find a definition for the value URI either from cache or from
          * Bioportal. Updates the popover if necessary.
+         *
+         * @param {Object} which - Which popover to create. Either this.property
+         * or this.value.
          */
-        queryAndUpdateValue: function () {
-            if (this.valueResolved) {
+        queryAndUpdate: function (which) {
+            if (which.resolved) {
                 return;
             }
 
@@ -82,24 +156,22 @@ define(['jquery',
                 token = MetacatUI.appModel.get("bioportalAPIKey");
 
             // Attempt to grab from cache first
-
-            if (cache && cache[this.valueURI]) {
-                this.valueDefinition = cache[this.valueURI].definition;
-                this.valueOntology = cache[this.valueURI].links.ontology;
+            if (cache && cache[which.uri]) {
+                which.definition = cache[which.uri].definition;
+                which.ontology = cache[which.uri].links.ontology;
 
                 // Try to get a simpler name for the ontology, rather than just
                 // using the ontology URI, which is all Bioportal gives back
-                this.valueOntologyName = this.getFriendlyOntologyName(cache[this.valueURI].links.ontology);
-
-                this.updatePopover();
-                this.valueResolved = true;
+                which.ontologyName = this.getFriendlyOntologyName(cache[which.uri].links.ontology);
+                which.resolved = true;
+                viewRef.updatePopover(which);
 
                 return;
             }
 
             // Verify token before moving on
             if (typeof token !== "string" || token.length === 0) {
-                this.valueResolved = true;
+                which.resolved = true;
 
                 return;
             }
@@ -107,7 +179,7 @@ define(['jquery',
             // Query the API and handle the response
             // TODO: Looks like we should proxy this so the token doesn't leak
             var url = MetacatUI.appModel.get("bioportalSearchUrl") +
-                "?q=" + encodeURIComponent(this.valueURI) +
+                "?q=" + encodeURIComponent(which.uri) +
                 "&apikey=" +
                 token;
 
@@ -123,7 +195,7 @@ define(['jquery',
 
                 // Find the first match by URI
                 match = _.find(data.collection, function(result) {
-                    return result["@id"] && result["@id"] === viewRef.valueURI;
+                    return result["@id"] && result["@id"] === which.uri;
                 });
 
                 // Verify structure of response looks right and bail out if it
@@ -132,52 +204,23 @@ define(['jquery',
                     !match.definition ||
                     !match.definition.length ||
                     !match.definition.length > 0) {
-                    viewRef.valueResolved = true;
-                    viewRef.updatePopover();
+                    which.resolved = true;
 
                     return;
                 }
 
-                viewRef.valueDefinition = match.definition[0];
-                viewRef.valueOntology = match.links.ontology;
+                which.definition = match.definition[0];
+                which.ontology = match.links.ontology;
 
                 // Try to get a simpler name for the ontology, rather than just
                 // using the ontology URI, which is all Bioportal gives back
-                viewRef.valueOntologyName = viewRef.getFriendlyOntologyName(match.links.ontology);
+                which.ontologyName = viewRef.getFriendlyOntologyName(match.links.ontology);
 
-                viewRef.valueResolved = true;
-                viewRef.updatePopover();
-                viewRef.updateCache(viewRef.valueURI, match);
+                which.resolved = true;
+                viewRef.updateCache(which.uri, match);
+                viewRef.updatePopover(which);
             });
         },
-
-        /**
-         * Create the Popover for the annotation
-         *
-         * Note: Has a side-effect of updating this.popoverSource;
-         */
-        createPopover: function () {
-            var new_content = this.annotationPopoverTemplate({
-                context: this.context,
-                propertyLabel: this.propertyLabel,
-                propertyURI: this.propertyURI,
-                valueLabel: this.valueLabel,
-                valueURI: this.valueURI,
-                valueDefinition: this.valueDefinition,
-                valueOntology: this.valueOntology,
-                valueOntologyName: this.valueOntologyName,
-                valueResolved: this.valueResolved
-            });
-
-            this.$el.data("content", new_content);
-
-            this.popoverSource = this.$el.popover({
-                container: this.$el,
-                delay: 500,
-                trigger: "click"
-            });
-        },
-
 
         /**
          * Update the popover data and raw HTML. This is necessary because
@@ -187,20 +230,25 @@ define(['jquery',
          * The main trick I had to figure out here was that I could access
          * the underlying content member of the popover with
          * popover_data.options.content which wasn't documented in the API.
+         *
+         * @param {Object} which - Which popover to create. Either this.property
+         * or this.value.
          */
-        updatePopover: function() {
-            var popover_content = $(this.$el).find(".popover-content").first();
+        updatePopover: function(which) {
+            var popover_content = $(which.popover).find(".popover-content")
 
             var new_content = this.annotationPopoverTemplate({
                 context: this.context,
-                propertyLabel: this.propertyLabel,
-                propertyURI: this.propertyURI,
-                valueLabel: this.valueLabel,
-                valueURI: this.valueURI,
-                valueDefinition: this.valueDefinition,
-                valueOntology: this.valueOntology,
-                valueOntologyName: this.valueOntologyName,
-                valueResolved: this.valueResolved
+                label: which.label,
+                uri: which.uri,
+                definition: which.definition,
+                ontology: which.ontology,
+                ontologyName: which.ontologyName,
+                resolved: which.resolved,
+                propertyURI: which.uri,
+                propertyLabel: which.label,
+                valueURI: this.value.uri,
+                valueLabel: this.value.label
             });
 
             // Update both the existing DOM and the underlying data
@@ -214,13 +262,13 @@ define(['jquery',
             // for Bootstrap's Popover and it showed the popover is generated
             // from the data-popover attribute's content which has an
             // options.content member we can modify directly
-            var popover_data = $(this.$el).data('popover');
+            var popover_data = $(which.el).data('popover');
 
             if (popover_data && popover_data.options && popover_data.options) {
                 popover_data.options.content = new_content;
             }
 
-            $(this.$el).data('popover', popover_data);
+            $(which.el).data('popover', popover_data);
 
             // Then update the DOM on the open popover
             $(popover_content).html(new_content);
@@ -228,6 +276,7 @@ define(['jquery',
 
         /**
          * Update the cache for a given term.
+         *
          * @param term: (string) The URI
          * @param match: (object) The BioPortal match object for the term
         */
@@ -244,39 +293,46 @@ define(['jquery',
         /**
          * Send the user to a pre-canned search for a term.
          *
-         * This gets called either from the popover or from clicking on the pill
-         * itself.
+         * @param {Event} e - Click event
          */
         findMore: function(e) {
             e.preventDefault();
 
-            var valueURI,
-                valueLabel,
-                pill = $(e.target).parents(".annotation");
+            // Find the URI we need to filter on. Try the value first
+            var parent = $(e.target).parents(".annotation-value");
 
-            // Decide whether we clicked from the pill first
-            if (pill.length == 1) {
-                valueURI = $(pill).data("value-uri");
-                valueLabel = $(pill).data("value-label");
-            } else {
-                valueURI = $(e.target).data("uri");
-                valueLabel = $(e.target).text();
+            // Fall back to finding the URI from the property
+            if (parent.length <= 0) {
+                parent = $(e.target).parents(".annotation-property");
             }
 
-            // Bail out if we didn't get a valueURI to search
-            if (typeof valueURI === "undefined") {
+            // Bail if we found neither
+            if (parent.length <= 0) {
+                return;
+            }
+
+            // Now grab the label and URI and filter
+            var label = $(parent).data("label"),
+                uri = $(parent).data("uri");
+
+            if (!label || !uri) {
                 return;
             }
 
             // Direct the user towards a search for the annotation
             MetacatUI.appSearchModel.clear();
             MetacatUI.appSearchModel.set('annotation', [{
-                label: valueLabel,
-                value: valueURI
+                label: label,
+                value: uri
             }]);
             MetacatUI.uiRouter.navigate('data', {trigger: true});
         },
 
+        /**
+         * Get a friendly name (ie ECSO) from a long BioPortal URI
+         *
+         * @param {string} uri - A URI returned from the BioPortal API
+         */
         getFriendlyOntologyName: function(uri) {
             if ((typeof uri === "string")) {
                 return uri;

--- a/src/js/views/AnnotationView.js
+++ b/src/js/views/AnnotationView.js
@@ -31,6 +31,19 @@ define(['jquery',
         value: null,
 
         initialize: function () {
+            // Detect legacy pill DOM structure with the old arrow,
+            // ┌───────────┬───────┬───┐
+            // │ property  │ value │ ↗ │
+            // └───────────┴───────┴───┘
+            // clean up, and disable ourselves. This can be removed at some
+            // point in the future
+            if (this.$el.find(".annotation-findmore").length > 0) {
+                this.$el.find(".annotation-findmore").remove();
+                this.$el.find(".annotation-value").attr("style", "color: white");
+
+                return;
+            }
+
             this.property = {
                 type: "property",
                 el: null,
@@ -89,6 +102,10 @@ define(['jquery',
          * @param {Event} e - Click event
          */
         handleClick: function (e) {
+            if (!this.property || !this.value) {
+                    return;
+            }
+
             if (e.target.className === "annotation-property") {
                 if (this.property.popover) {
                     return;


### PR DESCRIPTION
Before this change, clicking anywhere in the annotation pill shows a single popover providing more information about the `valueURI`. No extra information can be found about the `propertyURI` beyond its label.

<img width="521" alt="Screen Shot 2021-08-02 at 5 56 02 PM" src="https://user-images.githubusercontent.com/563/127945503-1eb9d222-bac1-4436-9d1a-d321a2b78be5.png">

Now, you get two separate popovers, and each one can show more information about each term (if found):

<img width="511" alt="Screen Shot 2021-08-02 at 5 57 33 PM" src="https://user-images.githubusercontent.com/563/127945592-5e058c43-78f4-4ca5-92f0-712295e23c85.png">

This change is tied with https://github.com/NCEAS/metacat/pull/1518 which modifies the underlying DOM structure returned by the view service. For perfect functionality, this change requires a Metacat upgrade. However, the changes were made to be relatively backwards compatible:

| | Old Metacat | New Metacat |
|-:|:-:|:-:|
|**Old MetacatUI** | ✅ | Pill has one minor glitch, old popover works |
|**New MetacatUI** | Pill looks good, no popovers | ✅ |

The minor glitch above when an old MetacatUI encounters an upgraded Metacat is just that the right side of the pill doesn't have a rounded border. 

**Testing notes**

1. I don't have an example of a real dataset that exercises the new behavior so I put a test document on my own VM with a non-sense annotation just to show everything works: https://neutral-cat.nceas.ucsb.edu/view/a534573b-c40b-47ad-909f-d7a639e6a003

2. Ensure `bioportalAPIKey` is set in your config to a valid BioPortal API key

    Here's my usual config:

    ```json
    MetacatUI.AppConfig = {
      root: "/",
      theme: "arctic",
      baseUrl: "https://neutral-cat.nceas.ucsb.edu",
      d1CNBaseUrl: "https://cn-stage.test.dataone.org",
      bioportalAPIKey: "CHANGEME",
      metacatContext: "metacat",
    }
    ```
3. https://neutral-cat.nceas.ucsb.edu has the latest changes both to Metacat and to MetacatUI deployed on it and is in cn-stage and you're welcome to test things there
