### PR TITLE
Bugfix #2265 portals body height

### DIFF
--- a/src/css/metacatui-common.css
+++ b/src/css/metacatui-common.css
@@ -4879,7 +4879,6 @@ i.toc-sub-item {
 ********************************************/
 
 .PortalView {
-  height: 100%;
   display: grid;
   grid-template-rows: 40px 0px 100fr 0px;
 }

--- a/src/js/views/portals/PortalSectionView.js
+++ b/src/js/views/portals/PortalSectionView.js
@@ -144,6 +144,8 @@ define(["jquery",
               }
           });
 
+          document.body.style.removeProperty("height");
+
           this.markdownView?.tocView?.setAffix();
         },
 

--- a/src/js/views/portals/PortalView.js
+++ b/src/js/views/portals/PortalView.js
@@ -1060,6 +1060,14 @@ define(["jquery",
 
           MetacatUI.appModel.resetTitle();
           MetacatUI.appModel.resetDescription();
+
+          // Run subView onClose functions if they exist
+          for (const subView of this.subviews) {
+            if (typeof subView?.onClose === "function") {
+              subView.onClose();
+            }
+          }
+
           //Remove each subview from the DOM and remove listeners
           _.invoke(this.subviews, "remove");
 

--- a/src/js/views/portals/PortalVisualizationsView.js
+++ b/src/js/views/portals/PortalVisualizationsView.js
@@ -181,8 +181,23 @@ define(["jquery",
           this.$("iframe").css("height", remainingHeight + "px");
         },
 
+        /**
+         * Clean up
+         */
         onClose: function() {
-          $(window).removeListener("resize", this.adjustVizHeight);
+          // Remove body height style tag
+          document.body.style.removeProperty("height");
+
+          // this is failing for Cesium pages but might be necessary in FEVer ones
+          try {
+            $(window).removeListener("resize", this.adjustVizHeight);
+          }
+          catch (error) {
+            console.log(
+              'Failed to remove resize listener in portal viz onClose function. ' +
+              'Error details: ' + error
+            );
+          }
         }
 
      });

--- a/src/js/views/portals/PortalVisualizationsView.js
+++ b/src/js/views/portals/PortalVisualizationsView.js
@@ -137,6 +137,13 @@ define(["jquery",
               }
             }
   
+            if( this.model.get("visualizationType") == "cesium" ){
+              document.body.style.setProperty("height", "100%");
+            }
+            else {
+              document.body.style.removeProperty("height");
+            }
+
             if( this.model.get("visualizationType") == "fever" ){
               $(window).resize(this.adjustVizHeight);
               $(".auto-height-member").resize(this.adjustVizHeight);


### PR DESCRIPTION
From [my comment](https://github.com/NCEAS/metacatui/issues/2265#issuecomment-1949332448) on the issue:

> My solution to this is a little different than the [above method](https://github.com/NCEAS/metacatui/issues/2265#issuecomment-1936748651), instead of using the `.PortalView` element, I set `height: 100%` on `document.style.body` in `PortalVisualizationsView`, and remove the property in `PortalSectionView`. I did this because it echoes the way [the `--footer-height` is set and unset](https://github.com/NCEAS/metacatui/blob/758ff8e3710637d9fdf406a9c2383e56ff5be877/src/js/views/FooterView.js#L30-L42). If it would be cleaner for me to do this another way (such as setting this on `.PortalView`), I'm happy to switch to a different method.