### PR TITLE
Enable layer-level notifications in Cesium map

### DIFF
--- a/src/css/map-view.css
+++ b/src/css/map-view.css
@@ -33,6 +33,9 @@
   --map-col-buttons: #313c52;
   --map-col-text: #F9FAFB;
   --map-col-highlight: var(--portal-primary-color);
+  --map-col-green: #069868;
+  --map-col-blue: #057fc6;
+  --map-col-yellow: #f8b406;
   /* SIZING: */
   --map-size-toolbar-link: 2.2rem;
   --map-size-toolbar-link-margin: 0.4rem;
@@ -44,6 +47,13 @@
   --map-shadow-md: 0 1px 9px -1px rgba(0, 0, 0, 0.2), 0 1px 2px 0px rgba(0, 0, 0, 0.5);
   /* NOTE: 768px is used as the mobile -> desktop breakpoint throughout the map view, but we cannot use a CSS variable for this. */
 }
+
+/* hide the credits until we can find a better placement for them */
+.cesium-widget-credits, .cesium-credit-lightbox-overlay {
+  display: none !important;
+}
+
+/* ---- TOOLTIP ---- */
 
 .map-tooltip {
   color: var(--map-col-text);
@@ -75,6 +85,8 @@
   background-color: var(--map-col-buttons);
 }
 
+/* ---- BUTTON ---- */
+
 .map-view__button {
   /* override default button styles */
   font-family: inherit;
@@ -100,9 +112,44 @@
   filter: brightness(1.2);
 }
 
-/* hide the credits until we can find a better placement for them */
-.cesium-widget-credits, .cesium-credit-lightbox-overlay {
-  display: none !important;
+/* ---- BADGE ---- */
+
+.map-view__badge{
+  padding: 0.4em 0.5em 0.3em 0.55em;
+  margin: 0 -0.2rem 0 0.3rem;
+  font-size: 0.62rem;
+  background-color: var(--map-col-bkg-lighter);
+  color: var(--map-col-text);
+  text-transform: uppercase;
+  letter-spacing: 0.09em;
+  filter: brightness(1.3);
+  border-radius: var(--map-border-radius);
+  line-height: 100%;
+  font-weight: 500;
+}
+
+.map-view__badge--blue{
+  background-color: var(--map-col-blue);
+  filter: none;
+}
+
+.map-view__badge--green{
+  background-color: var(--map-col-green);
+  filter: none;
+}
+
+.map-view__badge--yellow{
+  background-color: var(--map-col-yellow);
+  color: var(--map-col-bkg-lighter);
+  filter: none;
+  font-weight: 600;
+  opacity: 0.9;
+}
+.map-view__badge--contrast{
+  background-color: var(--map-col-text);
+  color: var(--map-col-bkg);
+  opacity: 0.8;
+  font-weight: 600;
 }
 
 
@@ -328,7 +375,7 @@ represents 1 unit of the given distance measurement. */
 .toolbar__all-content {
   background-color: var(--map-col-bkg);
   width: var(--map-width-toolbar);
-  padding: 0.8rem 1rem;
+  padding: 0.8rem;
   box-shadow: var(--map-shadow-md);
   flex-direction: column;
   /* Don't display the content unless the toolbar is open. The outermost element, with
@@ -436,10 +483,10 @@ represents 1 unit of the given distance measurement. */
 
 .layer-item__label {
   cursor: pointer;
-  font-size: 1.04rem;
+  font-size: 0.93rem;
   font-weight: 500;
   letter-spacing: 0.015em;
-  margin-right: 1rem;
+  margin-right: 0.4rem;
   display: flex;
   align-items: center;
 }
@@ -448,7 +495,7 @@ represents 1 unit of the given distance measurement. */
   fill: currentColor;
   height: 1.04rem;
   width: auto;
-  margin-right: 0.6rem;
+  margin-right: 0.34rem;
   opacity: 0.8;
 }
 
@@ -464,6 +511,8 @@ represents 1 unit of the given distance measurement. */
 .layer-item__visibility-toggle {
   background: none;
   opacity: 0.85;
+  padding: 0;
+  margin-left: 0.5rem;
 }
 
 .layer-item__visibility-toggle:before {
@@ -512,7 +561,8 @@ represents 1 unit of the given distance measurement. */
   box-shadow: var(--map-shadow-md);
   grid-template-columns: auto min-content;
   grid-template-rows: min-content auto;
-  gap: 1rem;
+  row-gap: 1rem;
+  column-gap: 0.5rem;
   align-items: center;
   /* Don't show the details panel unless it also has the layer-details--open class */
   display: none;
@@ -531,7 +581,7 @@ represents 1 unit of the given distance measurement. */
   text-align: center;
   width: 100%;
   font-weight: 500;
-  font-size: 0.9rem;
+  font-size: 0.85rem;
   opacity: 60%;
 }
 
@@ -540,6 +590,36 @@ represents 1 unit of the given distance measurement. */
   font-size: 1.3rem;
   background-color: transparent;
   opacity: 0.6;
+}
+
+/* The notification div holds a badge & message, if one is set */
+.layer-details__notification {
+  margin: -0.2rem 0 0.9rem 0;
+  padding: 0.3rem 0.5rem;
+  background-color: var(--map-col-buttons);
+  border-radius: var(--map-border-radius);
+}
+
+.layer-details__notification--blue{
+  background-color: var(--map-col-blue);
+  filter: none;
+}
+
+.layer-details__notification--green{
+  background-color: var(--map-col-green);
+  filter: none;
+}
+
+.layer-details__notification--yellow{
+  background-color: var(--map-col-yellow);
+  color: var(--map-col-bkg-lighter);
+  filter: none;
+  opacity: 0.9;
+}
+.layer-details__notification--contrast{
+  background-color: var(--map-col-text);
+  color: var(--map-col-bkg);
+  opacity: 0.95;
 }
 
 .layer-details__sections {
@@ -562,10 +642,10 @@ represents 1 unit of the given distance measurement. */
   color: var(--map-col-text) !important;
   margin: 0;
   text-transform: uppercase;
-  letter-spacing: 0.01em;
+  letter-spacing: 0.04em;
   width: 100%;
   font-weight: 600;
-  font-size: 0.95rem;
+  font-size: 0.9rem;
   line-height: 1;
 }
 
