### PR TITLE
Add project search filter option

### DIFF
--- a/src/js/models/AppModel.js
+++ b/src/js/models/AppModel.js
@@ -271,7 +271,7 @@ define(['jquery', 'underscore', 'backbone'],
       * @default ["all", "attribute", "documents", "creator", "dataYear", "pubYear", "id", "taxon", "spatial", "isPrivate"]
       * @example ["all", "annotation", "attribute", "dataSource", "documents", "creator", "dataYear", "pubYear", "id", "taxon", "spatial"]
       */
-      defaultSearchFilters: ["all", "attribute", "documents", "creator", "dataYear", "pubYear", "id", "taxon", "spatial", "isPrivate"],
+      defaultSearchFilters: ["all", "attribute", "documents", "creator", "dataYear", "pubYear", "id", "taxon", "spatial", "isPrivate", "projectText"],
 
       /**
        * Enable to show Whole Tale features

--- a/src/js/models/Search.js
+++ b/src/js/models/Search.js
@@ -848,7 +848,7 @@ define(["jquery", "underscore", "backbone", "models/SolrResult", "collections/Fi
                 if (this.filterIsAvailable("projectText") && ((filter == "projectText") || getAll)) {
 
                     var project = this.get('projectText');
-                    if (project.length > 0 && project !== 'undefined') {
+                    if (project && project.length > 0) {
 
                         if( query.length ){
                             query += " AND ";

--- a/src/js/models/Search.js
+++ b/src/js/models/Search.js
@@ -25,6 +25,7 @@ define(["jquery", "underscore", "backbone", "models/SolrResult", "collections/Fi
             defaults: function() {
                 return {
                     all: [],
+                    projectText: [],
                     creator: [],
                     taxon: [],
                     isPrivate: null,
@@ -99,7 +100,8 @@ define(["jquery", "underscore", "backbone", "models/SolrResult", "collections/Fi
                 taxon: "Taxon",
                 spatial: "Location",
                 isPrivate: "Private datasets",
-                all: ""
+                all: "",
+                projectText: "Project",
             },
 
             //Map the filter names to their index field names
@@ -120,7 +122,8 @@ define(["jquery", "underscore", "backbone", "models/SolrResult", "collections/Fi
                 submitter: "submitter",
                 username: ["rightsHolder", "writePermission", "changePermission"],
                 taxon: ["kingdom", "phylum", "class", "order", "family", "genus", "species"],
-                isPrivate: "isPublic"
+                isPrivate: "isPublic",
+                projectText: "projectText"
             },
 
             facetNameMap: {
@@ -130,7 +133,8 @@ define(["jquery", "underscore", "backbone", "models/SolrResult", "collections/Fi
                 "spatial": "site",
                 "taxon": ["kingdom", "phylum", "class", "order", "family", "genus", "species"],
                 "isPublic": "isPublic",
-                "all": "keywords"
+                "all": "keywords",
+                "projectText": "project"
             },
 
             getCurrentFilters: function() {
@@ -839,6 +843,20 @@ define(["jquery", "underscore", "backbone", "models/SolrResult", "collections/Fi
                       }
                     }
                 }
+                
+                // Add project filter
+                if (this.filterIsAvailable("projectText") && ((filter == "projectText") || getAll)) {
+
+                    var project = this.get('projectText');
+                    if (project.length > 0 && project !== 'undefined') {
+
+                        if( query.length ){
+                            query += " AND ";
+                        }
+                        query += 'projectText:"' + project[0].value + '"';
+                    }
+                }
+
 
                 return query;
             },

--- a/src/js/templates/search.html
+++ b/src/js/templates/search.html
@@ -10,6 +10,7 @@
 		    <div class="current-filters-container">
 		    	<h5>My Search</h5>
 		    	<ul id="current-all-filters" class="current-filters" data-category="all"></ul>
+				<ul id="current-projectText-filters" class="current-filters" data-category="projectText"></ul>
 		    	<ul id="current-attribute-filters" class="current-filters" data-category="attribute"></ul>
 		    	<ul id="current-annotation-filters" class="current-filters" data-category="annotation"></ul>
 		    	<ul id="current-documents-filters" class="current-filters" data-category="documents">
@@ -36,6 +37,24 @@
 		    </div>
     		<div class="filter-container collapsable">
 				<h5 id="filters-header">Filter by:</h5>
+
+				<% if(searchModelRef.filterIsAvailable("projectText")){ %>
+				<div class="filter-contain collapsable" data-category="projectText">
+					<label class="expand-collapse-control">
+						<i class="icon icon-caret-right expand"></i>
+						<i class="icon icon-caret-down collapse"></i>
+						<i class="icon icon-group"></i>
+						<span class="tooltip-this" data-trigger="hover" data-title="Find datasets if they have the filter project name." data-placement="top">
+							Project
+						</span>
+					</label>
+					<div class="filter-input-contain input-append ">
+						<input class="filter" type="text" placeholder="Project name" id="projectText_input" data-category="projectText">
+						<button class="filter btn" id="projectText_btn" data-category="projectText"><i class="icon-search"></i></button>
+					</div>
+					<div class="clear"></div>
+				</div>
+				<% } %>
 
 				<div class="filter-contain collapsable" data-category="attribute">
 					<label class="expand-collapse-control">


### PR DESCRIPTION
Enables turning on project search in the DataCatalogView.
+ Documentation change made to AppModel.js (provide projectText in
  example for defaultSearchFilters
+ Updates Backbone Search model to include projectText
+ Updates search.html template to optionally render the project search
  filter

Closes #2044