### PR TITLE
Ensure page numbers are always >0 in catalog search

### DIFF
--- a/src/js/routers/router.js
+++ b/src/js/routers/router.js
@@ -299,8 +299,8 @@ function ($, _, Backbone) {
 			this.routeHistory.push("data");
 			// Check for a page URL parameter
 			page = parseInt(page);
-			page = isNaN(page) || page < 1 ? 0 : page;
-			MetacatUI.appModel.set("page", page);
+			page = (isNaN(page) || page < 1) ? 1 : page;
+			MetacatUI.appModel.set("page", (page-1));
 
 			// Check if we are using the new CatalogSearchView
 			if(!MetacatUI.appModel.get("useDeprecatedDataCatalogView")){

--- a/src/js/routers/router.js
+++ b/src/js/routers/router.js
@@ -298,8 +298,9 @@ function ($, _, Backbone) {
 		renderData: function (mode, query, page) {
 			this.routeHistory.push("data");
 			// Check for a page URL parameter
-			if(!page) MetacatUI.appModel.set("page", 0);
-			else MetacatUI.appModel.set('page', page - 1);
+			page = parseInt(page);
+			page = isNaN(page) || page < 1 ? 0 : page;
+			MetacatUI.appModel.set("page", page);
 
 			// Check if we are using the new CatalogSearchView
 			if(!MetacatUI.appModel.get("useDeprecatedDataCatalogView")){

--- a/src/js/themes/arctic/routers/router.js
+++ b/src/js/themes/arctic/routers/router.js
@@ -112,8 +112,9 @@ function ($, _, Backbone) {
 		renderData: function (mode, query, page) {
 			this.routeHistory.push("data");
 			// Check for a page URL parameter
-			if(!page) MetacatUI.appModel.set("page", 0);
-			else MetacatUI.appModel.set('page', page - 1);
+			page = parseInt(page);
+			page = isNaN(page) || page < 1 ? 0 : page;
+			MetacatUI.appModel.set("page", page);
 
 			// Check if we are using the new CatalogSearchView
 			if(!MetacatUI.appModel.get("useDeprecatedDataCatalogView")){

--- a/src/js/themes/arctic/routers/router.js
+++ b/src/js/themes/arctic/routers/router.js
@@ -113,8 +113,8 @@ function ($, _, Backbone) {
 			this.routeHistory.push("data");
 			// Check for a page URL parameter
 			page = parseInt(page);
-			page = isNaN(page) || page < 1 ? 0 : page;
-			MetacatUI.appModel.set("page", page);
+			page = (isNaN(page) || page < 1) ? 1 : page;
+			MetacatUI.appModel.set("page", (page-1));
 
 			// Check if we are using the new CatalogSearchView
 			if(!MetacatUI.appModel.get("useDeprecatedDataCatalogView")){


### PR DESCRIPTION
Don't allow router to navigate to page numbers <0 in the catalog search

Fixes #2155