### PR TITLE
Make zoom button in Cesium more obvious

### DIFF
--- a/src/css/map-view.css
+++ b/src/css/map-view.css
@@ -31,8 +31,9 @@
   --map-col-bkg-lighter: #1b2538;
   --map-col-bkg-lightest: #242e42;
   --map-col-buttons: #313c52;
+  --map-col-buttons-emphasis: var(--portal-secondary-color, #04da88);
   --map-col-text: #F9FAFB;
-  --map-col-highlight: var(--portal-primary-color);
+  --map-col-highlight: var(--portal-primary-color, #00a0e9);
   /* SIZING: */
   --map-size-toolbar-link: 2.2rem;
   --map-size-toolbar-link-margin: 0.4rem;
@@ -98,6 +99,13 @@
 
 .map-view__button:hover {
   filter: brightness(1.2);
+}
+
+.map-view__button--emphasis {
+  background: var(--map-col-buttons-emphasis);
+  padding: 0.5rem 0.55rem;
+  font-weight: 900;
+  font-size: 1rem;
 }
 
 /* hide the credits until we can find a better placement for them */
@@ -582,6 +590,10 @@ represents 1 unit of the given distance measurement. */
   display: flex;
 }
 
+.layer-detail--no-header .layer-detail__content {
+  margin-top: 0;
+}
+
 .layer-detail__toggle {
   --toggle-size: 1.7rem;
   display: block;
@@ -658,6 +670,8 @@ represents 1 unit of the given distance measurement. */
 
 .layer-navigation {
   width: 100%;
+  display: flex;
+  justify-content: center;
 }
 
 /* The shaded part of the slider that stretches from 0 to the current opacity */

--- a/src/js/templates/maps/layer-detail.html
+++ b/src/js/templates/maps/layer-detail.html
@@ -1,3 +1,7 @@
-<h5 class="layer-detail__label"><%=label%></h5>
-<button class="layer-detail__toggle map-view__button"></button>
+<% if (showTitle) { %>
+  <h5 class="layer-detail__label"><%=label%></h5>
+<% } %>
+<% if (collapsible) { %>
+  <button class="layer-detail__toggle map-view__button"></button>
+<% } %>
 <div class="layer-detail__content"></div>

--- a/src/js/templates/maps/layer-navigation.html
+++ b/src/js/templates/maps/layer-navigation.html
@@ -1,3 +1,3 @@
-<button class="map-view__button layer-navigation__button layer-navigation__button--extent">
+<button class="map-view__button map-view__button--emphasis layer-navigation__button layer-navigation__button--extent">
   <i class="icon-fullscreen icon-on-left"></i> Zoom to entire dataset
 </button>

--- a/src/js/views/maps/LayerDetailView.js
+++ b/src/js/views/maps/LayerDetailView.js
@@ -63,12 +63,15 @@ define(
          * expand or collapse this Layer Detail section.
          * @property {string} open The class to add to the view when the contents are
          * visible (i.e. the section is expanded)
+         * @property {string} noHeader The class to add to the view when there is no
+         * title/label and the view is not collapsible.
          * @property {string} label The element that holds the view's label text
          * @property {string} contentContainer The container into which the contentView's
          * rendered content will be placed
          */
         classes: {
           open: 'layer-detail--open',
+          noHeader: 'layer-detail--no-header',
           label: 'layer-detail__label',
           toggle: 'layer-detail__toggle',
           contentContainer: 'layer-detail__content'
@@ -147,7 +150,9 @@ define(
 
             // Insert the template into the view
             this.$el.html(this.template({
-              label: this.label
+              label: this.label,
+              collapsible: this.collapsible,
+              showTitle: this.showTitle
             }));
 
             // Render the content for this Layer Detail section
@@ -160,6 +165,10 @@ define(
               })
               contentContainer.append(this.renderedContentView.el)
               this.renderedContentView.render()
+            }
+
+            if (!this.collapsible && !this.showTitle) {
+              this.el.classList.add(this.classes.noHeader);
             }
 
             return this

--- a/src/js/views/maps/LayerDetailsView.js
+++ b/src/js/views/maps/LayerDetailsView.js
@@ -91,6 +91,10 @@ define(
          * display information about the MapAsset and/or allow some aspect of the
          * MapAsset's appearance to be edited - e.g. a LayerInfoView or a
          * LayerOpacityView.
+         * @property {boolean} collapsible Whether or not this section should be
+         * expandable and collapsible.
+         * @property {boolean} showTitle Whether or not to show the title/label for this
+         * section.
          * @property {boolean} hideIfError Set to true to hide this section when there is
          * an error loading the layer. Example: we should hide the opacity slider for
          * layers that are not visible on the map
@@ -104,18 +108,24 @@ define(
          */
         sections: [
           {
-            label: 'Opacity',
-            view: LayerOpacityView,
+            label: 'Navigation',
+            view: LayerNavigationView,
+            collapsible: false,
+            showTitle: false,
             hideIfError: true
           },
           {
-            label: 'Navigation',
-            view: LayerNavigationView,
+            label: 'Opacity',
+            view: LayerOpacityView,
+            collapsible: false,
+            showTitle: true,
             hideIfError: true
           },
           {
             label: 'Info & Data',
             view: LayerInfoView,
+            collapsible: true,
+            showTitle: true,
             hideIfError: false
           }
         ],
@@ -193,7 +203,9 @@ define(
               var detailSection = new LayerDetailView({
                 label: section.label,
                 contentView: section.view,
-                model: view.model
+                model: view.model,
+                collapsible: section.collapsible,
+                showTitle: section.showTitle
               })
               sectionsContainer.append(detailSection.el)
               detailSection.render()


### PR DESCRIPTION
### Before
<img width="200" src="https://user-images.githubusercontent.com/26600641/158694805-0e1f7182-aa06-44f9-9bba-c6585174c684.png">

### After
<img width="200" src="https://user-images.githubusercontent.com/26600641/158694802-442f1be8-1b0f-44c7-aa01-b35033794460.png">

### Details
- Add section options to LayerDetailsView that allows sections to not display a title or not be collapsible
- Add a map button "emphasis" style. The button will use the `portal-secondary-color` if one is set, or a default color otherwise.
- Use the "emphasis" button style on the Zoom To button, move the navigation section to the top of the LayerDetailsView, and hide the title & collapse button

Fixes issue #1974