### PR TITLE
Adds Project Base Model, View and Placeholder HTML

### DIFF
--- a/src/js/collections/ProjectList.js
+++ b/src/js/collections/ProjectList.js
@@ -1,0 +1,71 @@
+/* global define */
+"use strict";
+define(['jquery', 'backbone', 'models/Project'],
+    function ($, Backbone, Project) {
+        'use strict';
+        /**
+         @class ProjectList
+         @classdesc A ProjectList represents a collection of projects. This can be
+         used for a projects list view populating EML projects. It also supports loading
+         projects from a third-party API in case projects information is located outside of
+         metacat.
+         * @classcategory Collections
+         @extends Backbone.Collection
+         @constructor
+         */
+
+        var ProjectList = Backbone.Collection.extend({
+            model: Project,
+            type: "ProjectList",                            //The name of this type of collection
+            authToken: undefined,
+            urlBase: undefined,
+            urlEndpoint: "project/",
+
+            /** Builds the url from the urlBase **/
+            url: function(){
+                if(this.urlBase)
+                {
+                    return new URL(new URL(this.urlBase).pathname + this.urlEndpoint, this.urlBase).href
+                }
+                else {
+                    return undefined
+                }
+            },
+            /**
+             * Override backbone's parse to set the data after the request returns from the server
+             */
+            parse: function (response, options) {
+                // Add any custom data structure code here.
+                return response
+            },
+            /**
+             * Override backbone's sync to set the auth token
+             */
+            sync: function(method, model, options) {
+
+                if (this.authToken) {
+                    if (options.headers === undefined){
+                        options.headers = {}
+                    }
+                    options.headers["Authorization"] = "Bearer " + this.authToken;
+                }
+                if (this.urlBase)
+                    return Backbone.Model.prototype.sync.apply(this, [method, model, options]);
+            },
+
+            /**
+             * Initializing the Model objects project variables.
+             */
+            initialize: function (options) {
+                if (MetacatUI && MetacatUI.appModel) this.urlBase = MetacatUI.appModel.get("projectsApiUrl");
+                if (options) {
+                    if (options.authToken) this.authToken = options.authToken;
+                    if (options.urlBase) this.urlBase = options.urlBase;
+                }
+                Backbone.Collection.prototype.initialize.apply(this, options);
+            }
+        });
+
+        return ProjectList
+
+    });

--- a/src/js/models/AppModel.js
+++ b/src/js/models/AppModel.js
@@ -1450,6 +1450,18 @@ define(['jquery', 'underscore', 'backbone'],
       },
 
       /**
+       * Add an API service URL that retrieves projects data. This is an optional
+       * configuration in case the memberNode have a third-party service that provides
+       * their projects information.
+       *
+       * If the configuration is not set, set the default projects list in the views using it.
+       *
+       * @type {string}
+       * @private
+       * @since 2.20.0 #TODO Update version here.
+       */
+      projectsApiUrl: undefined,
+      /**
       * Enable or disable the use of Fluid Earth Viewer visualizations in portals.
       * This config option is marked as `private` since this is an experimental feature.
       * @type {boolean}

--- a/src/js/models/Project.js
+++ b/src/js/models/Project.js
@@ -1,0 +1,70 @@
+define(['jquery', 'backbone'],
+    function($, Backbone) {
+        'use strict';
+        /**
+         * @class Citation
+         * @classdesc A Project model represents a single instance of a project. This can be
+         *          used for a projects list view populating EML projects. It also supports loading
+         *          projects from a third-party API in case projects information is located outside of
+         *          metacat.
+         * @classcategory Models
+         */
+
+        var Project = Backbone.Model.extend({
+
+            idAttribute: "id",
+            defaults: {           // Set the project model attributes defaults here.
+                id: undefined,
+                title: undefined,
+            },
+            authToken: undefined,
+            urlBase: undefined,
+
+            /** Builds  from the urlBase **/
+            urlRoot: function(){
+                if(this.urlBase)
+                {
+                    return new URL(new URL(this.urlBase).pathname + this.urlEndpoint, this.urlBase).href
+                }
+                else {
+                    return undefined
+                }
+            },
+            /**
+             * Override backbone's parse to set the data after the request returns from the server
+             */
+            parse: function(response, options) {
+                // Add any custom data structure code here.
+                return response
+            },
+            /**
+             * Override backbone's sync to set the auth token
+             */
+            sync: function(method, model, options) {
+
+                if (this.authToken) {
+                    if (options.headers === undefined){
+                        options.headers = {}
+                    }
+                    options.headers["Authorization"] = "Bearer " + this.authToken
+                }
+
+                if(this.urlBase)
+                    return Backbone.Model.prototype.sync.apply(this, [method, model, options])
+            },
+            /**
+             * Initializing the Model objects project variables. The projects are retrieved from the
+             * model url service
+             */
+            initialize: function (options) {
+                if (MetacatUI && MetacatUI.appModel)  this.urlBase = MetacatUI.appModel.get("projectsApiUrl")
+                if (options.authToken)  this.authToken = options.authToken
+                if (options.urlBase) this.urlBase = options.urlBase;
+
+                Backbone.Model.prototype.initialize.apply(this, options)
+            }
+
+        });
+        return Project;
+    }
+);

