### PR TITLE
Layer List Polish 6: Update layer toggles mechanism

### DIFF
--- a/src/css/map-view.css
+++ b/src/css/map-view.css
@@ -647,6 +647,7 @@ represents 1 unit of the given distance measurement. */
   grid-template-columns: min-content auto max-content;
   align-items: center;
   padding: 0 24px;
+  cursor: pointer;
 
   .layer-item__visibility-toggle {
     opacity: var(--map-no-brightness-or-opacity-tweaks, 0.85);
@@ -676,30 +677,89 @@ represents 1 unit of the given distance measurement. */
 
   &:hover {
     background-color: var(--map-col-content-bkg-muted, #323745);
+
+    &.layer-item--shown {
+      background-color: var(--map-col-content-bkg-highlight, #15324e);
+    }
+
+    .layer-item__legend-and-settings {
+      /* Show button when layer is hovered. */
+      display: flex;
+      border: 1px solid var(--map-col-border-muted);
+
+      /* Use the same style on button hover and when selected. */
+      &.layer-item--selected, &:hover {
+        background-color: var(--map-col-buttons-bkg-hover, var(--map-col-bkg-lighter__deprecate));
+      }
+    }
   }
 
-  &.layer-item--shown:hover {
-    background-color: var(--map-col-content-bkg-highlight, #15324e);
-  }
+  &.layer-item--shown {
+    .layer-item__visibility-toggle {
+      color: var(--map-col-buttons-bkg-highlight, var(--map-col-highlight__deprecate));
 
-  &.layer-item--shown .layer-item__visibility-toggle {
-    color: var(--map-col-buttons-bkg-highlight, var(--map-col-highlight__deprecate));
-
-    .layer-item__icon {
-      fill: var(--map-col-buttons-bkg-highlight, var(--map-col-highlight__deprecate));
-      svg>path {
+      .layer-item__icon {
         fill: var(--map-col-buttons-bkg-highlight, var(--map-col-highlight__deprecate));
+        svg>path {
+          fill: var(--map-col-buttons-bkg-highlight, var(--map-col-highlight__deprecate));
+        }
+      }
+    }
+
+    .layer-item__legend-and-settings {
+      /* Show button when layer is shown. */
+      display: flex;
+      border: 1px solid var(--map-col-border);
+
+      /* Only show legend when layer is shown. */
+      .layer-item__legend-container {
+        display: block;
+      }
+    }
+  }
+
+  .layer-item__legend-and-settings {
+    /* By default, don't show button. */
+    display: none;
+    align-items: center;
+    border-radius: 4px;
+
+    .layer-item__settings-toggle {
+      font-size: 16px;
+      width: 32px;
+      height: 32px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      color: var(--map-col-utility-buttons, currentColor);
+    }
+
+    .layer-item__legend-container {
+      /* By default, don't show legend. */
+      display: none;
+    }
+
+    /* Use the same style on button hover and when selected. */
+    &.layer-item--selected, &:hover {
+      display: flex;
+      background-color: var(--map-col-content-bkg-highlight, #15324e);
+      border: none;
+
+      .layer-item__settings-toggle {
+        color: var(--map-col-buttons-icon);
       }
     }
   }
 }
 
 .layer-item__label {
-  cursor: pointer;
   font-size: 14px;
   font-weight: 500;
   margin: 0 8px;
   color: var(--map-col-text-label);
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .layer-item__highlighted-text {
@@ -713,13 +773,6 @@ represents 1 unit of the given distance measurement. */
 
 .layer-item__visibility-toggle:hover {
   opacity: var(--map-no-brightness-or-opacity-tweaks, 0.5);
-}
-
-/* How to style the layer item when the layer details panel is showing for this item */
-
-.layer-item--selected .layer-item__label {
-  color: var(--map-col-text-label, var(--map-col-highlight__deprecate));
-  font-weight: 700;
 }
 
 /*****************************************************************************************
@@ -1185,9 +1238,8 @@ other class: .ui-slider-range */
 }
 
 .map-legend__img--preview {
-  --img-overflow: 0.8rem;
   /* allow images previews to bleed into the padding a little, so that more detail is visible */
-  height: calc(100% + var(--img-overflow));
+  height: 100%;
   max-width: 100%;
   margin-top: calc(-0.5* var(--img-overflow));
   border-radius: 3px;

--- a/src/js/templates/maps/layer-item.html
+++ b/src/js/templates/maps/layer-item.html
@@ -2,6 +2,12 @@
   <i class="icon-eye-open"></i>
 </button>
 <span class="<%= classes.label %>">
-  <span class="<%= classes.labelText %>"><%= label %></span>
+  <!-- Title needed for when label overflows -->
+  <span class="<%= classes.labelText %>" title="<%= label %>">
+    <%= label %>
+  </span>
 </span>
-<span class="layer-item__legend-container"></span>
+<span class="<%= classes.legendAndSettings %>">
+  <i class="icon-gear layer-item__settings-toggle"></i>
+  <span class="layer-item__legend-container"></span>
+</span>

--- a/src/js/views/maps/LayerItemView.js
+++ b/src/js/views/maps/LayerItemView.js
@@ -99,6 +99,7 @@ define(
           labelText: 'layer-item__label-text',
           highlightedText: 'layer-item__highlighted-text',
           categorized: 'layer-item__categorized',
+          legendAndSettings: 'layer-item__legend-and-settings',
           badge: 'map-view__badge',
           tooltip: 'map-tooltip',
         },
@@ -120,8 +121,8 @@ define(
         events: function () {
           try {
             var events = {}
-            events['click .' + this.classes.label] = 'toggleSelected';
-            events['click .' + this.classes.visibilityToggle] = 'toggleVisibility';
+            events['click .' + this.classes.legendAndSettings] = 'toggleSelected';
+            events['click'] = 'toggleVisibility';
             return events
           }
           catch (error) {
@@ -281,8 +282,12 @@ define(
          * Sets the Layer model's visibility status attribute to true if it's false, and
          * to false if it's true. Executed when a user clicks on the visibility toggle.
          */
-        toggleVisibility: function () {
+        toggleVisibility: function (event) {
           try {
+            if (this.$(`.${this.classes.legendAndSettings}`).has(event.target).length > 0) {
+              return;
+            }
+
             const layerModel = this.model;
             // Hide if visible
             if (layerModel.get('visible')) {
@@ -316,9 +321,9 @@ define(
           try {
             var layerModel = this.model;
             if (layerModel.get('selected')) {
-              this.el.classList.add(this.classes.selected)
+              this.$(`.${this.classes.legendAndSettings}`).addClass(this.classes.selected)
             } else {
-              this.el.classList.remove(this.classes.selected)
+              this.$(`.${this.classes.legendAndSettings}`).removeClass(this.classes.selected)
             }
           }
           catch (error) {


### PR DESCRIPTION
Changes:
1. Change the visibility click target from the icon to the entire row
2. Change the layer settings click target to a button on the right that contains a gear icon and the legend
3. Implement various stylings for the layer settings button in different states. [Mock](https://www.figma.com/file/9R80DBDAMQtOsu8y1HkAVT/permafrost-discovery-gateway?type=design&node-id=26%3A7115&mode=design&t=nYp86WLQp769PgSt-1)
4. Because the new settings button takes up quite some space, allow layer label to overflow and hide the excess.

Demos:

[Light](https://github.com/NCEAS/metacatui/assets/8570665/c4f096eb-e54f-4df6-95df-ed6e2990651a)

[Dark](https://github.com/NCEAS/metacatui/assets/8570665/b8208cf4-fa0a-42e8-86a8-995d1a02f377)

