### PR TITLE
Layer List Polish 8: Widen toolbar panel and layer details view

### DIFF
--- a/src/css/map-view.css
+++ b/src/css/map-view.css
@@ -474,8 +474,10 @@ represents 1 unit of the given distance measurement. */
   pointer-events: all;
 }
 
-.map-view__portal .toolbar__all-content {
-  width: var(--map-width-toolbar-wide);
+@media only screen and (min-width: 31.5rem) {
+  .map-view__portal .toolbar__all-content {
+    width: var(--map-width-toolbar-wide);
+  }
 }
 
 .toolbar--open .toolbar__all-content {
@@ -939,8 +941,10 @@ represents 1 unit of the given distance measurement. */
   animation: fadeIn .3s ease-in-out;
 }
 
-.map-view__portal .layer-details {
-  width: var(--map-width-toolbar-wide);
+@media only screen and (min-width: 31.5rem) {
+  .map-view__portal .layer-details {
+    width: var(--map-width-toolbar-wide);
+  }
 }
 
 .layer-details--open {

--- a/src/css/map-view.css
+++ b/src/css/map-view.css
@@ -93,6 +93,7 @@
   --map-border-radius-small: 0.25rem;
   --map-border-radius-big: 0.5rem;
   --map-width-toolbar: 21rem;
+  --map-width-toolbar-wide: 30rem;
   --map-toolbar-link-width: calc(var(--map-size-toolbar-link) + 2 * var(--map-size-toolbar-link-padding));
   /* SHADOWS */
   --map-shadow-md: var(--portal-shadow-md, 0 1px 9px -1px rgba(0, 0, 0, 0.2), 0 1px 2px 0px rgba(0, 0, 0, 0.5));
@@ -471,6 +472,10 @@ represents 1 unit of the given distance measurement. */
   display: none;
   overflow: hidden;
   pointer-events: all;
+}
+
+.map-view__portal .toolbar__all-content {
+  width: var(--map-width-toolbar-wide);
 }
 
 .toolbar--open .toolbar__all-content {
@@ -932,6 +937,10 @@ represents 1 unit of the given distance measurement. */
   display: none;
   border: 1px solid var(--map-col-border);
   animation: fadeIn .3s ease-in-out;
+}
+
+.map-view__portal .layer-details {
+  width: var(--map-width-toolbar-wide);
 }
 
 .layer-details--open {

--- a/src/js/views/maps/MapView.js
+++ b/src/js/views/maps/MapView.js
@@ -31,6 +31,14 @@ define(
     // CSS
     MapCSS
   ) {
+    const CLASS_NAMES = {
+      mapWidgetContainer: 'map-view__map-widget-container',
+      scaleBarContainer: 'map-view__scale-bar-container',
+      featureInfoContainer: 'map-view__feature-info-container',
+      toolbarContainer: 'map-view__toolbar-container',
+      layerDetailsContainer: 'map-view__layer-details-container',
+      portalIndicator: 'map-view__portal',
+    };
 
     /**
     * @class MapView
@@ -69,28 +77,6 @@ define(
          * @type {Underscore.template}
          */
         template: _.template(Template),
-
-        /**
-         * Classes that will be used to select specific elements from the template.
-         * @name MapView#classes
-         * @type {Object}
-         * @property {string} mapWidgetContainer The element that will hold the map widget
-         * (i.e. CesiumWidgetView)
-         * @property {string} scaleBarContainer The container for the ScaleBarView
-         * @property {string} featureInfoContainer The container for the box that will
-         * show details about a selected feature
-         * @property {string} toolbarContainer The container for the toolbar UI
-         * @property {string} layerDetailsContainer The container for the element that
-         * will show details about a specific layer
-         */
-        classes: {
-          mapWidgetContainer: 'map-view__map-widget-container',
-          scaleBarContainer: 'map-view__scale-bar-container',
-          featureInfoContainer: 'map-view__feature-info-container',
-          toolbarContainer: 'map-view__toolbar-container',
-          layerDetailsContainer: 'map-view__layer-details-container',
-          portalIndicator: 'map-view__portal',
-        },
 
         /**
         * The events this view will listen to and the associated function to call.
@@ -138,12 +124,12 @@ define(
             // Ensure the view's main element has the given class name
             this.el.classList.add(this.className);
             if (this.isPortalMap) {
-              this.el.classList.add(this.classes.portalIndicator);
+              this.el.classList.add(CLASS_NAMES.portalIndicator);
             }
 
             // Select the elements that will be updatable
             this.subElements = {};
-            for (const [element, className] of Object.entries(view.classes)) {
+            for (const [element, className] of Object.entries(CLASS_NAMES)) {
               view.subElements[element] = document.querySelector('.' + className)
             }
 

--- a/src/js/views/maps/MapView.js
+++ b/src/js/views/maps/MapView.js
@@ -88,7 +88,8 @@ define(
           scaleBarContainer: 'map-view__scale-bar-container',
           featureInfoContainer: 'map-view__feature-info-container',
           toolbarContainer: 'map-view__toolbar-container',
-          layerDetailsContainer: 'map-view__layer-details-container'
+          layerDetailsContainer: 'map-view__layer-details-container',
+          portalIndicator: 'map-view__portal',
         },
 
         /**
@@ -100,30 +101,22 @@ define(
         },
 
         /**
+        * @typedef {Object} ViewfinderViewOptions
+        * @property {Map} model The map model that contains the configs for this map view.
+        * @property {boolean} isPortalMap Indicates whether the map view is a part of a
+        * portal, which is styled differently.
+        */
+
+        /**
         * Executed when a new MapView is created
-        * @param {Object} [options] - A literal object with options to pass to the view.
+        * @param {ViewfinderViewOptions} options
         */
         initialize: function (options) {
+          // Add the CSS required for this view and its sub-views.
+          MetacatUI.appModel.addCSS(MapCSS, 'mapView');
 
-          try {
-            // Add the CSS required for this view and its sub-views.
-            MetacatUI.appModel.addCSS(MapCSS, 'mapView');
-
-            // Get all the options and apply them to this view
-            if (typeof options == 'object') {
-              for (const [key, value] of Object.entries(options)) {
-                this[key] = value;
-              }
-            }
-
-            if(!this.model) {
-              this.model = new Map();
-            }
-            
-          } catch (e) {
-            console.log('A MapView failed to initialize. Error message: ' + e);
-          }
-
+          this.model = options?.model ? options.model : new Map();
+          this.isPortalMap = options?.isPortalMap;
         },
 
         /**
@@ -144,6 +137,9 @@ define(
 
             // Ensure the view's main element has the given class name
             this.el.classList.add(this.className);
+            if (this.isPortalMap) {
+              this.el.classList.add(this.classes.portalIndicator);
+            }
 
             // Select the elements that will be updatable
             this.subElements = {};

--- a/src/js/views/portals/PortalVisualizationsView.js
+++ b/src/js/views/portals/PortalVisualizationsView.js
@@ -110,7 +110,8 @@ define(["jquery",
                   thisView.model.set("mapModel", mapModel)
                 }
                 let mapView = new MapView({
-                  model: mapModel
+                  model: mapModel,
+                  isPortalMap: true,
                 });
                 thisView.$el.html(mapView.el);
                 mapView.render();

--- a/test/config/tests.json
+++ b/test/config/tests.json
@@ -63,7 +63,8 @@
     "./js/specs/unit/views/maps/SearchInputView.spec.js",
     "./js/specs/unit/models/Search.spec.js",
     "./js/specs/unit/models/SolrResult.spec.js",
-    "./js/specs/unit/models/DataONEObject.spec.js"
+    "./js/specs/unit/models/DataONEObject.spec.js",
+    "./js/specs/unit/views/maps/MapView.spec.js"
   ],
   "integration": [
     "./js/specs/integration/collections/SolrResults.spec.js",

--- a/test/js/specs/unit/views/maps/MapView.spec.js
+++ b/test/js/specs/unit/views/maps/MapView.spec.js
@@ -1,0 +1,25 @@
+define([
+  "views/maps/MapView",
+  'models/maps/Map',
+], (MapView, MapAsset) => {
+  const expect = chai.expect;
+
+  describe("MapView Test Suite", () => {
+    describe("Initialization", () => {
+      it("creates a MapView instance", () => {
+        const view = new MapView();
+        expect(view).to.be.instanceof(MapView);
+      });
+    });
+
+    describe("Portal map", () => {
+      it("has an additional portal indicator class", () => {
+        const nonPortalMap = new MapView();
+        expect(nonPortalMap.$el.hasClass(nonPortalMap.classes.portalIndicator)).to.be.false;
+        
+        const portalMap = new MapView({ isPortalMap: true });
+        expect(portalMap.$el.hasClass(portalMap.classes.portalIndicator)).to.be.true;
+      });
+    });
+  });
+});

--- a/test/js/specs/unit/views/maps/MapView.spec.js
+++ b/test/js/specs/unit/views/maps/MapView.spec.js
@@ -15,9 +15,11 @@ define([
     describe("Portal map", () => {
       it("has an additional portal indicator class", () => {
         const nonPortalMap = new MapView();
+        nonPortalMap.render();
         expect(nonPortalMap.$el.hasClass(nonPortalMap.classes.portalIndicator)).to.be.false;
         
         const portalMap = new MapView({ isPortalMap: true });
+        portalMap.render();
         expect(portalMap.$el.hasClass(portalMap.classes.portalIndicator)).to.be.true;
       });
     });

--- a/test/js/specs/unit/views/maps/MapView.spec.js
+++ b/test/js/specs/unit/views/maps/MapView.spec.js
@@ -1,6 +1,6 @@
 define([
   "views/maps/MapView",
-  'models/maps/Map',
+  "models/maps/Map",
 ], (MapView, MapAsset) => {
   const expect = chai.expect;
 
@@ -16,11 +16,11 @@ define([
       it("has an additional portal indicator class", () => {
         const nonPortalMap = new MapView();
         nonPortalMap.render();
-        expect(nonPortalMap.$el.hasClass(nonPortalMap.classes.portalIndicator)).to.be.false;
+        expect(nonPortalMap.$el.hasClass("map-view__portal")).to.be.false;
         
         const portalMap = new MapView({ isPortalMap: true });
         portalMap.render();
-        expect(portalMap.$el.hasClass(portalMap.classes.portalIndicator)).to.be.true;
+        expect(portalMap.$el.hasClass("map-view__portal")).to.be.true;
       });
     });
   });


### PR DESCRIPTION
As a followup to https://github.com/NCEAS/metacatui/pull/2318, we now keep every layer in one line and use ellipsis if the layer name is too long. Unfortunately that is the case for a lot of our layers on the demo site. The fix is to widen the toolbar panel and layer details view so we can accommodate longer layer names.

Then we face a challenge in the main repository maps that use a 3-part view, where the map view doesn't have enough space for the wide panel. Given that it's a setup only existing in main repositories (for now), we'll apply the wide panel only in portal maps.

Before:
<img width="345" alt="image" src="https://github.com/NCEAS/metacatui/assets/8570665/934bd632-717d-4455-a71c-00235dae383f">

After:
<img width="491" alt="image" src="https://github.com/NCEAS/metacatui/assets/8570665/b358bbcd-bf82-49b1-8593-7ad47668b598">

3-part map view in ADC:
<img width="1449" alt="image" src="https://github.com/NCEAS/metacatui/assets/8570665/345e4b79-1221-436a-94d1-987cc53ed9e0">