### PR TITLE
Layer List Polish: Fix empty legend and layer settings button

### DIFF
--- a/src/js/views/maps/LayerItemView.js
+++ b/src/js/views/maps/LayerItemView.js
@@ -284,7 +284,8 @@ define(
          */
         toggleVisibility: function (event) {
           try {
-            if (this.$(`.${this.classes.legendAndSettings}`).has(event.target).length > 0) {
+            if (this.$(`.${this.classes.legendAndSettings}`).is(event.target) ||
+                this.$(`.${this.classes.legendAndSettings}`).has(event.target).length > 0) {
               return;
             }
 

--- a/src/js/views/maps/LegendView.js
+++ b/src/js/views/maps/LegendView.js
@@ -240,6 +240,10 @@ define(
             const view = this
             // Data to use in d3
             let data = colorPalette.get('colors').toJSON().reverse();
+
+            if (data.length === 0) {
+              return;
+            }
             // The max width of the SVG, to be reduced if there are few colours
             let width = this.previewSvgDimensions.width
             // The height of the SVG


### PR DESCRIPTION
1. Categorical legend still occupies an small empty space even when the color palette doesn't have colors. The fix returns early instead of inserting an empty svg.
Before: <img width="65" alt="image" src="https://github.com/NCEAS/metacatui/assets/8570665/f5aefdb8-4c42-4200-a6e5-3101a9dd8aa7">
After: <img width="50" alt="image" src="https://github.com/NCEAS/metacatui/assets/8570665/bacef4c1-948e-48b0-8aa1-41bc93c609a2">

2. The toggleVisibility function is expected to return early when the event target is the layer settings button, but I noticed that clicking on the edge of the button still toggles on layer visibility. This was because the current check for early return only checks for the button's children components, not itself.
![image](https://github.com/NCEAS/metacatui/assets/8570665/1708ddd4-bc4d-4a65-8f44-c21d7d5c5619)
Before: Click here turns on layer settings AND layer visibility
After: Click here only turns on layer settings

