### PR TITLE
Fix styles in viewfinder

### DIFF
--- a/src/css/map-view.css
+++ b/src/css/map-view.css
@@ -548,11 +548,12 @@ represents 1 unit of the given distance measurement. */
     align-items: center;
     height: 40px;
     margin-bottom: 8px;
+    border: 1px solid;
+    border-color: var(--map-col-border-muted);
+    border-radius: 4px;
   
     .search-input__input {
       width: 100%;
-      position: absolute;
-      padding-right: 32px;
     
       input[type=text]& {  /* Override bootstrap */
         height: 100%;
@@ -561,43 +562,68 @@ represents 1 unit of the given distance measurement. */
         background-color: var(--map-col-content-bkg, var(--map-col-bkg));
         color: var(--map-col-text-body, var(--map-col-text));
         font-family: var(--map-body-font);
-        border: 1px solid;
-        border-color: var(--map-col-border-muted);
+        border: none;
         box-shadow: unset;
 
         ::placeholder {
           color: var(--map-col-text-muted);
         }
-
-        &.search-input__error-input {
-          border-color: var(--map-col-input-error-border);
-          background-color: var(--map-col-input-error-bkg);
-        }
       }
     }
+
+    &:focus-within {
+      border-color: var(--map-col-border-highlight-search-box, var(--map-col-blue));
+    }
+
+    &.search-input__error-input,
+    &.search-input__error-input input[type=text].search-input__input {
+      border-color: var(--map-col-input-error-border);
+      background-color: var(--map-col-input-error-bkg);
+    }
   
-    .search-input__search-button, .search-input__cancel-button {
+    .search-input__cancel-button-container {
+      align-items: center;
+      display: flex;
+    }
+
+    .search-input__search-button,
+    .search-input__cancel-button {
       background-color: transparent;
-      border-color: transparent;
+      border: none;
       color: unset;
-      width: 24px;
-      height: 24px;
-      margin-right: 8px;
+      width: 32px;
+      height: 32px;
       display: inline-flex;
       justify-content: center;
       align-items: center;
       position: relative;
+      flex-shrink: 0;
+      margin: 4px;
   
       .search-input__button-icon {
         font-size: 16px;
       }
     }
 
+    .search-input__vertical-divider {
+      width: 0;
+      height:24px;
+      border-right: solid 2px var(--map-col-border-muted);
+    }
+
     .search-input__search-button {
       color: var(--map-col-buttons-icon-muted);
+      border-radius: 4px;
+
+      &.search-input__search-button--active {
+        color: var(--map-col-text-highlight, var(--map-col-text-body));
+        background: var(--map-col-content-bkg-highlight, var(--map-col-bkg-lighter__deprecate));
+      }
     }
     .search-input__cancel-button {
       color: var(--map-col-utility-buttons);
+      margin-left: 0;
+      width: 24px;
     }
   }
 
