### PR TITLE
Disable pointer events on transparent toolbar blocking Cesium map

### DIFF
--- a/src/css/map-view.css
+++ b/src/css/map-view.css
@@ -233,6 +233,7 @@
   width: min-content;
   /* required to be placed above map widget in firefox: */
   z-index: 1;
+  pointer-events: none;
 }
 
 /* On large screens, the toolbar should not overlap the map, it should squish it */
@@ -385,6 +386,7 @@ represents 1 unit of the given distance measurement. */
   background-color: var(--map-col-bkg);
   border-radius: var(--map-border-radius);
   margin: var(--map-size-toolbar-inter-link-margin);
+  pointer-events: all;
 }
 
 .toolbar__all-content {
@@ -398,6 +400,7 @@ represents 1 unit of the given distance measurement. */
   toolbar is closed */
   display: none;
   overflow: hidden;
+  pointer-events: all;
 }
 
 .toolbar--open .toolbar__all-content {


### PR DESCRIPTION
With no interactable elements the transparent toolbar blocked the Cesium view. This change enables pointer events only on the parts of the toolbar with content.

GitHub issue: #2207

![no-pointer-events](https://github.com/NCEAS/metacatui/assets/4664309/63b4ae45-6875-4e21-98b1-c6508b9f05bc)
