### PR TITLE
Javascript error after saving a data package

### DIFF
--- a/src/js/models/DataONEObject.js
+++ b/src/js/models/DataONEObject.js
@@ -209,7 +209,9 @@ define(['jquery', 'underscore', 'backbone', 'uuid', 'he', 'collections/AccessPol
               }
 
               //Return the full URL
-              return baseUrl;
+              return baseUrl +
+                        (encodeURIComponent(this.get("id")) ||
+                         encodeURIComponent(this.get("seriesid")));
 
             }
             else {


### PR DESCRIPTION
This alters the DataONEObject.url function by adding
the object id to the returned URL when the object is
in an 'isNew' state. Otherwise, the returned url is just
the object endpoint with no identifier. This causes parsing
errors because the xml returned is not expected.

Closes #1882