@@ -1376,12 +1402,10 @@ other class: .ui-slider-range */
   .viewfinder-prediction__content {
     align-items: center;
     background: var(--map-col-content-bkg, var(--map-col-bkg__deprecate));
-    /* TODO(ianguerin) */
-    border: 1px solid var(--map-col-border);
+    border: 1px solid var(--map-col-border, white);
     border-radius: 4px;
     box-sizing: border-box;
-    /* TODO(ianguerin) */
-    color: var(--map-col-text-body);
+    color: var(--map-col-text-highlight, var(--map-col-text-body));
     cursor: pointer;
     display: flex;
     height: 48px;

--- a/src/js/models/maps/Map.js
+++ b/src/js/models/maps/Map.js
@@ -216,8 +216,7 @@ define([
           showToolbar: true,
           showLayerList: true,
           showHomeButton: true,
-          // todo(ianguerin): revert.
-          showViewfinder: true,
+          showViewfinder: false,
           toolbarOpen: false,
           showScaleBar: true,
           showFeatureInfo: true,

--- a/src/js/models/maps/viewfinder/ViewfinderModel.js
+++ b/src/js/models/maps/viewfinder/ViewfinderModel.js
@@ -173,6 +173,8 @@ define(
        * @param {string} value is the query string.
        */
       async search(value) {
+        if (!value) return;
+
         // This is not a lat,long value, so geocode the prediction instead.
         if (!GeoPoint.couldBeLatLong(value)) {
           const focusedIndex = Math.max(0, this.get("focusIndex"));

--- a/src/js/templates/maps/search-input.html
+++ b/src/js/templates/maps/search-input.html
@@ -1,10 +1,13 @@
-<div class="search-input__field">
+<div class="<%= classNames.inputField %>">
   <input class="<%= classNames.input %>" type="text" placeholder="<%= placeholder %>" />
+  <div class="<%= classNames.cancelButtonContainer %>" style="display: none">
+    <button class="<%= classNames.cancelButton %>" >
+      <i class="icon-remove-circle search-input__button-icon"></i>
+    </button>
+    <div class="search-input__vertical-divider"></div>
+  </div>
   <button class="<%= classNames.searchButton %>">
     <i class="icon-search search-input__button-icon"></i>
-  </button>
-  <button class="<%= classNames.cancelButton %>" style="display: none">
-    <i class="icon-remove-circle search-input__button-icon"></i>
   </button>
 </div>
 <div class="<%= classNames.errorText %>" style="display: none">

--- a/src/js/views/maps/SearchInputView.js
+++ b/src/js/views/maps/SearchInputView.js
@@ -10,8 +10,11 @@ define([
   const BASE_CLASS = "search-input";
   const CLASS_NAMES = {
     searchButton: `${BASE_CLASS}__search-button`,
+    searchButtonActive: `${BASE_CLASS}__search-button--active`,
     cancelButton: `${BASE_CLASS}__cancel-button`,
+    cancelButtonContainer: `${BASE_CLASS}__cancel-button-container`,
     input: `${BASE_CLASS}__input`,
+    inputField: `${BASE_CLASS}__field`,
     errorInput: `${BASE_CLASS}__error-input`,
     errorText: `${BASE_CLASS}__error-text`,
   };
@@ -112,7 +115,31 @@ define([
         return;
       }
 
+      if (this.getInputValue().toLowerCase() !== "") {
+        this.showCancelAndSearch();
+      } else {
+        this.hideCancelAndDimSearch();
+      }
+
       this.keyupCallback(event);
+    },
+
+    /**
+     * Manage state change for the search button and cancel button when user has
+     * entered some input.
+     */
+    showCancelAndSearch() {
+      this.getCancelButtonContainer().show();
+      this.getSearchButton().addClass(CLASS_NAMES.searchButtonActive);
+    },
+
+    /**
+     * Manage state change for the search button and cancel button when user has
+     * cleared the input.
+     */
+    hideCancelAndDimSearch() {
+      this.getCancelButtonContainer().hide();
+      this.getSearchButton().removeClass(CLASS_NAMES.searchButtonActive);
     },
 
     /**
@@ -146,24 +173,16 @@ define([
     onSearch() {
       this.getError().hide();
 
-      const input = this.getInput();
+      const inputField = this.getInputField();
       const inputValue = this.getInputValue().toLowerCase();
       const matched = this.search(inputValue);
       if (matched) {
-        input.removeClass(CLASS_NAMES.errorInput);
+        inputField.removeClass(CLASS_NAMES.errorInput);
       } else {
-        input.addClass(CLASS_NAMES.errorInput);
-        if (typeof(this.noMatchCallback) === "function") {
+        inputField.addClass(CLASS_NAMES.errorInput);
+        if (typeof (this.noMatchCallback) === "function") {
           this.noMatchCallback();
         }
-      }
-
-      if (inputValue !== "") {
-        this.getSearchButton().hide();
-        this.getCancelButton().show();
-      } else {
-        this.getSearchButton().show();
-        this.getCancelButton().hide();
       }
     },
 
@@ -172,7 +191,7 @@ define([
      * @param {string} errorText
      */
     setError(errorText) {
-      this.getInput().addClass(CLASS_NAMES.errorInput);
+      this.getInputField().addClass(CLASS_NAMES.errorInput);
       const errorTextEl = this.getError();
       if (errorText) {
         errorTextEl.html(errorText);
@@ -187,9 +206,11 @@ define([
      * Handler function for the cancel icon button action.
      */
     onCancel() {
+      this.hideCancelAndDimSearch();
       this.getInput().val("");
       this.onSearch();
       this.focus();
+      this.getInputField().removeClass(CLASS_NAMES.errorInput);
     },
 
     /**
@@ -216,12 +237,21 @@ define([
     },
 
     /**
-     * Get the cancel icon button.
-     * @return jQuery element representing the cancel icon button. Or an empty
+     * Get the cancel icon button container.
+     * @return jQuery element representing the cancel icon button container. Or
+     * an empty jQuery selector if the button is not found.
+     */
+    getCancelButtonContainer() {
+      return this.$(`.${CLASS_NAMES.cancelButtonContainer}`);
+    },
+
+    /**
+     * Get the container element for the input.
+     * @return jQuery element representing the input container. Or an empty
      * jQuery selector if the button is not found.
      */
-    getCancelButton() {
-      return this.$(`.${CLASS_NAMES.cancelButton}`);
+    getInputField() {
+      return this.$(`.${CLASS_NAMES.inputField}`);
     },
 
     /**

--- a/test/js/specs/unit/models/maps/viewfinder/ViewfinderModel.spec.js
+++ b/test/js/specs/unit/models/maps/viewfinder/ViewfinderModel.spec.js
@@ -293,6 +293,18 @@ define(
       });
 
       describe('searching for a location', () => {
+        it('does nothing if the search string is null', async () => {
+          await state.model.search();
+
+          expect(state.zoomSpy.callCount).to.equal(0);
+        });
+
+        it('does nothing if the search string is empty', async () => {
+          await state.model.search('');
+
+          expect(state.zoomSpy.callCount).to.equal(0);
+        });
+
         it('geocodes and selects the focused prediction', async () => {
           state.geocodeSpy.returns([
             new GeocodedLocation({

--- a/test/js/specs/unit/views/maps/SearchInputView.spec.js
+++ b/test/js/specs/unit/views/maps/SearchInputView.spec.js
@@ -66,28 +66,28 @@ define([
         expect(spy.callCount).to.equal(1);
       });
 
-      it("only shows search button if there is no input", () => {
+      it("shows search button as active if there is input", () => {
         state.harness.typeQuery("123");
         state.harness.hitEnter();
 
-        expect(state.harness.getSearchButton().css("display")).to.equal("none");
+        expect(state.harness.getSearchButton().hasClass("search-input__search-button--active")).to.be.true;
 
         state.harness.typeQuery("");
         state.harness.hitEnter();
 
-        expect(state.harness.getSearchButton().css("display")).to.not.equal("none");
+        expect(state.harness.getSearchButton().hasClass("search-input__search-button--active")).to.be.false;
       });
 
       it("only shows cancel button if there is input", () => {
         state.harness.typeQuery("123");
         state.harness.hitEnter();
 
-        expect(state.harness.getCancelButton().css("display")).to.not.equal("none");
+        expect(state.harness.getCancelButtonContainer().css("display")).to.not.equal("none");
 
         state.harness.typeQuery("");
         state.harness.hitEnter();
 
-        expect(state.harness.getCancelButton().css("display")).to.equal("none");
+        expect(state.harness.getCancelButtonContainer().css("display")).to.equal("none");
       });
 
       it("clears error text", () => {
@@ -108,7 +108,7 @@ define([
         expect(spy.callCount).to.equal(1);
       });
 
-      it("applies an error class to the input box if there is no match", () => {
+      it("applies an error class to the input field if there is no match", () => {
         stub(state.view, "search").returns(false);
 
         state.harness.clickSearch();

--- a/test/js/specs/unit/views/maps/SearchInputViewHarness.js
+++ b/test/js/specs/unit/views/maps/SearchInputViewHarness.js
@@ -8,6 +8,7 @@ define([], function () {
 
     typeQuery(searchString) {
       this.view.getInput().val(searchString);
+      this.view.getInput().trigger('keyup');
     }
 
     clickSearch() {
@@ -50,8 +51,12 @@ define([], function () {
       return this.view.$el.find(".search-input__cancel-button");
     }
 
+    getCancelButtonContainer() {
+      return this.view.$el.find(".search-input__cancel-button-container");
+    }
+
     hasErrorInput() {
-      return this.view.getInput().hasClass("search-input__error-input");
+      return this.view.getInputField().hasClass("search-input__error-input");
     }
   }
 });


### PR DESCRIPTION
This change:
- updates behaviors for shared search input to show a cancel button as soon as user types anything
- removes absolute positioning from input box to make space for a variable number of buttons in the input field
- always shows the search icon and gives it treatment when clicking it would trigger a search

after: 
![someplace](https://github.com/NCEAS/metacatui/assets/4664309/57e8e756-bdb8-42fc-9bfa-47696d4f5a69)

before:
![someplace--before](https://github.com/NCEAS/metacatui/assets/4664309/009313f1-3621-4c8a-b7e4-411e8a73f5f2)

[search input changes.webm](https://github.com/NCEAS/metacatui/assets/4664309/e34f5701-2125-4d43-9111-d0a78c25aad5)
