### PR TITLE
Adds `enablePublishOnAllNonPublic` configuration

### DIFF
--- a/src/js/models/AppModel.js
+++ b/src/js/models/AppModel.js
@@ -1080,6 +1080,20 @@ define(['jquery', 'underscore', 'backbone'],
       isJSONLDEnabled: true,
 
       /**
+      * If true, users can see a "Publish" button in the MetadataView on all non-public datasets regardless if
+      * a DOI is assigned to the dataset
+      * If false, the default behavior would take place based on the {@link AppConfig#enablePublishDOI} config.
+      *
+      * This config helps in the case that a member-node publication workflow requires review of the datasets before
+      * they can be public. It also allows datasets to be reviewed for publication regardless of the DOI status,
+      * as some datasets could have a pre-assigned DOI when transferring their dataset to a member node.
+      * @type {boolean}
+      * @default false
+      * @since 2.27.0
+      */
+      enablePublishOnAllNonPublic: false,
+
+      /**
       * If true, users can see a "Publish" button in the MetadataView, which makes the metadata
       * document public and gives it a DOI identifier.
       * If false, the button will be hidden completely.

--- a/src/js/views/MetadataView.js
+++ b/src/js/views/MetadataView.js
@@ -1231,10 +1231,20 @@ define(['jquery',
           }
 
           try {
-            //Determine if this metadata can be published.
+            // Determine if this metadata can be published.
             // The Publish feature has to be enabled in the app.
             // The model cannot already have a DOI
-            var canBePublished = MetacatUI.appModel.get("enablePublishDOI") && !view.model.isDOI();
+            var canBePublished;
+
+            // Check if this metadata can be published based on the "enablePublishOnAllNonPublic" Configuration.
+            // This helps in the case that a member-node publication workflow requires review of the datasets before
+            // they can be public. It also allows datasets to be reviewed for publication regardless of the DOI status,
+            // as some datasets could have a pre-assigned DOI when transferring their dataset to a member node.
+            if (MetacatUI.appModel.get("enablePublishOnAllNonPublic") && view.model.get("isPublic") === false){
+              canBePublished = true;
+            } else {
+              canBePublished = MetacatUI.appModel.get("enablePublishDOI") && !view.model.isDOI();
+            }
 
             //If publishing is enabled, check if only certain users and groups can publish metadata
             if (canBePublished) {
@@ -1242,8 +1252,9 @@ define(['jquery',
               var authorizedPublishers = MetacatUI.appModel.get("enablePublishDOIForSubjects");
               //If the logged-in user is one of the subjects in the list or is in a group that is
               // in the list, then this metadata can be published. Otherwise, it cannot.
-              if (Array.isArray(authorizedPublishers) && authorizedPublishers.length) {
-                if (MetacatUI.appUserModel.hasIdentityOverlap(authorizedPublishers)) {
+              if (Array.isArray(authorizedPublishers) && (authorizedPublishers.length ||
+						  !view.model.get("isPublic") === false)){
+                if (MetacatUI.appUserModel.hasIdentityOverlap(authorizedPublishers)){
                   canBePublished = true;
                 }
                 else {


### PR DESCRIPTION
## Description

Adds `enablePublishOnAllNonPublic` configuration. If true, users can see a "Publish" button in the MetadataView on all non-public datasets regardless if a DOI is assigned to the dataset. If false, the default behavior would take place based on the `AppConfig#enablePublishDOI` config.

closes #2202