@@ -733,7 +813,7 @@ other class: .ui-slider-range */
   text-align: center;
   width: 100%;
   font-weight: 500;
-  font-size: 0.9rem;
+  font-size: 0.85rem;
   opacity: 60%;
 }
 
@@ -770,7 +850,7 @@ other class: .ui-slider-range */
   width: calc(var(--map-width-toolbar) - 2.2rem);
 }
 
-.feature-info__table-body {}
+/* .feature-info__table-body {} */
 
 .feature-info__table-row {
   padding-bottom: 0.6rem;

--- a/src/js/models/maps/assets/MapAsset.js
+++ b/src/js/models/maps/assets/MapAsset.js
@@ -84,6 +84,9 @@ define(
          * allows for the definition of custom feature properties, potentially based on
          * other properties. For example, a custom property could be a formatted version
          * of an existing date property.
+         * @property {MapConfig#Notification} [notification] A custom badge and message to
+         * display about the layer in the Layer list. For example, this could highlight
+         * the layer if it is new, give a warning if they layer is under development, etc.
          * @property {'ready'|'error'|null} [status = null] Set to 'ready' when the
          * resource is loaded and ready to be rendered in a map view. Set to 'error' when
          * the asset is not supported, or there was a problem requesting the resource.
@@ -106,6 +109,7 @@ define(
             colorPalette: null,
             customProperties: {},
             featureTemplate: {},
+            notification: {},
             status: null,
             statusDetails: null
           }
@@ -167,6 +171,9 @@ define(
          * custom properties may be expanded to support formatted numbers and booleans.
          * @property {MapConfig#VectorFilterConfig} [filters] - A set of conditions used
          * to show or hide specific features of this tileset.
+         * @property {MapConfig#Notification} [notification] A custom badge and message to
+         * display about the layer in the Layer list. For example, this could highlight
+         * the layer if it is new, give a warning if they layer is under development, etc.
         */
 
         /**
@@ -274,6 +281,20 @@ define(
          * available. In the future, templates that include other properties may be
          * supported.
          */
+
+        /**
+         * A notification displays a badge in the {@link LayerListView} and a message in
+         * the {@link LayerDetailsView}. This is useful for indicating some special status
+         * of the layer: "new", "under development", etc.
+         * @typedef {Object} Notification
+         * @name MapConfig#Notification
+         * @since x.x.x
+         * @property {'yellow'|'green'|'blue'|'contrast'} [style] - The badge and message
+         * color. If none is set, then notification elements will be similar to the
+         * background colour (subtle).
+         * @property {string} badge - The text to display in the badge element next to the
+         * layer label in the list. This badge should be as few characters as possible.
+         * @property {string} message - A longer message to display explaining the status.
 
         /**
          * Executed when a new MapAsset model is created.

--- a/src/js/views/maps/LayerDetailsView.js
+++ b/src/js/views/maps/LayerDetailsView.js
@@ -74,11 +74,20 @@ define(
          * @property {string} toggle The element in the template that acts as a toggle to
          * close/hide the details view
          * @property {string} sections The container for all of the LayerDetailViews.
+         * @property {string} label The label element for the layer that displays a title
+         * in the header of the details view
+         * @property {string} notification The element that holds the notification message,
+         * if there is one. Inserted before all the details sections.
+         * @property {string} badge The class to add to the badge element that is shown
+         * when the layer has a notification message.
          */
         classes: {
           open: 'layer-details--open',
           toggle: 'layer-details__toggle',
-          sections: 'layer-details__sections'
+          sections: 'layer-details__sections',
+          label: 'layer-details__label',
+          notification: 'layer-details__notification',
+          badge: 'map-view__badge'
         },
 
         /**
@@ -169,6 +178,7 @@ define(
 
             // Save a reference to this view
             var view = this;
+            var model = this.model;
 
             // Show the layer details box as open if the view is set to have it open
             // already
@@ -178,29 +188,31 @@ define(
 
             // Insert the template into the view
             this.$el.html(this.template({
-              label: this.model ? this.model.get('label') || '' : ''
+              label: model ? model.get('label') || '' : ''
             }));
 
             // Ensure the view's main element has the given class name
             this.el.classList.add(this.className);
 
-            var sectionsContainer = this.el.querySelector('.' + this.classes.sections)
-
-            this.renderedSections = _.clone(this.sections)
+            // Select elements in the template that we will need to manipulate
+            const sectionsContainer = this.el.querySelector('.' + this.classes.sections)
+            const labelEl = this.el.querySelector('.' + this.classes.label)
 
             // Render each section in the Details panel
+            this.renderedSections = _.clone(this.sections)
+
             this.renderedSections.forEach(function (section) {
               var detailSection = new LayerDetailView({
                 label: section.label,
                 contentView: section.view,
-                model: view.model
+                model: model
               })
               sectionsContainer.append(detailSection.el)
               detailSection.render()
               // Hide the section if there is an error with the asset, and this section
               // does make sense to show for a layer that can't be displayed
-              if (section.hideIfError && view.model) {
-                if (view.model.get('status') === 'error') {
+              if (section.hideIfError && model) {
+                if (model && model.get('status') === 'error') {
                   detailSection.el.style.display = 'none'
                 }
               }
@@ -209,8 +221,8 @@ define(
 
             // Hide/show sections with the 'hideIfError' property when the status of the
             // MapAsset changes
-            this.stopListening(this.model, 'change:status')
-            this.listenTo(this.model, 'change:status', function (model, status) {
+            this.stopListening(model, 'change:status')
+            this.listenTo(model, 'change:status', function (model, status) {
               const hideIfErrorSections = _.filter(this.renderedSections, function (section) {
                 return section.hideIfError
               })
@@ -222,6 +234,35 @@ define(
                 section.renderedView.el.style.display = displayProperty
               })
             })
+
+            // If this layer has a notification, show the badge and notification
+            // message
+            const notice = model ? model.get('notification') : null
+            if (notice && (notice.message || notice.badge)) {
+              // message
+              if (notice.message) {
+                const noticeEl = document.createElement('div')
+                noticeEl.classList.add(this.classes.notification)
+                noticeEl.innerText = notice.message
+                if (notice.style) {
+                  const badgeClass = this.classes.notification + '--' + notice.style
+                  noticeEl.classList.add(badgeClass)
+                }
+                sectionsContainer.prepend(noticeEl)
+              }
+              // badge
+              if (notice.badge) {
+                const badge = document.createElement('span')
+                badge.classList.add(this.classes.badge)
+                badge.innerText = notice.badge
+                if (notice.style) {
+                  const badgeClass = this.classes.badge + '--' + notice.style
+                  badge.classList.add(badgeClass)
+                }
+                labelEl.append(badge)
+              }
+              
+            }
 
             return this
 

--- a/src/js/views/maps/LayerItemView.js
+++ b/src/js/views/maps/LayerItemView.js
@@ -64,8 +64,8 @@ define(
         template: _.template(Template),
 
         /**
-         * Classes that are used to identify or create the HTML elements that comprise
-         * this view.
+         * Classes that are used to identify or create the HTML elements that comprise this
+         * view.
          * @type {Object}
          * @property {string} label The element that contains the layer's name/label
          * @property {string} icon The span element that contains the SVG icon
@@ -73,10 +73,12 @@ define(
          * switch the Layer's visibility on and off
          * @property {string} legendContainer The element that the legend preview will be
          * inserted into.
-         * @property {string} selected The class that gets added to the view when the
-         * Layer Item is selected
+         * @property {string} selected The class that gets added to the view when the Layer
+         * Item is selected
          * @property {string} hidden The class that gets added to the view when the Layer
          * Item is not visible
+         * @property {string} badge The class to add to the badge element that is shown
+         * when the layer has a notification message
          * @property {string} tooltip Class added to tooltips used in this view
          */
         classes: {
@@ -86,6 +88,7 @@ define(
           legendContainer: 'layer-item__legend-container',
           selected: 'layer-item--selected',
           hidden: 'layer-item--hidden',
+          badge: 'map-view__badge',
           tooltip: 'map-tooltip',
         },
 
@@ -346,6 +349,11 @@ define(
               this.showError(errorMessage)
             } else if (status === 'ready') {
               this.removeStatuses()
+              const notice = layerModel.get('notification')
+              const badge = notice ? notice.badge : null
+              if (badge) {
+                this.showBadge(badge, notice.style)
+              }
             } else if (status === 'loading') {
               this.showLoading()
             }
@@ -367,6 +375,9 @@ define(
             if (this.statusIcon) {
               this.statusIcon.remove()
             }
+            if (this.badge) {
+              this.badge.remove()
+            }
             this.$el.tooltip('destroy')
           }
           catch (error) {
@@ -378,12 +389,40 @@ define(
         },
 
         /**
+         * Create a badge element and insert it to the right of the layer label.
+         * @param {string} text - The text to display in the badge
+         * @param {string} [style] - The style of the badge. Can be any of the styles
+         * defined in the {@link MapConfig#Notification} style property, e.g. 'green'
+         */
+        showBadge: function (text, style) {
+          try {
+            if (!text) {
+              return
+            }
+            this.removeStatuses();
+            this.badge = document.createElement('span')
+            this.badge.classList.add(this.classes.badge)
+            this.badge.innerText = text
+            this.labelEl.append(this.badge)
+            if (style) {
+              const badgeClass = this.classes.badge + '--' + style
+              this.badge.classList.add(badgeClass)
+            }
+          } catch (error) {
+            console.log(
+              'There was an error showing the badge in a LayerItemView' +
+              '. Error details: ' + error
+            );
+          }
+        },
+
+        /**
          * Indicate to the user that there was a problem showing or loading this error.
          * Shows a 'warning' icon to the right of the label for the asset and a tooltip
          * with more details
-         * @param {string} message The error message to show in the tooltip
+         * @param {string} message The error message to show in the tooltip.
          */
-        showError: function (message) {
+        showError: function (message='') {
           try {
             const view = this
 


### PR DESCRIPTION
This PR adds support for configuring notifications in Cesium maps that are specific to individual layers. A notification is configured by adding a `notification` property to a layer, for example:

``` json
{
  "layers": [
    {
      "label": "Ice Wedge Polygons",
      "type": "Cesium3DTileset",
      "notification": {
        "badge": "Preview",
        "style": "green",
        "message": "Pan-arctic coverage will be available for this layer soon! While the data pipeline is under development, a subset of the data is available here."
      }
    }
]}
```

This adds a badge element next to the layer name in the layers list, and a longer message in the layer details panel:

<img width="444" alt="Screen Shot 2022-03-18 at 13 43 29" src="https://user-images.githubusercontent.com/26600641/159055845-be74cd9a-d9d7-4c7d-beb7-670de03b6063.png">
<img width="332" alt="Screen Shot 2022-03-18 at 13 43 07" src="https://user-images.githubusercontent.com/26600641/159055847-d9120be1-f6ae-474e-9b8c-3c6e574db7fb.png">

Five styles of notifications are available:

<img width="462" alt="Screen Shot 2022-03-18 at 13 29 34" src="https://user-images.githubusercontent.com/26600641/159055997-2258286f-662b-46e8-b419-3a402a0046cf.png">

The image above comes from the the test portal `permafrost-test-portal` on `urn:node:mnTestARCTIC` - this portal could be used to test the notifications feature.

If we move forward with these notification styles, we should test out how they look with the new "Zoom To" button styles, if PR #1976 is accepted.

This PR additionally refines spacing & font sizes in the UI elements of the Cesium Map. It became apparent when adding the badge element that the UI layout could be a little more compact (I think elements were too large and spaced out before.)

Fixes #1972