### PR TITLE
Layer List Polish 4: Add isCategorized attr to LayerItemView

### DIFF
--- a/src/js/views/maps/LayerCategoryItemView.js
+++ b/src/js/views/maps/LayerCategoryItemView.js
@@ -103,7 +103,10 @@ define(
           // Insert the icon on the left
           this.insertIcon();
 
-          this.layerListView = new LayerListView({ collection: this.model.get('mapAssets') });
+          this.layerListView = new LayerListView({
+            collection: this.model.get('mapAssets'),
+            isCategorized: true,
+          });
           this.layerListView.render();
           this.$(`.${CLASS_NAMES.layers}`).append(this.layerListView.el);
 

--- a/src/js/views/maps/LayerItemView.js
+++ b/src/js/views/maps/LayerItemView.js
@@ -60,6 +60,13 @@ define(
         model: undefined,
 
         /**
+        * Whether the layer item is a under a category. Flat layer item and categorized
+        * layer item are styled differently.
+        * @type {boolean}
+        */
+        isCategorized: undefined,
+
+        /**
          * The primary HTML template for this view
          * @type {Underscore.template}
          */
@@ -92,6 +99,7 @@ define(
           hidden: 'layer-item--hidden',
           labelText: 'layer-item__label-text',
           highlightedText: 'layer-item__highlighted-text',
+          categorized: 'layer-item__categorized',
           badge: 'map-view__badge',
           tooltip: 'map-tooltip',
         },

--- a/src/js/views/maps/LayerListView.js
+++ b/src/js/views/maps/LayerListView.js
@@ -53,6 +53,13 @@ define(
         collection: undefined,
 
         /**
+        * Whether the layer list is a under a category. Flat layer list and categorized
+        * layer list are styled differently.
+        * @type {boolean}
+        */
+        isCategorized: undefined,
+
+        /**
          * The primary HTML template for this view
          * @type {Underscore.template}
          */
@@ -135,7 +142,8 @@ define(
               return memo;
             }
             const layerItem = new LayerItemView({
-              model: layerModel
+              model: layerModel,
+              isCategorized: this.isCategorized,
             })
             layerItem.render();
             this.el.appendChild(layerItem.el);

--- a/src/js/views/maps/LayersPanelView.js
+++ b/src/js/views/maps/LayersPanelView.js
@@ -65,7 +65,10 @@ define([
       if (this.map.get('layerCategories')?.length > 0) {
         this.layersView = new LayerCategoryListView({ collection: this.map.get("layerCategories") });
       } else {
-        this.layersView = new LayerListView({ collection: this.map.get("layers") });
+        this.layersView = new LayerListView({
+          collection: this.map.get("layers"),
+          isCategorized: false,
+        });
       }
       this.layersView.render();
       this.$(`.${this.classNames.layers}`).append(this.layersView.el);

--- a/test/js/specs/unit/views/maps/LayerCategoryItemView.spec.js
+++ b/test/js/specs/unit/views/maps/LayerCategoryItemView.spec.js
@@ -27,6 +27,10 @@ define([
       it("creates an LayerCategoryItemView instance", () => {
         expect(state.view).to.be.instanceof(LayerCategoryItemView);
       });
+
+      it("creates layer items with isCategorized set to true", () => {
+        expect(state.view.layerListView.layerItemViews[0].isCategorized).to.be.true;
+      });
     });
 
     it("toggles between expanded and collapsed", () => {

--- a/test/js/specs/unit/views/maps/LayersPanelView.spec.js
+++ b/test/js/specs/unit/views/maps/LayersPanelView.spec.js
@@ -32,10 +32,18 @@ define([
         expect(state.view.layersView).to.be.instanceof(LayerCategoryListView);
       });
 
-      it("uses LayerListView if layerCategories doesn't exist", () => {
-        state.view.render();
+      describe("when layerCategories doesn't exist", () => {
+        it("uses LayerListView", () => {
+          state.view.render();
+  
+          expect(state.view.layersView).to.be.instanceof(LayerListView);
+        });
 
-        expect(state.view.layersView).to.be.instanceof(LayerListView);
+        it("creates layer items with isCategorized set to false", () => {
+          state.view.render();
+  
+          expect(state.view.layersView.layerItemViews[0].isCategorized).to.be.false;
+        });
       });
     });
 


### PR DESCRIPTION
Per discussion in https://github.com/NCEAS/metacatui/issues/2277#issuecomment-1984829655, if a layer list is not categorized, we'll use different colors in the layer icon to indicate layer shown vs hidden. For a categorized layer list, we use the eye icon instead, because a custom icon is already used for the category label.

The different treatments require LayerItemView to be aware of whether it's categorized or not.