### PR TITLE
Layer List Polish 5: Update layer item styling

### DIFF
--- a/src/css/map-view.css
+++ b/src/css/map-view.css
@@ -153,8 +153,6 @@
   text-decoration: none;
   padding: 0.25rem 0.5rem;
   cursor: pointer;
-  /* temp */
-  margin-right: -1px !important;
 }
 
 .map-view__button:hover {
@@ -638,7 +636,6 @@ represents 1 unit of the given distance measurement. */
   display: grid;
   grid-template-columns: 100%;
   grid-template-rows: auto;
-  gap: 0.8rem;
   width: 100%;
   height: min-content;
 }
@@ -646,20 +643,61 @@ represents 1 unit of the given distance measurement. */
 /* A layer-item is one item in the layer-list */
 
 .layer-item {
-  width: 100%;
   display: grid;
-  grid-template-columns: auto max-content min-content;
+  grid-template-columns: min-content auto max-content;
   align-items: center;
   padding: 0 24px;
+
+  .layer-item__visibility-toggle {
+    opacity: var(--map-no-brightness-or-opacity-tweaks, 0.85);
+    padding: 0;
+    margin: 4px;
+    border: 0;
+    width: 32px;
+    height: 32px;
+    font-size: 16px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--map-col-buttons-icon-muted, currentColor);
+    background-color: transparent;
+
+    .layer-item__icon {
+      fill: var(--map-col-buttons-icon-muted, currentColor);
+      svg>path {
+        fill: var(--map-col-buttons-icon-muted, currentColor);
+      }
+
+      height: 16px;
+      width: auto;
+      opacity: var(--map-no-brightness-or-opacity-tweaks, 0.8);
+    }
+  }
+
+  &:hover {
+    background-color: var(--map-col-content-bkg-muted, #323745);
+  }
+
+  &.layer-item--shown:hover {
+    background-color: var(--map-col-content-bkg-highlight, #15324e);
+  }
+
+  &.layer-item--shown .layer-item__visibility-toggle {
+    color: var(--map-col-buttons-bkg-highlight, var(--map-col-highlight__deprecate));
+
+    .layer-item__icon {
+      fill: var(--map-col-buttons-bkg-highlight, var(--map-col-highlight__deprecate));
+      svg>path {
+        fill: var(--map-col-buttons-bkg-highlight, var(--map-col-highlight__deprecate));
+      }
+    }
+  }
 }
 
 .layer-item__label {
   cursor: pointer;
-  font-size: 0.93rem;
+  font-size: 14px;
   font-weight: 500;
-  letter-spacing: 0.015em;
-  display: flex;
-  align-items: center;
   margin: 0 8px;
   color: var(--map-col-text-label);
 }
@@ -668,35 +706,9 @@ represents 1 unit of the given distance measurement. */
   background-color: var(--map-col-search-match-highlight);
 }
 
-.layer-item__icon {
-  fill: currentColor;
-  height: 1.04rem;
-  width: auto;
-  margin-right: 0.34rem;
-  opacity: var(--map-no-brightness-or-opacity-tweaks, 0.8);
-}
-
 .layer-item__icon>svg {
   height: 100%;
   width: auto;
-}
-
-.layer-item__label:hover {
-  color: var(--map-col-text-label, var(--map-col-highlight__deprecate));
-  background-color: var(--map-col-content-bkg-muted);
-}
-
-.layer-item__visibility-toggle {
-  background: none;
-  opacity: var(--map-no-brightness-or-opacity-tweaks, 0.85);
-  padding: 0;
-  margin-left: 0.5rem;
-}
-
-.layer-item__visibility-toggle:before {
-  /* use the font awesome 'eye-open' icon */
-  font-family: FontAwesome;
-  content: "\f06e";
 }
 
 .layer-item__visibility-toggle:hover {
@@ -708,17 +720,6 @@ represents 1 unit of the given distance measurement. */
 .layer-item--selected .layer-item__label {
   color: var(--map-col-text-label, var(--map-col-highlight__deprecate));
   font-weight: 700;
-}
-
-/* How to style the layer item when the layer is hidden on the map */
-
-.layer-item--hidden {
-  opacity: var(--map-no-brightness-or-opacity-tweaks, 0.3);
-}
-
-.layer-item--hidden .layer-item__visibility-toggle:before {
-  /* switch to the font awesome 'eye-closed' icon */
-  content: "\f070";
 }
 
 /*****************************************************************************************
@@ -742,6 +743,10 @@ represents 1 unit of the given distance measurement. */
       font-size: 16px;
       grid-template-columns: min-content auto min-content;
       padding: 0 24px;
+
+      &:hover {
+        background-color: var(--map-col-content-bkg-highlight, #15324e);
+      }
     }
   }
 }
