### PR TITLE
Fix URL encoding issues for GET requests for Solr searches

### DIFF
--- a/src/js/models/Search.js
+++ b/src/js/models/Search.js
@@ -354,10 +354,10 @@ define(["jquery", "underscore", "backbone", "models/SolrResult", "collections/Fi
                       }
 
                       if( forPOST ){
-                        query += this.fieldNameMap["id"] + ':*' + this.escapeSpecialChar(identifiers) + "*";
+                        query += this.fieldNameMap["id"] + ':*' + identifiers + "*";
                       }
                       else{
-                        query += this.fieldNameMap["id"] + ':*' + this.escapeSpecialChar(encodeURIComponent(identifiers)) + "*";
+                        query += this.fieldNameMap["id"] + ':*' + encodeURIComponent(identifiers) + "*";
                       }
                     }
                 }
@@ -493,7 +493,7 @@ define(["jquery", "underscore", "backbone", "models/SolrResult", "collections/Fi
                             " AND endDate:[* TO " + yearMax + "-12-31T00:00:00Z]";
                     }
                 }
-                
+
                 //----- public/private ------
                 if (this.filterIsAvailable("isPrivate") && ((filter == "isPrivate") || getAll)) {
                     
@@ -569,8 +569,6 @@ define(["jquery", "underscore", "backbone", "models/SolrResult", "collections/Fi
                           }
                         }
 
-                        filterValue = model.escapeSpecialChar(filterValue);
-
                         if( query.length ){
                           query += " AND ";
                         }
@@ -597,7 +595,7 @@ define(["jquery", "underscore", "backbone", "models/SolrResult", "collections/Fi
                           query += " AND ";
                         }
 
-                        query += model.escapeSpecialChar(value);
+                        query += value;
                     }
                 }
 
@@ -635,7 +633,7 @@ define(["jquery", "underscore", "backbone", "models/SolrResult", "collections/Fi
                           query += " AND ";
                         }
 
-                        query += model.escapeSpecialChar(filterValue);
+                        query += filterValue;
                     }
                 }
 
@@ -675,7 +673,7 @@ define(["jquery", "underscore", "backbone", "models/SolrResult", "collections/Fi
                               query += " AND ";
                             }
 
-                            query += model.fieldNameMap[filterName] + ":" + model.escapeSpecialChar(filterValue);
+                            query += model.fieldNameMap[filterName] + ":" + filterValue;
                         }
                     }
                 });
@@ -773,10 +771,10 @@ define(["jquery", "underscore", "backbone", "models/SolrResult", "collections/Fi
                       }
 
                       if( forPOST ){
-                        query += this.fieldNameMap["spatial"] + ':' + model.escapeSpecialChar(spatial);
+                        query += this.fieldNameMap["spatial"] + ':' + spatial;
                       }
                       else{
-                        query += this.fieldNameMap["spatial"] + ':' + model.escapeSpecialChar(encodeURIComponent(spatial));
+                        query += this.fieldNameMap["spatial"] + ':' + encodeURIComponent(spatial);
                       }
 
                     }
@@ -802,14 +800,19 @@ define(["jquery", "underscore", "backbone", "models/SolrResult", "collections/Fi
                       }
 
                       if( forPOST ){
-                        query += this.fieldNameMap["creator"] + ':' + model.escapeSpecialChar(creator);
+                        query += this.fieldNameMap["creator"] + ':' + creator;
                       }
                       else{
-                        query += this.fieldNameMap["creator"] + ':' + model.escapeSpecialChar(encodeURIComponent(creator));
+                        query += this.fieldNameMap["creator"] + ':' + encodeURIComponent(creator);
                       }
                     }
                 }
 
+                // The query is already URL-encoded except for brackets, if the request is not POST.
+                if ( !forPOST ) {
+                   query = query.replace(/\[/g, "%5B");
+                   query = query.replace(/\]/g, "%5D");
+                }
                 return query;
             },
 
