### PR TITLE
Fixes duplicate ids with EML annotations

### DIFF
--- a/src/js/models/metadata/eml211/EML211.js
+++ b/src/js/models/metadata/eml211/EML211.js
@@ -949,7 +949,7 @@ define(['jquery', 'underscore', 'backbone', 'uuid',
         }, this);
 
         //Since there is at least one annotation, the dataset node needs to have an id attribute.
-        datasetNode.attr("id", this.getXMLSafeID());
+        datasetNode.attr("id", this.getUniqueEntityId(this));
       }
 
       //If there is no creator, create one from the user


### PR DESCRIPTION
Combination of EML annotation and custom xml safe generated identifiers
raise error on save
+ replaces the use of this.getXMLSafeID() with
  this.getUniqueEntityId(this) in `EML211.serialize()` to make sure that the identifier is
  unique.

Closes #2038