--- a/src/js/routers/router.js
+++ b/src/js/routers/router.js
@@ -31,11 +31,12 @@ function ($, _, Backbone) {
 			"signinldaperror(/)"                : "renderLdapSignInError",
 			"signinLdap(/)"                     : "renderLdapSignIn",
 			"signinSuccessLdap(/)"              : "renderLdapSignInSuccess",
-      "signin-help"                       : "renderSignInHelp", //The Sign In troubleshotting page
+      		"signin-help"                       : "renderSignInHelp", //The Sign In troubleshotting page
 			'share(/*pid)(/)'                   : 'renderEditor', // registry page
 			'submit(/*pid)(/)'                  : 'renderEditor', // registry page
 			'quality(/s=:suiteId)(/:pid)(/)'    : 'renderMdqRun', // MDQ page
 			'api(/:anchorId)(/)'                : 'renderAPI',       // API page
+			"projects"                          : "renderProjectInfo", // Projects view
 			"edit/:portalTermPlural(/:portalIdentifier)(/:portalSection)(/)" : "renderPortalEditor",
 			'drafts' : 'renderDrafts'
 		},
@@ -165,6 +166,13 @@ function ($, _, Backbone) {
 				}
 
 			this.renderText(options);
+		},
+
+		renderProjectInfo: function() {
+			require(["views/ProjectView"], function(ProjectView) {
+				MetacatUI.appView.projectView = new ProjectView();
+				MetacatUI.appView.showView(MetacatUI.appView.projectView)
+			});
 		},
 
 		/*

--- a/src/js/templates/projectInfo.html
+++ b/src/js/templates/projectInfo.html
@@ -1,0 +1,16 @@
+<div class="row">
+    <div class="row">
+        <div class="col-12">
+            <select id="projects" class="ui dropdown projects-dropdown">
+                <!--     PLACEHOLDER FOR PROJECT TEMPLATE RENDER       -->
+                <!--                Example code below                 -->
+                <% if ( projectList && projectList.length > 0 ) { %>
+                <% projectList.models.forEach(function(project) { %><option <% if ( selectedProject && selectedProject.id == project.id ) { %>
+                    <%=selected="selected"%>
+                <% }%>
+                    value="<%= project.id %>"><%= project.get("project_title") %></option> <% })%>
+                <% } %>
+            </select>
+        </div>
+    </div>
+</div>

--- a/src/js/views/ProjectView.js
+++ b/src/js/views/ProjectView.js
@@ -1,0 +1,99 @@
+define([
+        'jquery',
+        'underscore',
+        'backbone',
+        'text!templates/projectInfo.html', 'models/Project',
+        'collections/ProjectList'],
+    function ($, _, Backbone, template, Project, ProjectList) {
+        /**
+         * @class ProjectView
+         * @classdesc    This is a base view for projects list loading. It is structured
+         * on the premise that a project gets selected to be having its details viewed. The template associated
+         * with this view has a placeholder to render the projects with the desired way.
+         * @classcategory Views
+         * @extends Backbone.View
+         */
+        var ProjectView = Backbone.View.extend({
+            el: "#Content",
+            template: _.template(template),
+            projectList: undefined, // Set default list if not using projectsApiUrl
+            selectedProject: undefined,
+            load: undefined,
+            events: {
+                "change #projects": "handleSelectProject"
+            },
+
+            initialize: function (options) {
+                this.getProjectsList()
+
+
+                // After projectList fetch call is successful, set the default selected project to the first project
+                // received from the projectsList then render to load the select element.
+                this.listenTo(this.projectList, 'sync', this.setSelectedProject);
+                this.listenTo(this.projectList, 'sync', this.render);
+
+                // In case the token was not loaded already, get the projects after it gets loaded.
+                this.listenTo(MetacatUI.appUserModel, 'change:token', this.getProjectsList);
+            },
+
+            /**
+             *
+             * @returns {ProjectView}
+             */
+            render: function () {
+                // If a project selection logic is implemented, pass down the selection.
+                if(this.selectedProject !== undefined) {
+                    this.$el.html(this.template({
+                        projectList: this.projectList,
+                        selectedProject: this.selectedProject
+                    }));
+                } else {
+                    this.$el.html(this.template({
+                        projectList: this.projectList,
+                    }));
+                }
+                return this;
+            },
+
+            /**
+             * Handles the change event for selecting a project in the dropdown and then render.
+             * @param e
+             */
+            handleSelectProject: function (e) {
+                // Set the selectedProject based on the selected project id from the select element.
+                this.selectedProject = this.projectList.findWhere({id: e.target.value});
+                this.render();
+                return;
+            },
+
+            /**
+             * Call back to set the selectedProject
+             * This is used as a callback to only set the current project on the success of the fetch call.
+             */
+            setSelectedProject: function () {
+                if (this.selectedProject === undefined)
+                    this.selectedProject = this.projectList.at(0)
+                this.render()
+            },
+
+            /**
+             * Call back to initialize the ProjectsList
+             * This is used as a callback so that the fetch would happen after the change:token event gets loaded.
+             */
+            getProjectsList: function (){
+                // Note that if the projectsApiUrl config is not set, projectsList will fall to the default set.
+                if(MetacatUI.appModel.get("projectsApiUrl")){
+                    // Get the projects for the user
+                    this.projectList = new ProjectList({
+                        authToken: MetacatUI.appUserModel.get("token"),
+                        urlBase: MetacatUI.appModel.get("projectsApiUrl")
+                    })
+                    this.projectList.fetch({
+                        parse: true,
+                        data: {can_manage: true}
+                    })
+                }
+            }
+        });
+        return ProjectView;
+    });

