### PR TITLE
Quick Add Taxa feature in the EML editor 🪸

### DIFF
--- a/src/css/metacatui-common.css
+++ b/src/css/metacatui-common.css
@@ -8432,6 +8432,33 @@ textarea.medium{
 .taxon-rank-value{
 	width: calc(100% - 50px);
 }
+
+/* quick add box */
+.taxa-quick-add{
+	background-color: #ddf3f6;
+	display: grid;
+	padding: 0.5rem 1rem 1rem 1rem;
+	border-radius: 4px;
+	border: 1px solid #c4deea;
+}
+.taxa-quick-add__controls{
+	display: grid;
+	grid-template-columns: auto max-content;
+	gap: 1rem;
+	align-items: end;
+}
+.taxa-quick-add__selects{
+	display: grid;
+	grid-template-columns: repeat(auto-fit, minmax(10rem, 1fr));
+	gap: 1rem;
+}
+.taxa-quick-add__button{
+	height: min-content;
+}
+.taxa-quick-add__text{
+	margin: 0
+}
+
 /* ---- Methods ---- */
 .metadata-container .sampling{
 	margin-top: 20px;

--- a/src/js/models/AppModel.js
+++ b/src/js/models/AppModel.js
@@ -518,6 +518,63 @@ define(['jquery', 'underscore', 'backbone'],
       * @since 2.19.0
       */
       customEMLMethods: [],
+      
+      /**
+       * Configuration options for a drop down list of taxa.
+       * @typedef {object} AppConfig#quickAddTaxaList
+       * @type {Object}
+       * @property {string} label - The label for the dropdown menu
+       * @property {string} placeholder - The placeholder text for the input field
+       * @property {EMLTaxonCoverage#taxonomicClassification[]} taxa - The list of taxa to show in the dropdown menu
+       * @example
+       * {
+       *  label: "Primates",
+       *  placeholder: "Select one or more primates",
+       *  taxa: [
+       *    {
+       *     commonName: "Bonobo",
+       *     taxonRankName: "Species",
+       *     taxonRankValue: "Pan paniscus",
+       *     taxonId: {
+       *        provider: "ncbi",
+       *        value: "9597"
+       *     }
+       *   },
+       *   {
+       *     commonName: "Chimpanzee",
+       *     ...
+       *   },
+       *   ...
+       * }
+       * @since x.x.x
+       */
+
+      /**
+       * A list of taxa to show in the Taxa Quick Add section of the EML editor.
+       * This can be used to expedite entry of taxa that are common in the
+       * repository's domain. The quickAddTaxa is a list of objects, each
+       * defining a separate dropdown interface. This way, common taxa can
+       * be grouped together.
+       * Alternative, provide a SID for a JSON data object that is stored in the
+       * repository. The JSON must be in the same format as required for this
+       * configuration option.
+       * @since x.x.x
+       * @type {AppConfig#quickAddTaxaList[] | string}
+       * @example
+       * [
+       *   {
+       *     label: "Bats"
+       *     placeholder: "Select one or more bats",
+       *     taxa: [ ... ]
+       *   },
+       *   {
+       *     label: "Birds"
+       *     placeholder: "Select one or more birds",
+       *     taxa: [ ... ]
+       *   }
+       * ]
+       */
+      quickAddTaxa: [],
 
       /**
       * The base URL for the repository. This only needs to be changed if the repository
@@ -2240,6 +2297,33 @@ define(['jquery', 'underscore', 'backbone'],
       if( !defaultAltRepo ){
         this.set("activeAlternateRepositoryId", altRepos[0].identifier);
       }
+      },
+
+      /**
+       * Get the config options for the Taxa Quick Add feature. IF a SID is
+       * configured, this will fetch the taxa from the repository. Otherwise,
+       * it will return the object set on the quickAddTaxa attribute.
+       */
+      getQuickAddTaxa: function () {
+        var taxa = this.get("quickAddTaxa");
+        if (typeof taxa === "object") return taxa;
+        if (typeof taxa !== "string") return null;
+
+        // Otherwise, fetch the DataONE Object
+        fetch(this.get("objectServiceUrl") + encodeURIComponent(taxa), {
+          method: "get",
+          headers: {
+            "Content-Type": "application/json",
+          },
+        })
+        .then((response) => response.json())
+        .then((data) => {
+          console.log("Successfully fetched taxa", data);
+          this.set("quickAddTaxa", data);
+        })
+        .catch((error) => {
+          console.log("Error fetching taxa", error);
+        });
       },
 
       /**

--- a/src/js/models/AppModel.js
+++ b/src/js/models/AppModel.js
@@ -2318,7 +2318,6 @@ define(['jquery', 'underscore', 'backbone'],
         })
         .then((response) => response.json())
         .then((data) => {
-          console.log("Successfully fetched taxa", data);
           this.set("quickAddTaxa", data);
         })
         .catch((error) => {

--- a/src/js/models/metadata/eml211/EMLTaxonCoverage.js
+++ b/src/js/models/metadata/eml211/EMLTaxonCoverage.js
@@ -5,7 +5,41 @@ define(["jquery", "underscore", "backbone", "models/DataONEObject"], function (
   Backbone,
   DataONEObject
 ) {
+
+  /**
+   * @name taxonomicClassification
+   * @type {Object}
+   * @property {string} taxonRankName - The name of the taxonomic rank, for
+   * example, Domain, Kingdom, etc.
+   * @property {string} taxonRankValue - The value for the given taxonomic rank,
+   * for example, Animalia, Chordata, etc.
+   * @property {string[]} commonName - Common name(s) for the taxon, for example
+   * ["Animal"]
+   * @property {Object[]} taxonId - A taxon identifier from a controlled
+   * vocabulary, for example, ITIS, NCBI, etc.
+   * @property {string} taxonId.provider - The provider of the taxon identifier,
+   * given as a URI, for example http://www.itis.gov
+   * @property {string} taxonId.value - The identifier from the provider, for
+   * example, 180092
+   * @property {Object[]} taxonomicClassification - A nested taxonomic
+   * classification, since taxonomy is represented as a hierarchy in EML.
+   */
+
+
   var EMLTaxonCoverage = Backbone.Model.extend({
+
+    /**
+     * Returns the default properties for this model. Defined here.
+     * @type {Object}
+     * @property {string} objectXML - The XML string for this model
+     * @property {Element} objectDOM - The XML DOM for this model
+     * @property {EML211} parentModel - The parent EML211 model
+     * @property {taxonomicClassification[]} taxonomicClassification - An array
+     * of taxonomic classifications, defining the taxonomic coverage of the
+     * dataset
+     * @property {string} generalTaxonomicCoverage - A general description of the
+     * taxonomic coverage of the dataset
+     */
     defaults: {
       objectXML: null,
       objectDOM: null,

--- a/src/js/models/metadata/eml211/EMLTaxonCoverage.js
+++ b/src/js/models/metadata/eml211/EMLTaxonCoverage.js
@@ -1,268 +1,329 @@
 /* global define */
-define(['jquery', 'underscore', 'backbone', 'models/DataONEObject'],
-    function($, _, Backbone, DataONEObject) {
+define(["jquery", "underscore", "backbone", "models/DataONEObject"], function (
+  $,
+  _,
+  Backbone,
+  DataONEObject
+) {
+  var EMLTaxonCoverage = Backbone.Model.extend({
+    defaults: {
+      objectXML: null,
+      objectDOM: null,
+      parentModel: null,
+      taxonomicClassification: [],
+      generalTaxonomicCoverage: null,
+    },
 
-	var EMLTaxonCoverage = Backbone.Model.extend({
+    initialize: function (attributes) {
+      if (attributes.objectDOM) this.set(this.parse(attributes.objectDOM));
 
-		defaults: {
-			objectXML: null,
-			objectDOM: null,
-			parentModel: null,
-			taxonomicClassification: [],
-			generalTaxonomicCoverage: null
-		},
+      this.on("change:taxonomicClassification", this.trickleUpChange);
+      this.on("change:taxonomicClassification", this.updateDOM);
+    },
 
-		initialize: function(attributes){
-			if(attributes.objectDOM)
-				this.set(this.parse(attributes.objectDOM));
+    /*
+     * Maps the lower-case EML node names (valid in HTML DOM) to the camel-cased
+     * EML node names (valid in EML). Used during parse() and serialize()
+     */
+    nodeNameMap: function () {
+      return {
+        generaltaxonomiccoverage: "generalTaxonomicCoverage",
+        taxonomicclassification: "taxonomicClassification",
+        taxonrankname: "taxonRankName",
+        taxonrankvalue: "taxonRankValue",
+        taxonomiccoverage: "taxonomicCoverage",
+        taxonomicsystem: "taxonomicSystem",
+        classificationsystem: "classificationSystem",
+        classificationsystemcitation: "classificationSystemCitation",
+        classificationsystemmodifications: "classificationSystemModifications",
+        identificationreference: "identificationReference",
+        identifiername: "identifierName",
+        taxonomicprocedures: "taxonomicProcedures",
+        taxonomiccompleteness: "taxonomicCompleteness",
+        taxonid: "taxonId",
+        commonname: "commonName",
+      };
+    },
 
-			this.on("change:taxonomicClassification", this.trickleUpChange);
-			this.on("change:taxonomicClassification", this.updateDOM);
-		},
+    parse: function (objectDOM) {
+      if (!objectDOM) var xml = this.get("objectDOM");
 
-		/*
-         * Maps the lower-case EML node names (valid in HTML DOM) to the camel-cased EML node names (valid in EML).
-         * Used during parse() and serialize()
-         */
-        nodeNameMap: function(){
-        	return {
-            	"generaltaxonomiccoverage" : "generalTaxonomicCoverage",
-            	"taxonomicclassification" : "taxonomicClassification",
-            	"taxonrankname" : "taxonRankName",
-            	"taxonrankvalue" : "taxonRankValue",
-            	"taxonomiccoverage" : "taxonomicCoverage",
-				"taxonomicsystem" : "taxonomicSystem",
-				"classificationsystem" : "classificationSystem",
-				"classificationsystemcitation" : "classificationSystemCitation",
-				"classificationsystemmodifications" : "classificationSystemModifications",
-				"identificationreference": "identificationReference",
-				"identifiername": "identifierName",
-				"taxonomicprocedures": "taxonomicProcedures",
-				"taxonomiccompleteness":"taxonomicCompleteness",
-				"taxonid": "taxonId",
-				"commonname": "commonName"
+      var model = this,
+        taxonomicClassifications = $(objectDOM).children(
+          "taxonomicclassification"
+        ),
+        modelJSON = {
+          taxonomicClassification: _.map(
+            taxonomicClassifications,
+            function (tc) {
+              return model.parseTaxonomicClassification(tc);
+            }
+          ),
+          generalTaxonomicCoverage: $(objectDOM)
+            .children("generaltaxonomiccoverage")
+            .first()
+            .text(),
+        };
+
+      return modelJSON;
+    },
+
+    parseTaxonomicClassification: function (classification) {
+      var id = $(classification).attr("id");
+      var rankName = $(classification).children("taxonrankname");
+      var rankValue = $(classification).children("taxonrankvalue");
+      var commonName = $(classification).children("commonname");
+      var taxonId = $(classification).children("taxonId");
+      var taxonomicClassification = $(classification).children(
+        "taxonomicclassification"
+      );
+
+      var model = this,
+        modelJSON = {
+          id: id,
+          taxonRankName: $(rankName).text().trim(),
+          taxonRankValue: $(rankValue).text().trim(),
+          commonName: _.map(commonName, function (cn) {
+            return $(cn).text().trim();
+          }),
+          taxonId: _.map(taxonId, function (tid) {
+            return {
+              provider: $(tid).attr("provider").trim(),
+              value: $(tid).text().trim(),
             };
-        },
+          }),
+          taxonomicClassification: _.map(
+            taxonomicClassification,
+            function (tc) {
+              return model.parseTaxonomicClassification(tc);
+            }
+          ),
+        };
 
-		parse: function(objectDOM){
-			if(!objectDOM)
-				var xml = this.get("objectDOM");
+      if (
+        Array.isArray(modelJSON.taxonomicClassification) &&
+        !modelJSON.taxonomicClassification.length
+      )
+        modelJSON.taxonomicClassification = {};
 
-			var model = this,
-			    taxonomicClassifications = $(objectDOM).children('taxonomicclassification'),
-			    modelJSON = {
-					taxonomicClassification: _.map(taxonomicClassifications, function(tc) { return model.parseTaxonomicClassification(tc); }),
-					generalTaxonomicCoverage: $(objectDOM).children('generaltaxonomiccoverage').first().text()
-				};
+      return modelJSON;
+    },
 
-			return modelJSON;
-		},
+    serialize: function () {
+      var objectDOM = this.updateDOM(),
+        xmlString = objectDOM.outerHTML;
 
-		parseTaxonomicClassification: function(classification) {
-			var id = $(classification).attr("id");
-			var rankName = $(classification).children("taxonrankname");
-			var rankValue = $(classification).children("taxonrankvalue");
-			var commonName = $(classification).children("commonname");
-			var taxonId = $(classification).children("taxonId");
-			var taxonomicClassification = $(classification).children("taxonomicclassification");
+      //Camel-case the XML
+      xmlString = this.formatXML(xmlString);
 
-			var model = this,
-			    modelJSON = {
-				id: id,
-				taxonRankName: $(rankName).text().trim(),
-				taxonRankValue: $(rankValue).text().trim(),
-				commonName: _.map(commonName, function(cn) {
-					return $(cn).text().trim();
-				}),
-				taxonId: _.map(taxonId, function(tid) {
-					return {
-						provider: $(tid).attr("provider").trim(),
-						value: $(tid).text().trim()
-					}
-				}),
-				taxonomicClassification: _.map(taxonomicClassification, function(tc) {
-					return model.parseTaxonomicClassification(tc);
-				})
-			};
+      return xmlString;
+    },
 
-			if(Array.isArray(modelJSON.taxonomicClassification) && !modelJSON.taxonomicClassification.length)
-				modelJSON.taxonomicClassification = {};
+    /*
+     * Makes a copy of the original XML DOM and updates it with the new values
+     * from the model.
+     */
+    updateDOM: function () {
+      var objectDOM = this.get("objectDOM")
+        ? this.get("objectDOM").cloneNode(true)
+        : document.createElement("taxonomiccoverage");
 
-			return modelJSON;
-		},
+      $(objectDOM).empty();
 
-		serialize: function(){
-			var objectDOM = this.updateDOM(),
-				xmlString = objectDOM.outerHTML;
+      // generalTaxonomicCoverage
+      var generalCoverage = this.get("generalTaxonomicCoverage");
+      if (_.isString(generalCoverage) && generalCoverage.length > 0) {
+        $(objectDOM).append(
+          $(document.createElement("generaltaxonomiccoverage")).text(
+            this.get("generalTaxonomicCoverage")
+          )
+        );
+      }
 
-			//Camel-case the XML
-	    	xmlString = this.formatXML(xmlString);
+      // taxonomicClassification(s)
+      var classifications = this.get("taxonomicClassification");
 
-	    	return xmlString;
-		},
+      if (
+        typeof classifications === "undefined" ||
+        classifications.length === 0
+      ) {
+        return objectDOM;
+      }
 
-		/*
-		 * Makes a copy of the original XML DOM and updates it with the new values from the model.
-		 */
-		updateDOM: function(){
-			 var objectDOM = this.get("objectDOM") ? this.get('objectDOM').cloneNode(true) : document.createElement('taxonomiccoverage');
+      for (var i = 0; i < classifications.length; i++) {
+        $(objectDOM).append(
+          this.createTaxonomicClassificationDOM(classifications[i])
+        );
+      }
 
-			 $(objectDOM).empty();
+      // Remove empty (zero-length or whitespace-only) nodes
+      $(objectDOM)
+        .find("*")
+        .filter(function () {
+          return $.trim(this.innerHTML) === "";
+        })
+        .remove();
 
-			 // generalTaxonomicCoverage
-			 var generalCoverage = this.get('generalTaxonomicCoverage');
-			 if (_.isString(generalCoverage) && generalCoverage.length > 0) {
-				 $(objectDOM).append($(document.createElement('generaltaxonomiccoverage')).text(this.get('generalTaxonomicCoverage')));
-			 }
+      return objectDOM;
+    },
 
-			 // taxonomicClassification(s)
-			 var classifications = this.get('taxonomicClassification');
+    /*
+     * Create the DOM for a single EML taxonomicClassification.
+     * This function is currently recursive!
+     */
+    createTaxonomicClassificationDOM: function (classification) {
+      var id = classification.id,
+        taxonRankName = classification.taxonRankName || "",
+        taxonRankValue = classification.taxonRankValue || "",
+        commonName = classification.commonName || "",
+        taxonId = classification.taxonId,
+        finishedEl;
 
-			 if (typeof classifications === "undefined" ||
-			     classifications.length === 0) {
-					 return objectDOM;
-			}
+      if (!taxonRankName || !taxonRankValue) return "";
 
-			 for (var i = 0; i < classifications.length; i++) {
-				$(objectDOM).append(this.createTaxonomicClassificationDOM(classifications[i]));
-			 }
+      finishedEl = $(document.createElement("taxonomicclassification"));
 
-			// Remove empty (zero-length or whitespace-only) nodes
-			$(objectDOM).find("*").filter(function() { return $.trim(this.innerHTML) === ""; } ).remove();
+      if (typeof id === "string" && id.length > 0) {
+        $(finishedEl).attr("id", id);
+      }
 
-			 return objectDOM;
-		},
+      if (taxonRankName && taxonRankName.length > 0) {
+        $(finishedEl).append(
+          $(document.createElement("taxonrankname")).text(taxonRankName)
+        );
+      }
 
-		/* Create the DOM for a single EML taxonomicClassification.
+      if (taxonRankValue && taxonRankValue.length > 0) {
+        $(finishedEl).append(
+          $(document.createElement("taxonrankvalue")).text(taxonRankValue)
+        );
+      }
 
-		This function is currently recursive!
-		*/
-		createTaxonomicClassificationDOM: function(classification) {
-			var id = classification.id,
-				  taxonRankName = classification.taxonRankName || "",
-			    taxonRankValue = classification.taxonRankValue || "",
-					commonName = classification.commonName || "",
-					taxonId = classification.taxonId,
-  				finishedEl;
+      if (commonName && commonName.length > 0) {
+        $(finishedEl).append(
+          $(document.createElement("commonname")).text(commonName)
+        );
+      }
 
-			if(!taxonRankName || !taxonRankValue) return "";
+      if (taxonId && taxonId.length > 0) {
+        _.each(taxonId, function (el) {
+          var taxonIdEl = $(document.createElement("taxonId")).text(el.value);
 
-			finishedEl = $(document.createElement("taxonomicclassification"));
+          if (el.provider) {
+            $(taxonIdEl).attr("provider", el.provider);
+          }
 
-			if (typeof id === "string" && id.length > 0) {
-				$(finishedEl).attr("id", id);
-			}
+          $(finishedEl).append(taxonIdEl);
+        });
+      }
 
-			if (taxonRankName && taxonRankName.length > 0) {
-				$(finishedEl).append($(document.createElement("taxonrankname")).text(taxonRankName));
-			}
+      if (classification.taxonomicClassification) {
+        _.each(
+          classification.taxonomicClassification,
+          function (tc) {
+            $(finishedEl).append(this.createTaxonomicClassificationDOM(tc));
+          },
+          this
+        );
+      }
 
-			if (taxonRankValue && taxonRankValue.length > 0) {
-				$(finishedEl).append($(document.createElement("taxonrankvalue")).text(taxonRankValue));
-			}
+      return finishedEl;
+    },
 
-			if (commonName && commonName.length > 0) {
-				$(finishedEl).append($(document.createElement("commonname")).text(commonName));
-			}
-			
-			if (taxonId && taxonId.length > 0) {
-				_.each(taxonId, function(el) {
-					var taxonIdEl = $(document.createElement("taxonId")).text(el.value);
+    /* Validate this model */
+    validate: function () {
+      var errors = {};
 
-					if (el.provider) {
-						$(taxonIdEl).attr("provider", el.provider);
-					}
-
-					$(finishedEl).append(taxonIdEl);
-				});
-			}
-
-
-			if (classification.taxonomicClassification) {
-				_.each(classification.taxonomicClassification, function(tc) {
-				    $(finishedEl).append(this.createTaxonomicClassificationDOM(tc));
-				}, this);
-				
-			}
-
-			return finishedEl;
-		},
-
-		/* Validate this model */
-		validate: function(){
-			var errors = {};
-
-			if(!this.get("generalTaxonomicCoverage") && MetacatUI.appModel.get("emlEditorRequiredFields").generalTaxonomicCoverage)
-				errors.generalTaxonomicCoverage = "Provide a description of the taxonomic coverage.";
+      if (
+        !this.get("generalTaxonomicCoverage") &&
+        MetacatUI.appModel.get("emlEditorRequiredFields")
+          .generalTaxonomicCoverage
+      )
+        errors.generalTaxonomicCoverage =
+          "Provide a description of the taxonomic coverage.";
 
       //If there are no taxonomic classifications and it is either required in
       // the AppModel OR a general coverage was given, then require it
-			if( !this.get("taxonomicClassification").length &&
-            (MetacatUI.appModel.get("emlEditorRequiredFields").taxonCoverage || this.get("generalTaxonomicCoverage")) ){
-				errors.taxonomicClassification = "Provide at least one complete taxonomic classification.";
+      if (
+        !this.get("taxonomicClassification").length &&
+        (MetacatUI.appModel.get("emlEditorRequiredFields").taxonCoverage ||
+          this.get("generalTaxonomicCoverage"))
+      ) {
+        errors.taxonomicClassification =
+          "Provide at least one complete taxonomic classification.";
+      } else {
+        //Every taxonomic classification should be valid
+        if (
+          !_.every(
+            this.get("taxonomicClassification"),
+            this.isClassificationValid,
+            this
+          )
+        )
+          errors.taxonomicClassification =
+            "Every classification row should have a rank and value.";
       }
-			else{
-				//Every taxonomic classification should be valid
-				if(!_.every(this.get("taxonomicClassification"), this.isClassificationValid, this))
-					errors.taxonomicClassification = "Every classification row should have a rank and value.";
-			}
 
-			if(Object.keys(errors).length)
-				return errors;
+      if (Object.keys(errors).length) return errors;
+    },
 
-		},
+    isEmpty: function () {
+      return (
+        !this.get("generalTaxonomicCoverage") &&
+        !this.get("taxonomicClassification").length
+      );
+    },
 
-		isEmpty: function(){
-			return (!this.get("generalTaxonomicCoverage") && !this.get("taxonomicClassification").length)
-		},
+    isClassificationValid: function (taxonomicClassification) {
+      if (!Object.keys(taxonomicClassification).length) return true;
+      if (Array.isArray(taxonomicClassification)) {
+        if (
+          !taxonomicClassification[0].taxonRankName ||
+          !taxonomicClassification[0].taxonRankValue
+        ) {
+          return false;
+        }
+      } else if (
+        !taxonomicClassification.taxonRankName ||
+        !taxonomicClassification.taxonRankValue
+      ) {
+        return false;
+      }
 
-		isClassificationValid: function(taxonomicClassification){
-
-			if( ! Object.keys(taxonomicClassification).length )
-				return true;
-			if(Array.isArray(taxonomicClassification)) {
-				if(!taxonomicClassification[0].taxonRankName || !taxonomicClassification[0].taxonRankValue) {
-					return false;
-				}
-			} else if(!taxonomicClassification.taxonRankName || !taxonomicClassification.taxonRankValue) {
-				return false;
-			}
-
-			if(taxonomicClassification.taxonomicClassification)
-				return this.isClassificationValid(taxonomicClassification.taxonomicClassification);
-			else
-				return true;
-		},
+      if (taxonomicClassification.taxonomicClassification)
+        return this.isClassificationValid(
+          taxonomicClassification.taxonomicClassification
+        );
+      else return true;
+    },
 
     /*
-    * Climbs up the model heirarchy until it finds the EML model
-    *
-    * @return {EML211 or false} - Returns the EML 211 Model or false if not found
-    */
-    getParentEML: function(){
+     * Climbs up the model heirarchy until it finds the EML model
+     *
+     * @return {EML211 or false} - Returns the EML 211 Model or false if not
+     * found
+     */
+    getParentEML: function () {
       var emlModel = this.get("parentModel"),
-          tries = 0;
+        tries = 0;
 
-      while (emlModel.type !== "EML" && tries < 6){
+      while (emlModel.type !== "EML" && tries < 6) {
         emlModel = emlModel.get("parentModel");
         tries++;
       }
 
-      if( emlModel && emlModel.type == "EML")
-        return emlModel;
-      else
-        return false;
-
+      if (emlModel && emlModel.type == "EML") return emlModel;
+      else return false;
     },
 
-		trickleUpChange: function(){
-			MetacatUI.rootDataPackage.packageModel.set("changed", true);
-		},
+    trickleUpChange: function () {
+      MetacatUI.rootDataPackage.packageModel.set("changed", true);
+    },
 
-		formatXML: function(xmlString){
-			return DataONEObject.prototype.formatXML.call(this, xmlString);
-		}
-	});
+    formatXML: function (xmlString) {
+      return DataONEObject.prototype.formatXML.call(this, xmlString);
+    },
+  });
 
-	return EMLTaxonCoverage;
+  return EMLTaxonCoverage;
 });

--- a/src/js/models/metadata/eml211/EMLTaxonCoverage.js
+++ b/src/js/models/metadata/eml211/EMLTaxonCoverage.js
@@ -236,7 +236,8 @@ define(["jquery", "underscore", "backbone", "models/DataONEObject"], function (
         );
       }
 
-      if (taxonId && taxonId.length > 0) {
+      if (taxonId) {
+        if (!Array.isArray(taxonId)) taxonId = [taxonId];
         _.each(taxonId, function (el) {
           var taxonIdEl = $(document.createElement("taxonId")).text(el.value);
 

--- a/src/js/models/metadata/eml211/EMLTaxonCoverage.js
+++ b/src/js/models/metadata/eml211/EMLTaxonCoverage.js
@@ -332,29 +332,13 @@ define(["jquery", "underscore", "backbone", "models/DataONEObject"], function (
     },
 
     /**
-     * Returns true if the given classification is a duplicate of another
-     * classification in this model. Duplicates are considered those that have
-     * all values identical, including rankName, rankValue, commonName, and
-     * taxonId. If there are any nested classifications, then they too must
-     * be identical for the classification to be considered a duplicate, this
-     * this function is recursive. Only checks one classification at a time.
-     * @param {taxonomicClassification} classification
-     */
-    isDuplicate: function (classification) {
-      for (let c of this.get("taxonomicClassification")) {
-        if (this.classificationsAreEqual(c, classification)) {
-          return true;
-        }
-      }
-      return false;
-    },
-
-    /**
      * Check if two classifications are equal. Two classifications are equal if
      * they have the same rankName, rankValue, commonName, and taxonId, as well
      * as the same nested classifications. This function is recursive.
      * @param {taxonomicClassification} c1
      * @param {taxonomicClassification} c2
+     * @returns {boolean} - True if the two classifications are equal
+     * @since x.x.x
      */
     classificationsAreEqual: function (c1, c2) {
       if (!c1 && !c2) return true;
@@ -376,7 +360,9 @@ define(["jquery", "underscore", "backbone", "models/DataONEObject"], function (
             c.taxonomicClassification
           );
         }
-        return JSON.stringify(stringified);
+        const st = JSON.stringify(stringified);
+        // convert all to uppercase for comparison
+        return st.toUpperCase();
       };
 
       return stringifyClassification(c1) === stringifyClassification(c2);
@@ -394,6 +380,8 @@ define(["jquery", "underscore", "backbone", "models/DataONEObject"], function (
      * when checking for duplicates. This is useful when checking if a
      * classification is a duplicate of another classification in the same
      * model, but not itself.
+     * @returns {boolean} - True if the given classification is a duplicate
+     * @since x.x.x
      */
     isDuplicate: function (classification, indexToSkip) {
       const classifications = this.get("taxonomicClassification");
@@ -433,7 +421,7 @@ define(["jquery", "underscore", "backbone", "models/DataONEObject"], function (
     },
 
     /*
-     * Climbs up the model heirarchy until it finds the EML model
+     * Climbs up the model hierarchy until it finds the EML model
      *
      * @return {EML211 or false} - Returns the EML 211 Model or false if not
      * found

--- a/src/js/views/metadata/EML211View.js
+++ b/src/js/views/metadata/EML211View.js
@@ -1933,20 +1933,14 @@ define(['underscore', 'jquery', 'backbone',
               taxonRankName: classification.taxonRankName || '',
               taxonRankValue: classification.taxonRankValue || ''
             }));
-
-            // If there is a taxonId or commonName, save that to the DOM as data
+            // Save a reference to other taxon attributes that we need to keep
+            // when serializing the model
             if (classification.taxonId) {
-              console.log("taxonId: " + classification.taxonId);
-            
               $(finishedEl).data("taxonId", classification.taxonId);
             }
             if (classification.commonName) {
-              console.log("commonName: " + classification.commonName);
               $(finishedEl).data("commonName", classification.commonName);
             }
-
-            $(finishedEl).data("test", "aaaaa hello");
-
             return finishedEl;
           } catch (e) {
             console.log("Error making taxonomic classification row: ", e);

--- a/src/js/views/metadata/EML211View.js
+++ b/src/js/views/metadata/EML211View.js
@@ -2110,7 +2110,18 @@ define(['underscore', 'jquery', 'backbone',
               if (!taxonSelects || !taxonSelects.length) return
               const selectedItems = taxonSelects.map(select => select.selected).flat()
               if (!selectedItems || !selectedItems.length) return
-              const selectedItemObjs = selectedItems.map(item => JSON.parse(decodeURIComponent(item)))
+              const selectedItemObjs = selectedItems.map((item) => {
+                try {
+                  // It will be encoded JSON if it's a pre-defined taxon
+                  return JSON.parse(decodeURIComponent(item))
+                } catch (e) {
+                  // Otherwise it will be a string a user typed in
+                  return {
+                    taxonRankName: "",
+                    taxonRankValue: item
+                  }
+                }
+              })
               view.addTaxa(selectedItemObjs)
               taxonSelects.forEach(select => select.changeSelection([], true))
             }

--- a/src/js/views/metadata/EMLTaxonView.js
+++ b/src/js/views/metadata/EMLTaxonView.js
@@ -52,11 +52,11 @@ define(['underscore', 'jquery', 'backbone', 'models/metadata/eml211/EMLTaxonCove
 
 			// Makes a table... for the root level
 			for (var i = 0; i < classifications.length; i++) {
-				$(finishedEl).append(this.createTaxonomicClassifcationTable(classifications[i]));
+				$(finishedEl).append(this.createTaxonomicClassificationTable(classifications[i]));
 			}
 
 			// Create a new, blank table for another taxonomicClassification
-			var newTableEl = this.createTaxonomicClassifcationTable();
+			var newTableEl = this.createTaxonomicClassificationTable();
 
 			$(finishedEl).append(newTableEl);
 

--- a/src/js/views/searchSelect/SearchableSelectView.js
+++ b/src/js/views/searchSelect/SearchableSelectView.js
@@ -166,6 +166,7 @@ define([
          * single option. To create category headings, provide an object containing named
          * objects, where the key for each object is the category title to display, and
          * the value of each object comprises the option properties.
+         * @name SearchableSelectView#options
          * @type {Object[]|Object}
          * @property {string} icon - The name of a Font Awesome 3.2.1 icon to display to
          * the left of the label (e.g. "lemon", "heart")
@@ -452,6 +453,16 @@ define([
           } catch (e) {
             console.log("Error rendering the search select, error message: ", e);
           }
+        },
+
+        /**
+         * Change the options available in the dropdown menu and re-render.
+         * @param {SearchableSelectView#options} options - The new options
+         * @since x.x.x
+         */
+        updateOptions: function (options) {
+          this.options = options;
+          this.render();
         },
 
         /**


### PR DESCRIPTION
This PR introduces the configurable and optional "Quick Add Taxa" feature in the EML editor. This feature allows repositories to set a list or lists of common taxa to make entry in the EML a little quicker. Here's a screen shot of how it looks for the SCTLD test site:

<img width="1185" alt="Screenshot 2023-05-10 at 21 21 51" src="https://github.com/NCEAS/metacatui/assets/26600641/725810a2-4a95-4c0c-aa29-174c3114fd06">

Here is an example of the EML that it generates. Note that this PR also adds support for the taxonId and commonName elements, which were previously being lost if an EML document was edited in our Editor.

```
<taxonomicCoverage>
  <taxonomicClassification>
    <taxonRankName>species</taxonRankName>
    <taxonRankValue>Agaricia agaricites</taxonRankValue>
    <taxonId provider="https://www.itis.gov">53050</taxonId>
  </taxonomicClassification>
  <taxonomicClassification>
    <taxonRankName>species</taxonRankName>
    <taxonRankValue>Acropora cervicornis</taxonRankValue>
    <taxonId provider="https://www.itis.gov">52862</taxonId>
  </taxonomicClassification>
</taxonomicCoverage>
```

The specific dropdowns to render are configured in the [AppModel#quickAddTaxa](https://github.com/NCEAS/metacatui/blob/feature-2086-taxon-dropdown/src/js/models/AppModel.js#L577) option, which can be a list or a SID to a JSON file in the repository containing the taxa list. See the documentation in the appModel for details.

For testing, [here](https://dev.nceas.ucsb.edu/knb/d1/mn/v2/object/urn%3Auuid%3Ac09345f8-172e-450f-ad40-e6561477b464) is an example of a taxon dropdown list. It's saved on the `dev.nceas.ucsb` test node with the series ID `"urn:uuid:c09345f8-172e-450f-ad40-e6561477b464"`.