### PR TITLE
Resolves issues with infinite spinners for portal metrics

### DIFF
--- a/src/js/models/Stats.js
+++ b/src/js/models/Stats.js
@@ -387,7 +387,7 @@ define(['jquery', 'underscore', 'backbone', 'promise'],
         }
 
         var queryData = new FormData();
-        queryData.append("q", query);
+        queryData.append("q", decodeURIComponent(query));
         queryData.append("fq", filterQuery);
         queryData.append("stats", stats);
         queryData.append("stats.field", statsField);
@@ -573,7 +573,7 @@ define(['jquery', 'underscore', 'backbone', 'promise'],
         }
 
         var queryData = new FormData();
-        queryData.append("q", query);
+        queryData.append("q", decodeURIComponent(query));
         queryData.append("fq", filterQuery);
         queryData.append("stats", stats);
         queryData.append("stats.field", statsField);
@@ -751,7 +751,7 @@ define(['jquery', 'underscore', 'backbone', 'promise'],
           if( model.get("usePOST") ){
 
             var queryData = new FormData();
-            queryData.append("q", query);
+            queryData.append("q", decodeURIComponent(query));
             queryData.append("rows", rows);
             queryData.append("sort", sort);
             queryData.append("fl", fl);
@@ -811,7 +811,7 @@ define(['jquery', 'underscore', 'backbone', 'promise'],
         }
 
         var queryData = new FormData();
-        queryData.append("q", query);
+        queryData.append("q", decodeURIComponent(query));
         queryData.append("rows", rows);
         queryData.append("sort", sort);
         queryData.append("fl", fl);
@@ -925,7 +925,7 @@ define(['jquery', 'underscore', 'backbone', 'promise'],
         }
 
         var queryData = new FormData();
-        queryData.append("q", query);
+        queryData.append("q", decodeURIComponent(query));
         queryData.append("rows", rows);
         queryData.append("sort", sort);
         queryData.append("fl", fl);


### PR DESCRIPTION
Part of #2041 
MetacatUI was sending URL encoded query strings as part of POST request query parameter which was causing issues with SOLR request resulting in `500` error. The commit in this PR fixes those errors for Portal Metrics. 