@@ -1169,8 +1174,9 @@ other class: .ui-slider-range */
  */
 
 .map-legend--preview {
-  height: 1.2rem;
-  width: 100%
+  height: 24px;
+  width: 100%;
+  margin: 4px;
 }
 
 .map-legend__svg--preview {

--- a/src/js/models/maps/assets/MapAsset.js
+++ b/src/js/models/maps/assets/MapAsset.js
@@ -38,7 +38,7 @@ define([
        * The format of the data. Must be one of the supported types.
        * @property {string} label A user friendly name for this asset, to be displayed
        * in a map.
-       * @property {string} [icon = '<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M1.2 13.7 3.6 3.5l7.2 8.7zM5 3.3c2 .3 3.5.4 4.4.4H13l3 6.3-4 1.8-7-8.5Zm9.1.6 2.8 6 4.5-2.2a23 23 0 0 1-.7-4c0-.8-1.2-.7-2-.7l-4.6.9ZM1 15l11-1.9c1.2-.3 2.7-1 4.2-2l2.5 5.2c-1.2.3-3.6.4-7.3.4-2.8 0-7.3 0-9.4-.8a2 2 0 0 1-1-.9Zm16.4-4.2 4-1.8 1.3 5.5c0 .4.1 1-.4 1.2l-2.5.5-2.4-5.4ZM1.7 17l-.5 2.6c0 .7.2 1 1 1.3a64.1 64.1 0 0 0 19.8 0c.4-.3 1-.5.7-1.6l-.5-2.3a52.6 52.6 0 0 1-20.6 0Z"/></svg>']
+       * @property {string} [icon = '<svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 24 24"><path d="m3.2 7.3 8.6 4.6a.5.5 0 0 0 .4 0l8.6-4.6a.4.4 0 0 0 0-.8L12.1 3a.5.5 0 0 0-.4 0L3.3 6.5a.4.4 0 0 0 0 .8Z"></path><path d="M20.7 10.7 19 9.9l-6.7 3.6a.5.5 0 0 1-.4 0L5 9.9l-1.8.8a.5.5 0 0 0 0 .8l8.5 5a.5.5 0 0 0 .5 0l8.5-5a.5.5 0 0 0 0-.8Z"></path><path d="m20.7 15.1-1.5-.7-7 3.8a.5.5 0 0 1-.4 0l-7-3.8-1.5.7a.5.5 0 0 0 0 .9l8.5 5a.5.5 0 0 0 .5 0l8.5-5a.5.5 0 0 0 0-.9Z"></path></svg>']
        * A PID for an SVG saved as a dataObject, or an SVG string. The SVG will be used
        * as an icon that will be displayed next to the label in the layers list. It
        * should be an SVG file that has no fills, borders, or styles set on it (since
@@ -92,7 +92,7 @@ define([
         return {
           type: "",
           label: "",
-          icon: '<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path d="M1.2 13.7 3.6 3.5l7.2 8.7zM5 3.3c2 .3 3.5.4 4.4.4H13l3 6.3-4 1.8-7-8.5Zm9.1.6 2.8 6 4.5-2.2a23 23 0 0 1-.7-4c0-.8-1.2-.7-2-.7l-4.6.9ZM1 15l11-1.9c1.2-.3 2.7-1 4.2-2l2.5 5.2c-1.2.3-3.6.4-7.3.4-2.8 0-7.3 0-9.4-.8a2 2 0 0 1-1-.9Zm16.4-4.2 4-1.8 1.3 5.5c0 .4.1 1-.4 1.2l-2.5.5-2.4-5.4ZM1.7 17l-.5 2.6c0 .7.2 1 1 1.3a64.1 64.1 0 0 0 19.8 0c.4-.3 1-.5.7-1.6l-.5-2.3a52.6 52.6 0 0 1-20.6 0Z"/></svg>',
+          icon: '<svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 24 24"><path d="m3.2 7.3 8.6 4.6a.5.5 0 0 0 .4 0l8.6-4.6a.4.4 0 0 0 0-.8L12.1 3a.5.5 0 0 0-.4 0L3.3 6.5a.4.4 0 0 0 0 .8Z"></path><path d="M20.7 10.7 19 9.9l-6.7 3.6a.5.5 0 0 1-.4 0L5 9.9l-1.8.8a.5.5 0 0 0 0 .8l8.5 5a.5.5 0 0 0 .5 0l8.5-5a.5.5 0 0 0 0-.8Z"></path><path d="m20.7 15.1-1.5-.7-7 3.8a.5.5 0 0 1-.4 0l-7-3.8-1.5.7a.5.5 0 0 0 0 .9l8.5 5a.5.5 0 0 0 .5 0l8.5-5a.5.5 0 0 0 0-.9Z"></path></svg>',
           description: "",
           attribution: "",
           moreInfoLink: "",

--- a/src/js/templates/maps/layer-item.html
+++ b/src/js/templates/maps/layer-item.html
@@ -1,5 +1,7 @@
+<button class="<%= classes.visibilityToggle %> map-view__button" title="Toggle layer visibility">
+  <i class="icon-eye-open"></i>
+</button>
 <span class="<%= classes.label %>">
   <span class="<%= classes.labelText %>"><%= label %></span>
 </span>
 <span class="layer-item__legend-container"></span>
-<button class="layer-item__visibility-toggle map-view__button" title="Toggle layer visibility"></button>

--- a/src/js/views/maps/LayerCategoryItemView.js
+++ b/src/js/views/maps/LayerCategoryItemView.js
@@ -103,7 +103,10 @@ define(
           // Insert the icon on the left
           this.insertIcon();
 
-          this.layerListView = new LayerListView({ collection: this.model.get('mapAssets') });
+          this.layerListView = new LayerListView({
+            collection: this.model.get('mapAssets'),
+            isCategorized: true,
+          });
           this.layerListView.render();
           this.$(`.${CLASS_NAMES.layers}`).append(this.layerListView.el);
 

--- a/src/js/views/maps/LayerItemView.js
+++ b/src/js/views/maps/LayerItemView.js
@@ -60,6 +60,13 @@ define(
         model: undefined,
 
         /**
+        * Whether the layer item is a under a category. Flat layer item and categorized
+        * layer item are styled differently.
+        * @type {boolean}
+        */
+        isCategorized: undefined,
+
+        /**
          * The primary HTML template for this view
          * @type {Underscore.template}
          */
@@ -92,6 +99,7 @@ define(
           hidden: 'layer-item--hidden',
           labelText: 'layer-item__label-text',
           highlightedText: 'layer-item__highlighted-text',
+          categorized: 'layer-item__categorized',
           badge: 'map-view__badge',
           tooltip: 'map-tooltip',
         },

--- a/src/js/views/maps/LayerListView.js
+++ b/src/js/views/maps/LayerListView.js
@@ -53,6 +53,13 @@ define(
         collection: undefined,
 
         /**
+        * Whether the layer list is a under a category. Flat layer list and categorized
+        * layer list are styled differently.
+        * @type {boolean}
+        */
+        isCategorized: undefined,
+
+        /**
          * The primary HTML template for this view
          * @type {Underscore.template}
          */
@@ -135,7 +142,8 @@ define(
               return memo;
             }
             const layerItem = new LayerItemView({
-              model: layerModel
+              model: layerModel,
+              isCategorized: this.isCategorized,
             })
             layerItem.render();
             this.el.appendChild(layerItem.el);

--- a/src/js/views/maps/LayersPanelView.js
+++ b/src/js/views/maps/LayersPanelView.js
@@ -65,7 +65,10 @@ define([
       if (this.map.get('layerCategories')?.length > 0) {
         this.layersView = new LayerCategoryListView({ collection: this.map.get("layerCategories") });
       } else {
-        this.layersView = new LayerListView({ collection: this.map.get("layers") });
+        this.layersView = new LayerListView({
+          collection: this.map.get("layers"),
+          isCategorized: false,
+        });
       }
       this.layersView.render();
       this.$(`.${this.classNames.layers}`).append(this.layersView.el);

--- a/src/js/views/maps/LegendView.js
+++ b/src/js/views/maps/LegendView.js
@@ -322,22 +322,20 @@ define(
                 })
 
               legendSquares.on('mouseenter', function (d) {
-                if (view.model.get('visible')) {
-                  // Bring the hovered element to the front, while keeping other
-                  // legendSquares in order
-                  legendSquares.sort((a, b) => d3.ascending(a.i, b.i));
-                  this.parentNode.appendChild(this)
-                  // Show tooltip
-                  if (d.label || d.value || d.value === 0) {
-                    $(this).tooltip({
-                      placement: 'bottom',
-                      trigger: 'manual',
-                      title: d.label || d.value,
-                      container: view.$el,
-                      animation: false,
-                      template: '<div class="tooltip ' + view.classes.tooltip + '"><div class="tooltip-arrow"></div><div class="tooltip-inner"></div></div>'
-                    }).tooltip('show')
-                  }
+                // Bring the hovered element to the front, while keeping other
+                // legendSquares in order
+                legendSquares.sort((a, b) => d3.ascending(a.i, b.i));
+                this.parentNode.appendChild(this)
+                // Show tooltip
+                if (d.label || d.value || d.value === 0) {
+                  $(this).tooltip({
+                    placement: 'bottom',
+                    trigger: 'manual',
+                    title: d.label || d.value,
+                    container: view.$el,
+                    animation: false,
+                    template: '<div class="tooltip ' + view.classes.tooltip + '"><div class="tooltip-arrow"></div><div class="tooltip-inner"></div></div>'
+                  }).tooltip('show')
                 }
               })
                 // Hide tooltip and return squares to regular z-ordering

--- a/test/js/specs/unit/views/maps/LayerCategoryItemView.spec.js
+++ b/test/js/specs/unit/views/maps/LayerCategoryItemView.spec.js
@@ -27,6 +27,10 @@ define([
       it("creates an LayerCategoryItemView instance", () => {
         expect(state.view).to.be.instanceof(LayerCategoryItemView);
       });
+
+      it("creates layer items with isCategorized set to true", () => {
+        expect(state.view.layerListView.layerItemViews[0].isCategorized).to.be.true;
+      });
     });
 
     it("toggles between expanded and collapsed", () => {

--- a/test/js/specs/unit/views/maps/LayerItemView.spec.js
+++ b/test/js/specs/unit/views/maps/LayerItemView.spec.js
@@ -46,5 +46,41 @@ define([
         expect(matchedSpan.text()).to.equal("Layer");
       });
     });
+
+    describe("visibility toggle", () => {
+      it("uses eye icon if layer is categorized", () => {
+        state.view.isCategorized = true;
+        state.view.render();
+
+        expect(state.harness.getVisibilityToggle().children(".icon-eye-open")).to.have.lengthOf(1);
+      });
+
+      describe("when layer is not categorized", () => {
+        it("uses layer's icon", () => {
+          const icon = "<svg></svg>";
+          state.view.model.set("icon", icon);
+          state.view.render();
+  
+          expect(state.harness.getLayerIconVisibilityToggle().innerHTML).to.equal(icon);
+        });
+
+        it("uses the default icon if layer icon does not exist", () => {
+          expect(state.harness.getLayerIconVisibilityToggle().innerHTML).to.equal(state.view.model.defaults().icon);
+        });
+
+        it("updates the icon when it's fetched", () => {
+          state.view.model.set("iconStatus", "fetching");
+          state.view.render();
+
+          expect(state.harness.getLayerIconVisibilityToggle().innerHTML).to.equal(state.view.model.defaults().icon);
+
+          const icon = "<svg></svg>";
+          state.view.model.set("icon", icon);
+          state.view.model.set("iconStatus", "success");
+
+          expect(state.harness.getLayerIconVisibilityToggle().innerHTML).to.equal(icon);
+        });
+      });
+    });
   });
 });

--- a/test/js/specs/unit/views/maps/LayerItemViewHarness.js
+++ b/test/js/specs/unit/views/maps/LayerItemViewHarness.js
@@ -9,5 +9,13 @@ define([], function () {
     getLabelText() {
       return this.view.$(`.${this.view.classes.labelText}`);
     }
+
+    getVisibilityToggle() {
+      return this.view.$(`.${this.view.classes.visibilityToggle}`);
+    }
+
+    getLayerIconVisibilityToggle() {
+      return this.getVisibilityToggle().children(`.${this.view.classes.icon}`)[0];
+    }
   }
 });

--- a/test/js/specs/unit/views/maps/LayersPanelView.spec.js
+++ b/test/js/specs/unit/views/maps/LayersPanelView.spec.js
@@ -32,10 +32,18 @@ define([
         expect(state.view.layersView).to.be.instanceof(LayerCategoryListView);
       });
 
-      it("uses LayerListView if layerCategories doesn't exist", () => {
-        state.view.render();
+      describe("when layerCategories doesn't exist", () => {
+        it("uses LayerListView", () => {
+          state.view.render();
+  
+          expect(state.view.layersView).to.be.instanceof(LayerListView);
+        });
 
-        expect(state.view.layersView).to.be.instanceof(LayerListView);
+        it("creates layer items with isCategorized set to false", () => {
+          state.view.render();
+  
+          expect(state.view.layersView.layerItemViews[0].isCategorized).to.be.false;
+        });
       });
     });
 


### PR DESCRIPTION
Changes:
- Move visibility icon to the left, replacing the current layer's icon.
- Visibility icon decision tree:
- If layer is under a category, use eye icon
- If layer is in a flat list, use layer's icon
- If layer's icon is missing, use "layers" icon as default
- Remove opacity treatment as the layer invisible indicator. Instead, update visibility icon color and hover effect.
- Previously, only visible layers show legend details when you hover over it. Now that there's no opacity treatment to invisible layers, it's less obvious why certain legends don't show details. Remove the `if (visible)` condition from LegendView.

[Light theme flat layers.webm](https://github.com/NCEAS/metacatui/assets/8570665/85e13a11-60e0-488d-ae9c-7e184e70dde7)

[Light theme layer categories.webm](https://github.com/NCEAS/metacatui/assets/8570665/8a01cd1c-db4e-419c-a80e-0611c2ddf856)

[Dark theme flat layers.webm](https://github.com/NCEAS/metacatui/assets/8570665/caaa6718-2a06-4ccc-9160-f23c3bcbd2a2)

[Dark theme layer categories.webm](https://github.com/NCEAS/metacatui/assets/8570665/d6eedc91-98c7-4bed-a6bd-e170c132f008)