--- a/test/config/tests.json
+++ b/test/config/tests.json
@@ -4,6 +4,8 @@
     "./js/specs/unit/models/Search.js",
     "./js/specs/unit/models/filters/Filter.js",
     "./js/specs/unit/models/filters/NumericFilter.js",
+    "./js/specs/unit/collections/ProjectList.spec.js",
+    "./js/specs/unit/models/project/Project.spec.js",
     "./js/specs/unit/models/metadata/eml211/EML211.spec.js",
     "./js/specs/unit/models/metadata/eml211/EMLAttribute.spec.js",
     "./js/specs/unit/models/metadata/eml211/EMLDateTimeDomain.spec.js",

--- a/test/js/specs/unit/collections/ProjectList.spec.js
+++ b/test/js/specs/unit/collections/ProjectList.spec.js
@@ -1,0 +1,51 @@
+define([
+    "../../../../../../../../src/js/collections/ProjectList"
+], function (ProjectList) {
+
+    var should =  chai.should();
+    var expect = chai.expect;
+
+    describe("ProjectListTestSuite", function () {
+
+        var collection;
+
+        /* Setup */
+        before(function () {
+            // If needed
+            collection = new ProjectList([
+                    {
+                        "id": "6f6e4191-7916-44e5-b7d2-571ba00f67ee",
+                        "title": "Coupling model intercomparison with synthesized experimental data across time and space to constrain carbon dynamics and biogeochemical cycling in permafrost ecosystems"
+                    },
+                    {
+                        "id": "5b5528e9-2f92-4728-91c0-255a9c4beded",
+                        "title": "Soil Carbon Biogeochemistry"
+                    }
+                ]
+                ,{parse: true, async: false});
+        });
+
+        /* Tear down */
+        after(function () {
+            // If needed
+
+        });
+
+        describe("The collection object", function () {
+            it('should exist', function () {
+                console.log(collection)
+                expect(collection).to.exist;
+                collection.should.exist;
+                collection.length.should.equal(2)
+                _.each(collection.models, function (model) {
+                    expect(model).to.exist;
+                    expect(model.id).to.exist;
+                    expect(model.get("title")).to.exist;
+                })
+
+            });
+        });
+    });
+})
+;
+