@@ -884,19 +887,6 @@ define(["jquery", "underscore", "backbone", "models/SolrResult", "collections/Fi
                 return false;
             },
 
-            escapeSpecialChar: function(term) {
-                term = term.replace(/%7B/g, "\\%7B");
-                term = term.replace(/%7D/g, "\\%7D");
-                term = term.replace(/%3A/g, "\\%3A");
-                term = term.replace(/:/g, "\\:");
-                term = term.replace(/\(/g, "\\(");
-                term = term.replace(/\)/g, "\\)");
-                term = term.replace(/\?/g, "\\?");
-                term = term.replace(/%3F/g, "\\%3F");
-
-                return term;
-            },
-
             /*
              * Makes a Solr syntax grouped query using the field name, the field values to search for, and the operator.
              * Example:  title:(resistance OR salmon OR "pink salmon")
@@ -934,24 +924,24 @@ define(["jquery", "underscore", "backbone", "models/SolrResult", "collections/Fi
 
                     if (this.needsQuotes(values[0])) {
                       if( forPOST ){
-                        queryAddition = '"' + this.escapeSpecialChar(value) + '"';
+                        queryAddition = '"' + value + '"';
                       }
                       else{
-                        queryAddition = '%22' + this.escapeSpecialChar(encodeURIComponent(value)) + '%22';
+                        queryAddition = '%22' + encodeURIComponent(value) + '%22';
                       }
                     } else if (subtext) {
                       if( forPOST ){
-                        queryAddition = "*" + this.escapeSpecialChar(value) + "*";
+                        queryAddition = "*" + value + "*";
                       }
                       else{
-                        queryAddition = "*" + this.escapeSpecialChar(encodeURIComponent(value)) + "*";
+                        queryAddition = "*" + encodeURIComponent(value) + "*";
                       }
                     } else {
                       if( forPOST ){
-                        queryAddition = this.escapeSpecialChar(value);
+                        queryAddition = value;
                       }
                       else{
-                        queryAddition = this.escapeSpecialChar(encodeURIComponent(value));
+                        queryAddition = encodeURIComponent(value);
                       }
                     }
                     query = fieldName + ":" + queryAddition;
@@ -971,17 +961,14 @@ define(["jquery", "underscore", "backbone", "models/SolrResult", "collections/Fi
                           }
                         } else if (subtext) {
                           if( forPOST ){
-                            value = "*" + this.escapeSpecialChar(value) + "*";
+                            value = "*" + value + "*";
                           }
                           else{
-                            value = "*" + this.escapeSpecialChar(encodeURIComponent(value)) + "*";
+                            value = "*" + encodeURIComponent(value) + "*";
                           }
                         } else {
-                          if( forPOST ){
-                            value = this.escapeSpecialChar(value);
-                          }
-                          else{
-                            value = this.escapeSpecialChar(encodeURIComponent(value));
+                          if( !forPOST ){
+                            value = encodeURIComponent(value);
                           }
                         }
 
@@ -1061,24 +1048,24 @@ define(["jquery", "underscore", "backbone", "models/SolrResult", "collections/Fi
 
                         if (model.needsQuotes(v) || _.contains(fieldNames, "id")) {
                           if( forPOST ){
-                            valueString += '"' + this.escapeSpecialChar(v.trim()) + '"';
+                            valueString += '"' + v.trim() + '"';
                           }
                           else{
-                            valueString += '"' + this.escapeSpecialChar(encodeURIComponent(v.trim())) + '"';
+                            valueString += '"' + encodeURIComponent(v.trim()) + '"';
                           }
                         } else if (subtext) {
                           if( forPOST ){
-                            valueString += "*" + this.escapeSpecialChar(v.trim()) + "*";
+                            valueString += "*" + v.trim() + "*";
                           }
                           else{
-                            valueString += "*" + this.escapeSpecialChar(encodeURIComponent(v.trim())) + "*";
+                            valueString += "*" + encodeURIComponent(v.trim()) + "*";
                           }
                         } else {
                           if( forPOST ){
-                            valueString += this.escapeSpecialChar(v.trim());
+                            valueString += v.trim();
                           }
                           else{
-                            valueString += this.escapeSpecialChar(encodeURIComponent(v.trim()));
+                            valueString += encodeURIComponent(v.trim());
                           }
                         }
 

--- a/src/js/models/SolrResult.js
+++ b/src/js/models/SolrResult.js
@@ -374,19 +374,17 @@ define(['jquery', 'underscore', 'backbone'],
 			if(!fields)
 				var fields = "abstract,id,seriesId,fileName,resourceMap,formatType,formatId,obsoletedBy,isDocumentedBy,documents,title,origin,keywords,attributeName,pubDate,eastBoundCoord,westBoundCoord,northBoundCoord,southBoundCoord,beginDate,endDate,dateUploaded,archived,datasource,replicaMN,isAuthorized,isPublic,size,read_count_i,isService,serviceTitle,serviceEndpoint,serviceOutput,serviceDescription,serviceType,project,dateModified";
 
-			var escapeSpecialChar = MetacatUI.appSearchModel.escapeSpecialChar;
-
 			var query = "q=";
 
 			//If there is no seriesId set, then search for pid or sid
 			if(!this.get("seriesId"))
-				query += '(id:"' + escapeSpecialChar(encodeURIComponent(this.get("id"))) + '" OR seriesId:"' + escapeSpecialChar(encodeURIComponent(this.get("id"))) + '")';
+				query += '(id:"' + encodeURIComponent(this.get("id")) + '" OR seriesId:"' + encodeURIComponent(this.get("id")) + '")';
 			//If a seriesId is specified, then search for that
 			else if(this.get("seriesId") && (this.get("id").length > 0))
-				query += '(seriesId:"' + escapeSpecialChar(encodeURIComponent(this.get("seriesId"))) + '" AND id:"' + escapeSpecialChar(encodeURIComponent(this.get("id"))) + '")';
+				query += '(seriesId:"' + encodeURIComponent(this.get("seriesId")) + '" AND id:"' + encodeURIComponent(this.get("id")) + '")';
 			//If only a seriesId is specified, then just search for the most recent version
 			else if(this.get("seriesId") && !this.get("id"))
-				query += 'seriesId:"' + escapeSpecialChar(encodeURIComponent(this.get("id"))) + '" -obsoletedBy:*';
+				query += 'seriesId:"' + encodeURIComponent(this.get("id")) + '" -obsoletedBy:*';
 
 			query += "&fl=" + fields + //Specify the fields to return
 			         "&wt=json&rows=1000" + //Get the results in JSON format and get 1000 rows

--- a/src/js/models/Stats.js
+++ b/src/js/models/Stats.js
@@ -434,6 +434,15 @@ define(['jquery', 'underscore', 'backbone', 'promise'],
           dataType: "json",
           success: successCallback
         }
+
+        // TODO: Replace this clunky GET adjustment by refactoring the construction of fullQueryURL's encoding
+        requestSettings.url = requestSettings.url.replace(/\[/g, "%5B");
+        requestSettings.url = requestSettings.url.replace(/\]/g, "%5D");
+        requestSettings.url = requestSettings.url.replace(/\(/g, "%28");
+        requestSettings.url = requestSettings.url.replace(/\)/g, "%29");
+        requestSettings.url = requestSettings.url.replace(/!/g, "%21");
+        requestSettings.url = requestSettings.url.replace(/{/g, "%7B");
+        requestSettings.url = requestSettings.url.replace(/}/g, "%7D");
       }
 
       //Send the request
@@ -609,6 +618,10 @@ define(['jquery', 'underscore', 'backbone', 'promise'],
           dataType: "json",
           success: successCallback
         }
+
+        // TODO: Replace this clunky GET adjustment by refactoring the construction of fullQueryURL's encoding
+        requestSettings.url = requestSettings.url.replace(/\[/g, "%5B");
+        requestSettings.url = requestSettings.url.replace(/\]/g, "%5D");
       }
 
       //Send the request
@@ -718,7 +731,9 @@ define(['jquery', 'underscore', 'backbone', 'promise'],
     * searches for the earliest endDate.
     */
     getFirstBeginDate: function(){
-      var model = this;
+      var model = this,
+          open_bracket = this.get("usePOST") ? "[" : encodeURIComponent("["),
+          close_bracket = this.get("usePOST") ? "]" : encodeURIComponent("]");
 
       //Define a success callback when the query is successful
       var successCallback = function(data, textStatus, xhr) {
@@ -728,7 +743,8 @@ define(['jquery', 'underscore', 'backbone', 'promise'],
 
           //Construct a query to find the earliest endDate
           var query = model.get('query') +
-                " AND endDate:[" + model.get("firstPossibleDate") + " TO " + (new Date()).toISOString() + "]" + //Use date filter to weed out badly formatted data
+                " AND endDate:" + open_bracket + model.get("firstPossibleDate") + " TO " +
+                (new Date()).toISOString() + close_bracket + //Use date filter to weed out badly formatted data
                 " AND -obsoletedBy:*",
               //Get one row only
               rows = "1",
@@ -789,7 +805,7 @@ define(['jquery', 'underscore', 'backbone', 'promise'],
       }
 
       //Construct a query
-      var specialQueryParams = " AND beginDate:[" + this.get("firstPossibleDate") + " TO " + (new Date()).toISOString() + "] AND -obsoletedBy:* AND -formatId:*dataone.org/collections* AND -formatId:*dataone.org/portals*",
+      var specialQueryParams = " AND beginDate:" + open_bracket + this.get("firstPossibleDate") + " TO " + (new Date()).toISOString() + close_bracket + " AND -obsoletedBy:* AND -formatId:*dataone.org/collections* AND -formatId:*dataone.org/portals*",
           query = this.get("query") + specialQueryParams,
           //Get one row only
           rows = "1",
@@ -876,13 +892,15 @@ define(['jquery', 'underscore', 'backbone', 'promise'],
     * Gets the latest endDate from the Solr index
     */
     getLastEndDate: function(){
-      var model = this;
+      var model = this,
+          open_bracket = this.get("usePOST") ? "[" : encodeURIComponent("["),
+          close_bracket = this.get("usePOST") ? "]" : encodeURIComponent("]");
 
       var now = new Date();
 
       //Get the latest temporal data coverage year
-      var specialQueryParams = " AND endDate:[" + this.get("firstPossibleDate") + " TO " + now.toISOString() + "]" + //Use date filter to weed out badly formatted data
-            " AND -obsoletedBy:* AND -formatId:*dataone.org/collections* AND -formatId:*dataone.org/portals*",
+      var specialQueryParams = " AND endDate:" + open_bracket + this.get("firstPossibleDate") + " TO " + now.toISOString() + close_bracket +
+            " AND -obsoletedBy:* AND -formatId:*dataone.org/collections* AND -formatId:*dataone.org/portals*", //Use date filter to weed out badly formatted data
           query = this.get('query') + specialQueryParams,
           rows = 1,
           fl   = "endDate",

--- a/src/js/models/filters/Filter.js
+++ b/src/js/models/filters/Filter.js
@@ -470,14 +470,12 @@ define(['jquery', 'underscore', 'backbone'],
         var dateRangeRegEx = /^\[((\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d\.\d*Z)|\*)( |%20)TO( |%20)((\d{4}-[01]\d-[0-3]\dT[0-2]\d(:|\\:)[0-5]\d(:|\\:)[0-5]\d\.\d*Z)|\*)\]/,
             isDateRange = dateRangeRegEx.test(value),
             isSearchPhrase = value.indexOf(" ") > -1,
-            isIdFilter = this.isIdFilter();
-
-        // Escape special characters
-        value = this.escapeSpecialChar(value);
+            isIdFilter = this.isIdFilter(),
+            isOrcId = /^(?:https?:\/\/orcid\.org\/)?(?:\w{4}-){3}\w{4}/.test(value);
 
         // If the value is a search phrase (more than one word), is part of an ID filter,
         // and not a date range string, wrap in quotes
-        if( (isSearchPhrase || isIdFilter) && !isDateRange ){
+        if( (isSearchPhrase || isIdFilter || isOrcId) && !isDateRange ){
           value = "\"" + value + "\"";
         }
 
@@ -584,31 +582,6 @@ define(['jquery', 'underscore', 'backbone'],
       } catch (e) {
         console.log("Failed to check if a Filter is empty, error message: " + e);
       }
-    },
-
-    /**
-    * Escapes Solr query reserved characters so that search terms can include
-    *  those characters without throwing an error.
-    *
-    * @param {string} term - The search term or phrase to escape
-    * @return {string} - The search term or phrase, after special characters are escaped
-    */
-    escapeSpecialChar: function(term) {
-        term = term.replace(/%7B/g, "\\%7B");
-        term = term.replace(/%7D/g, "\\%7D");
-        term = term.replace(/%3A/g, "\\%3A");
-        term = term.replace(/:/g, "\\:");
-        term = term.replace(/\(/g, "\\(");
-        term = term.replace(/\)/g, "\\)");
-        term = term.replace(/\?/g, "\\?");
-        term = term.replace(/%3F/g, "\\%3F");
-        term = term.replace(/\"/g, '\\"');
-        term = term.replace(/\'/g, "\\'");
-        term = term.replace(/\#/g, "\\%23");
-        term = term.replace(/\-/g, "\\%2D");
-        term = term.replace(/\&amp\;/g, "\\%26");
-
-        return term;
     },
 
     /**

--- a/src/js/views/StatsView.js
+++ b/src/js/views/StatsView.js
@@ -291,12 +291,12 @@ define(['jquery', 'underscore', 'backbone', 'd3', 'LineChart', 'BarChart', 'Donu
 		if (this.userType === "repository") {
 			if (this.userLabel !== undefined)
 			{
-				var identifier = MetacatUI.appSearchModel.escapeSpecialChar(encodeURIComponent(this.userId));
+				var identifier = encodeURIComponent(this.userId);
 				this.model.getTotalReplicas(identifier);
 			}
 			else if (this.nodeSummaryView) {
 				var nodeId = MetacatUI.appModel.get("nodeId");
-				var identifier = MetacatUI.appSearchModel.escapeSpecialChar(encodeURIComponent(nodeId));
+				var identifier = encodeURIComponent(nodeId);
 				this.model.getTotalReplicas(identifier);
 			}
 


### PR DESCRIPTION
Most of the main menu selections in the UI were afflicted by bad GET
request composition including characters not permitted by the HTTP
standard, which was responsible for the server rejecting the request
with HTTP 400.

These patches resolve the bad request failures by dropping the invalid
injection of backslashes, and substituting special characters with the
URL-encoded representations, primarily square brackets. Lastly, there
was an instance where a Solr query fragment was being composed with
OrcID strings that weren't enclosed in quotes, which is also fixed.

The late string manipulations have been marked as TODO items since a
more permanent, ideal fix is to rework the preceding logic rather than
stripping bad characters back out of a string that was just composed.

Jing and Lauren are aware that we have been working on this issue. After
overcoming the problems causing the error 400 responses, we're receiving
good responses back, indicating that additional character escaping for Solr's
input was not even necessary. For that reason, I completely removed the
`escapeSpecialChars` methods.

I don't know the reason behind not simply making all the complicated requests
POSTs, regardless of their size or length; it would simplify a lot of the code.