### PR TITLE
Feature filter private #1902

### DIFF
--- a/src/js/models/AppModel.js
+++ b/src/js/models/AppModel.js
@@ -225,7 +225,7 @@ define(['jquery', 'underscore', 'backbone'],
       * @default ["all", "attribute", "documents", "creator", "dataYear", "pubYear", "id", "taxon", "spatial"]
       * @example ["all", "annotation", "attribute", "dataSource", "documents", "creator", "dataYear", "pubYear", "id", "taxon", "spatial"]
       */
-      defaultSearchFilters: ["all", "attribute", "documents", "creator", "dataYear", "pubYear", "id", "taxon", "spatial"],
+      defaultSearchFilters: ["all", "attribute", "documents", "creator", "dataYear", "pubYear", "id", "taxon", "spatial", "isPrivate"],
 
       /**
        * Enable to show Whole Tale features

--- a/src/js/models/Search.js
+++ b/src/js/models/Search.js
@@ -27,6 +27,7 @@ define(["jquery", "underscore", "backbone", "models/SolrResult", "collections/Fi
                     all: [],
                     creator: [],
                     taxon: [],
+                    isPrivate: null,
                     documents: false,
                     resourceMap: false,
                     yearMin: 1900, //The user-selected minimum year
@@ -97,6 +98,7 @@ define(["jquery", "underscore", "backbone", "models/SolrResult", "collections/Fi
                 seriesId: "seriesId",
                 taxon: "Taxon",
                 spatial: "Location",
+                isPrivate: "Private datasets",
                 all: ""
             },
 
@@ -117,7 +119,8 @@ define(["jquery", "underscore", "backbone", "models/SolrResult", "collections/Fi
                 rightsHolder: "rightsHolder",
                 submitter: "submitter",
                 username: ["rightsHolder", "writePermission", "changePermission"],
-                taxon: ["kingdom", "phylum", "class", "order", "family", "genus", "species"]
+                taxon: ["kingdom", "phylum", "class", "order", "family", "genus", "species"],
+                isPrivate: "isPublic"
             },
 
             facetNameMap: {
@@ -126,6 +129,7 @@ define(["jquery", "underscore", "backbone", "models/SolrResult", "collections/Fi
                 "annotation": "sem_annotation",
                 "spatial": "site",
                 "taxon": ["kingdom", "phylum", "class", "order", "family", "genus", "species"],
+                "isPublic": "isPublic",
                 "all": "keywords"
             },
 
@@ -489,6 +493,25 @@ define(["jquery", "underscore", "backbone", "models/SolrResult", "collections/Fi
                             " AND endDate:[* TO " + yearMax + "-12-31T00:00:00Z]";
                     }
                 }
+                
+                //----- public/private ------
+                if (this.filterIsAvailable("isPrivate") && ((filter == "isPrivate") || getAll)) {
+                    
+                    var isPrivate = this.get('isPrivate');
+                    if (isPrivate !== null && isPrivate !== 'undefined') {
+
+                        if( query.length ){
+                          query += " AND ";
+                        }
+
+                        // Currently, the Solr field 'isPublic' can be set to true or false, or not set.
+                        // isPrivate is equivalent to "isPublic:false" or isPublic not set
+                        if(isPrivate) {
+                            query += "-isPublic:true"
+                        }
+                    }
+                }
+
 
                 //-----Data Source--------
                 if (this.filterIsAvailable("dataSource") && ((filter == "dataSource") || getAll)) {

--- a/src/js/templates/search.html
+++ b/src/js/templates/search.html
@@ -31,6 +31,7 @@
 			    <ul id="current-id-filters" class="current-filters" data-category="id"></ul>
 				<ul id="current-taxon-filters" class="current-filters" data-category="taxon"></ul>
 				<ul id="current-spatial-filters" class="current-filters" data-category="spatial"></ul>
+                <ul id="current-isPrivate-filters" class="current-filters" data-category="isPrivate"></ul>
 				<ul id="current-additionalCriteria-filters" class="current-filters" data-category="additionalCriteria"></ul>
 		    </div>
     		<div class="filter-container collapsable">
@@ -210,7 +211,29 @@
 					</div>
 					<div class="clear"></div>
 				</div>
-
+                
+                
+                <% if(searchModelRef.filterIsAvailable("isPrivate")){ %>
+                    <div class="filter-contain collapsable" id="is-public" data-category="isPrivate">
+                         <label class="expand-collapse-control">
+                             <i class="icon icon-caret-right expand"></i>
+                             <i class="icon icon-caret-down collapse"></i>
+                             <img src="<%= MetacatUI.root %>/img/data-table.png" class="icon" />
+                             <span class="tooltip-this" data-trigger="hover" data-title="Check this to only public or private datasets" data-placement="top">
+                                 Access
+                             </span>
+                         </label>
+                         <div class="filter-input-contain clear">
+                         <input class="filter" type="checkbox" id="is_public_data" data-category="isPrivate"
+                      name="is_private_data" <% if (searchModelRef.filterIsAvailable("isPrivate") && isPrivate){ print("checked"); } %> />
+                             <label for="is_private_data" data-trigger="hover" data-title="Checking this option will return only packages that are private."
+                      data-placement="top" class="tooltip-this">
+                                 Private datasets
+                             </label>
+                         </div>
+                         <div class="clear"></div>
+                     </div>
+                 <% } %>
 			</div>
 		</aside>
 

--- a/src/js/templates/search.html
+++ b/src/js/templates/search.html
@@ -211,14 +211,14 @@
 					</div>
 					<div class="clear"></div>
 				</div>
-                
-                
+
+
                 <% if(searchModelRef.filterIsAvailable("isPrivate")){ %>
                     <div class="filter-contain collapsable" id="is-public" data-category="isPrivate">
                          <label class="expand-collapse-control">
                              <i class="icon icon-caret-right expand"></i>
                              <i class="icon icon-caret-down collapse"></i>
-                             <img src="<%= MetacatUI.root %>/img/data-table.png" class="icon" />
+                             <i class="icon icon-lock" />
                              <span class="tooltip-this" data-trigger="hover" data-title="Check this to only public or private datasets" data-placement="top">
                                  Access
                              </span>
@@ -228,7 +228,7 @@
                       name="is_private_data" <% if (searchModelRef.filterIsAvailable("isPrivate") && isPrivate){ print("checked"); } %> />
                              <label for="is_private_data" data-trigger="hover" data-title="Checking this option will return only packages that are private."
                       data-placement="top" class="tooltip-this">
-                                 Private datasets
+                                 Private datasets only
                              </label>
                          </div>
                          <div class="clear"></div>

--- a/src/js/themes/arctic/config.js
+++ b/src/js/themes/arctic/config.js
@@ -64,7 +64,7 @@ MetacatUI.AppConfig = Object.assign({
   enableSolrJoins: true,
   mapKey: "AIzaSyCYoTkUEpMAiOoWx5M61ButwgNGX8fIHUs",
   searchMapTileHue: "231",
-  defaultSearchFilters: ["all", "attribute", "annotation", "creator", "dataYear", "pubYear", "id", "taxon", "spatial"],
+  defaultSearchFilters: ["all", "attribute", "annotation", "creator", "dataYear", "pubYear", "id", "taxon", "spatial", "isPrivate"],
 
   //Temp message
   temporaryMessage: "",

--- a/src/js/views/DataCatalogView.js
+++ b/src/js/views/DataCatalogView.js
@@ -294,13 +294,13 @@ define(["jquery",
 
                 // Iterate through each search model text attribute and show UI filter for each
                 var categories = ["all", "attribute", "creator", "id", "taxon", "spatial",
-                    "additionalCriteria", "annotation"];
+                    "additionalCriteria", "annotation", "isPrivate"];
                 var thisTerm = null;
 
                 for (var i = 0; i < categories.length; i++) {
                     thisTerm = this.searchModel.get(categories[i]);
 
-                    if (thisTerm === undefined) break;
+                    if (thisTerm === undefined || thisTerm === null) break;
 
                     for (var x = 0; x < thisTerm.length; x++) {
                         this.showFilter(categories[i], thisTerm[x]);
@@ -1215,6 +1215,7 @@ define(["jquery",
                 $("#includes_data").prop("checked", this.searchModel.get("documents"));
                 $("#data_year").prop("checked", this.searchModel.get("dataYear"));
                 $("#publish_year").prop("checked", this.searchModel.get("pubYear"));
+                $("#is_private_data").prop("checked", this.searchModel.get("isPrivate"));
                 this.listDataSources();
 
                 // Zoom out the Google Map


### PR DESCRIPTION
This PR adds a `private` dataset filter to the main search window. The changes are:
- adding a new filter category `Access`
- a single option filter option `Private datasets`
- if this item is checked, the following clause is added to dataset retrieval Solr query: `-isPublic:true`