### PR TITLE
Base Map Polish: Support saturation for CesiumImagery

### DIFF
--- a/src/js/models/maps/assets/CesiumImagery.js
+++ b/src/js/models/maps/assets/CesiumImagery.js
@@ -207,7 +207,8 @@ define(
 
           var initialAppearance = {
             alpha: this.get('opacity'),
-            show: this.get('visible')
+            show: this.get('visible'),
+            saturation: this.get('saturation'),
             // TODO: brightness, contrast, gamma, etc.
           }
 

--- a/src/js/models/maps/assets/MapAsset.js
+++ b/src/js/models/maps/assets/MapAsset.js
@@ -60,6 +60,9 @@ define([
        * opacity of the layer on the map, with 0 representing fully transparent and 1
        * representing fully opaque. This applies to raster (imagery) and vector assets,
        * not to terrain assets.
+       * @property {Number} [saturation = 1] A number between 0 and 1 indicating the
+       * saturation of the layer on the map, with 0 representing grayscale and 1
+       * representing full color. This applies to raster (imagery) only.
        * @property {Boolean} [visible = true] Set to true if the layer is visible on the
        * map, false if it is hidden. This applies to raster (imagery) and vector assets,
        * not to terrain assets.
@@ -99,6 +102,7 @@ define([
           downloadLink: "",
           selected: false,
           opacity: 1,
+          saturation: 1,
           visible: true,
           colorPalette: null,
           customProperties: {},
@@ -142,6 +146,9 @@ define([
        * opacity of the layer on the map, with 0 representing fully transparent and 1
        * representing fully opaque. This applies to raster (imagery) and vector assets,
        * not to terrain assets.
+       * @property {Number} [saturation=1] - A number between 0 and 1 indicating the
+       * saturation of the layer on the map, with 0 representing grayscale and 1
+       * representing full color. This applies to raster (imagery) only.
        * @property {Boolean} [visible=true] - Set to true if the layer is visible on the
        * map, false if it is hidden. This applies to raster (imagery) and vector assets,
        * not to terrain assets.

--- a/src/js/models/maps/assets/MapAsset.js
+++ b/src/js/models/maps/assets/MapAsset.js
@@ -60,9 +60,9 @@ define([
        * opacity of the layer on the map, with 0 representing fully transparent and 1
        * representing fully opaque. This applies to raster (imagery) and vector assets,
        * not to terrain assets.
-       * @property {Number} [saturation = 1] A number between 0 and 1 indicating the
-       * saturation of the layer on the map, with 0 representing grayscale and 1
-       * representing full color. This applies to raster (imagery) only.
+       * @property {Number} [saturation = 1] A number that indicates the saturation of
+       * the layer on the map. Less than 1.0 reduces the saturation while greater than
+       * 1.0 increases it. This applies to raster (imagery) only.
        * @property {Boolean} [visible = true] Set to true if the layer is visible on the
        * map, false if it is hidden. This applies to raster (imagery) and vector assets,
        * not to terrain assets.
@@ -146,9 +146,9 @@ define([
        * opacity of the layer on the map, with 0 representing fully transparent and 1
        * representing fully opaque. This applies to raster (imagery) and vector assets,
        * not to terrain assets.
-       * @property {Number} [saturation=1] - A number between 0 and 1 indicating the
-       * saturation of the layer on the map, with 0 representing grayscale and 1
-       * representing full color. This applies to raster (imagery) only.
+       * @property {Number} [saturation=1] - A number that indicates the saturation of
+       * the layer on the map. Less than 1.0 reduces the saturation while greater than
+       * 1.0 increases it. This applies to raster (imagery) only.
        * @property {Boolean} [visible=true] - Set to true if the layer is visible on the
        * map, false if it is hidden. This applies to raster (imagery) and vector assets,
        * not to terrain assets.

--- a/test/js/specs/unit/models/maps/assets/CesiumImagery.spec.js
+++ b/test/js/specs/unit/models/maps/assets/CesiumImagery.spec.js
@@ -19,7 +19,8 @@ define([
           url: '/test/data/models/maps/assets/CesiumImagery/WorldCRS84Quad/{TileMatrix}/{TileCol}/{TileRow}.png',
           tilingScheme: 'GeographicTilingScheme',
           rectangle: boundingBox
-        }
+        },
+        saturation: 0.5,
       });
     })
 
@@ -46,8 +47,17 @@ define([
           done(error)
         })
 
-      })
+      });
 
+      it("should use saturation from the imagery model", function (done) {
+        imagery.whenReady().then(function (model) {
+          expect(model.get("cesiumModel").saturation).to.equal(0.5);
+          done();
+        }, function (error) {
+          done(error);
+        })
+
+      });
     });
 
   });


### PR DESCRIPTION
This is so that we can set OpenStreetMaps and the upcoming OpenTopoMap to greyscale.

Demo:
<img width="40%" alt="image" src="https://github.com/NCEAS/metacatui/assets/8570665/12eab6f8-f4a6-45a7-9f38-99dd54f94091"> -> <img width="40%" alt="image" src="https://github.com/NCEAS/metacatui/assets/8570665/6e7fe58b-3b27-4921-b209-98b1b9117606">