### PR TITLE
Base Map Polish: Support xml config'ed base color for globe

### DIFF
--- a/src/js/models/maps/Map.js
+++ b/src/js/models/maps/Map.js
@@ -78,6 +78,8 @@ define([
        * feedbackText.
        * @property {String} [feedbackText=null] - The text to show in the
        * feedback section. showFeedback must be true for this to be shown.
+       * @property {String} [globeBaseColor=null] - The base color of the globe when no
+       * layer is shown.
        *
        * @example
        * {
@@ -195,6 +197,8 @@ define([
        * feedback section in the toolbar.
        * @property {String} [feedbackText=null] - The text to show in the
        * feedback section.
+       * @property {String} [globeBaseColor=null] - The base color of the globe when no
+       * layer is shown.
        */
       defaults: function () {
         return {
@@ -223,7 +227,8 @@ define([
           clickFeatureAction: "showDetails",
           showNavHelp: true,
           showFeedback: false,
-          feedbackText: null
+          feedbackText: null,
+          globeBaseColor: null,
         };
       },
 

--- a/src/js/views/maps/CesiumWidgetView.js
+++ b/src/js/views/maps/CesiumWidgetView.js
@@ -235,6 +235,13 @@ define([
         view.scene = view.widget.scene;
         view.camera = view.widget.camera;
 
+        if (typeof this.model.get("globeBaseColor") === 'string') {
+          const baseColor = Cesium.Color.fromCssColorString(this.model.get("globeBaseColor"));
+          if (baseColor) {
+            view.scene.globe.baseColor = baseColor;
+          }
+        }
+
         return view.widget;
       },
 

--- a/test/js/specs/unit/views/maps/CesiumWidgetView.spec.js
+++ b/test/js/specs/unit/views/maps/CesiumWidgetView.spec.js
@@ -92,6 +92,15 @@ define([
         expect(state.view.scene.imageryLayers.get(1).imageryProvider).to.equal(Cesium.WebMapServiceImageryProvider);
         expect(state.view.scene.imageryLayers.get(0).imageryProvider).to.equal(Cesium.WebMapTileServiceImageryProvider);
       });
+
+      it("uses base color from model if applicable", () => {
+        state.view.model.set("globeBaseColor", "red");
+
+        state.view.render();
+
+        expect(state.view.scene.globe.baseColor).to.deep.equal(
+            new Cesium.Color(/* red= */ 1, /* green= */ 0, /* blue= */ 0, /* alpha= */ 1));
+      });
     });
   });
 });


### PR DESCRIPTION
Demo:
<img width="40%" alt="image" src="https://github.com/NCEAS/metacatui/assets/8570665/361c6523-eee8-44b1-b6b3-d8001caaabd9"> -> <img width="40%" alt="image" src="https://github.com/NCEAS/metacatui/assets/8570665/190371bb-fa25-4d09-88e5-bb9075e84077">

Fixes: #1904 