--- a/test/js/specs/unit/models/project/Project.spec.js
+++ b/test/js/specs/unit/models/project/Project.spec.js
@@ -1,0 +1,86 @@
+/**
+ * Check that the fields and values match in the specified model
+ * @param model
+ * @param fields
+ * @param values
+ */
+function checkFields(model, fields, values) {
+
+    for (var i in fields) {
+        console.log(model.get("title"))
+        model.get(fields[i]).should.exist;
+        model.get(fields[i]).should.equal(values[i]);
+    }
+}
+
+define([
+    "../../../../../../../../src/js/models/Project",
+], function (Project) {
+
+    // Configure the Chai assertion library
+    var should = chai.should();
+    var expect = chai.expect;
+
+    describe("ProjectTestSuite", function () {
+
+        var model;
+        var FIELDS = ["title", "id"];
+
+        /* Setup */
+        before(function () {
+
+            // If needed
+            model = new Project({
+                "id": "5b5528e9-2f92-4728-91c0-255a9c4beded",
+                "title": "Soil Carbon Biogeochemistry"
+            });
+
+
+        });
+
+        /* Tear down */
+        after(function () {
+            // If needed
+
+        });
+
+        describe("The model object", function () {
+            it('should exist', function () {
+                expect(model).to.exist;
+                model.should.exist;
+            });
+
+            it('should initialized attributes', function () {
+
+                var values = ["Soil Carbon Biogeochemistry",
+                    "5b5528e9-2f92-4728-91c0-255a9c4beded"]
+                checkFields(model, FIELDS, values)
+
+            });
+
+
+            it('should have fetched attributes', function () {
+                model = new Project({id: '6f6e4191-7916-44e5-b7d2-571ba00f67ee/'})
+
+                if (model.urlBase){
+                    model.fetch({
+                        parse: true,
+                        async: false,
+                    })
+
+                    var values = ["Coupling model intercomparison with synthesized experimental data across time and space to constrain carbon dynamics and biogeochemical cycling in permafrost ecosystems",
+                        "6f6e4191-7916-44e5-b7d2-571ba00f67ee"]
+                    checkFields(model, FIELDS, values)
+                } else {
+                    this._runnable.title += ` - Skipped with reason: No project api url set to test fetch.`
+                    this.skip();
+                }
+            })
+
+
+        });
+
+    });
+})
+;
+


### PR DESCRIPTION
Closes #1945

* Adds a base Project model and collection that can be populated
 either from a default or a direct API. In the case of populating
 from the API, extending member nodes will have to extend the Parse
 function if any data structure handling is needed.

* Adds tests for project model and collection.

* Adds a Project view with some functinality to handle basic view
project selection and rendering.

* Adds a projects info template as a placeholder for extending nodes.

Co-authors: Mario Melara, Val Hendrix