### PR TITLE
Adds exstensible dev server module

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,0 +1,84 @@
+/* Simple MetacatUI app module.
+
+You'll need node.js and express.js to run this.
+
+- Install dependencies with `npm install`.
+- load with `const main = require("./app");`
+
+*/
+
+const express = require("express");
+const path = require("path");
+const port = process.env.PORT || 3000;
+const app = express();
+const fs = require("fs");
+
+// Subdirectory where index.html and the rest are
+const src_dir = "src";
+
+/**
+ * Get the directories for the given path
+ * @param path
+ * @returns {*}
+ */
+function getDirectories(path) {
+    return fs.readdirSync(path).filter(function (file) {
+        return fs.statSync(path + '/' + file).isDirectory();
+    });
+}
+
+/**
+ * Initialize the MetacatUI App with the base dir to the main
+ * source directory
+ *
+ * @param metacatuiBaseDir [Optional] base metacatui repo directory
+ * @param configJs [Optional] override  /config/config.js
+ */
+function initializeApp(metacatuiBaseDir = null, configJs = null, ) {
+
+    // Determine where metacatui source directory is
+    if (metacatuiBaseDir === null || metacatuiBaseDir === undefined) {
+        metacatuiBaseDir = __dirname;
+    }
+
+    app.use('/loader.js', express.static(path.resolve(metacatuiBaseDir, src_dir, "loader.js")));
+
+    // Is /config/config/js to be overridden?
+    var overrideConfigJs = configJs !== null;
+
+    // Map metacatui source directories
+    let metacatDirs = getDirectories(metacatuiBaseDir + "/" + src_dir)
+    for (let i in metacatDirs) {
+
+        var metacatCurrentDir = path.resolve(metacatuiBaseDir, src_dir, metacatDirs[i])
+        // Determine if we override the configuration file (/config/config.js)
+        if (metacatDirs[i] !== 'config' || !overrideConfigJs) {
+            console.log('Setting /' + metacatDirs[i]+ " to " + metacatCurrentDir)
+            app.use('/' + metacatDirs[i], express.static(metacatCurrentDir))
+        } else if (metacatDirs[i] === 'config' || overrideConfigJs) {
+            console.log("Setting " + '/' + metacatDirs[i] + "/config.js to " + configJs)
+            app.use('/' + metacatDirs[i] + "/config.js", express.static(configJs));
+        }
+    }
+
+    app.get("*", function (request, response) {
+        response.sendFile(path.resolve(metacatuiBaseDir, src_dir, "index.html"));
+    });
+
+
+    return app;
+}
+
+/**
+ * Expose the `initializeApp`  function.
+ */
+exports.initializeApp = initializeApp
+
+/**
+ * Expose the prototypes.
+ */
+
+exports.express = express;
+exports.app = app;
+exports.srcDir = src_dir;
+exports.port = port;

--- a/server.js
+++ b/server.js
@@ -8,19 +8,10 @@ You'll need node.js and express.js to run this.
 You'll also likely want to edit index.html and loader.js as needed.
 See README.md for more details.
 */
+'use strict';
 
-const express = require("express");
-const path = require("path");
-const port = process.env.PORT || 3000;
-const app = express();
+const main = require("./app");
+const app = main.initializeApp()
 
-// Subdirectory where index.html and the rest are
-const src_dir = "src";
-
-app.use(express.static(__dirname + "/" + src_dir));
-app.get("*", function(request, response) {
-  response.sendFile(path.resolve(__dirname, src_dir, "index.html"));
-});
-app.listen(port);
-
-console.log("Now running at http://localhost:" + port);
+app.listen(main.port)
+console.log("Now running at http://localhost:" + main.port);


### PR DESCRIPTION
Ability to extend metacatui server.js for a custom metacatui theme
+ adds app.js module that is extended by server.js
+ Running `npm run dev` should produce the same results

**Tested against 2.21.0**
I tested this against the dataone theme from the `main@2.21.0` branch using the following configuration.

```javascript
MetacatUI.AppConfig = {
    theme: "dataone",
    root: "/",
    baseUrl: "https://search.dataone.org",
    d1CNBaseUrl: "https://cn.dataone.org",
}

```

Executing `npm run dev` outputs the following informational lines
```bash
% npm run dev                             

> metacatui@2.21.0 dev
> node server.js

Setting /components to /Users/val/workspace/metacatui/src/components
Setting /config to /Users/val/workspace/metacatui/src/config
Setting /css to /Users/val/workspace/metacatui/src/css
Setting /font to /Users/val/workspace/metacatui/src/font
Setting /img to /Users/val/workspace/metacatui/src/img
Setting /js to /Users/val/workspace/metacatui/src/js
Now running at http://localhost:3000

```

Closes #2036