### PR TITLE
Fix overflow issue on toolbar link tooltips

### DIFF
--- a/src/css/map-view.css
+++ b/src/css/map-view.css
@@ -229,7 +229,7 @@
   top: 0;
   left: 0;
   height: 100%;
-  overflow: hidden;
+  min-height: 100%;
   width: min-content;
   /* required to be placed above map widget in firefox: */
   z-index: 1;


### PR DESCRIPTION
Layers list scrolling functionality caused tooltips to not be visible. 
Fix bug while still supporting the layer list scrolling.

![bugfix-tooltips](https://github.com/NCEAS/metacatui/assets/4664309/981c0b9b-8cbb-44b7-b7fc-4681803849af)
