### PR TITLE
Light theme 8: Deprecate old color variables in themes

### DIFF
--- a/src/css/map-view.css
+++ b/src/css/map-view.css
@@ -1290,7 +1290,7 @@ other class: .ui-slider-range */
   border: 1px solid var(--map-col-border);
   border-radius: var(--map-border-radius-small);
   text-decoration: none;
-  color: var(--map-col-buttons-text, var(--portal-col-highlight));
+  color: var(--map-col-buttons-text, var(--portal-col-highlight__deprecate));
   display: inline-block;
   padding: .5rem 1rem;
 

--- a/src/css/portal-layouts/panels.css
+++ b/src/css/portal-layouts/panels.css
@@ -115,7 +115,7 @@
   left: 1.5rem;
   width: max-content;
   max-width: 15rem;
-  background-color: var(--portal-col-bkg-active, white);
+  background-color: var(--portal-col-bkg-active__deprecate, white);
   z-index: 1;
   padding: 0 0.3rem;
   border-radius: 0.2rem;

--- a/src/css/portal-themes/dark.css
+++ b/src/css/portal-themes/dark.css
@@ -1,32 +1,32 @@
 :root {
   /* COLOURS */
-  --portal-col-bkg: #111827;
-  --portal-col-bkg-lighter: #1F2937;
-  --portal-col-bkg-active: #374151;
-  --portal-col-buttons: #4B5563F2;
-  --portal-col-text-subtle: #9CA3AF;
-  --portal-col-text: #F9FAFB;
-  --portal-col-highlight: #269fb9;
-  --portal-col-highlight-subtle: #0c4e66;
+  --portal-col-bkg__deprecate: #111827;
+  --portal-col-bkg-lighter__deprecate: #1F2937;
+  --portal-col-bkg-active__deprecate: #374151;
+  --portal-col-buttons__deprecate: #4B5563F2;
+  --portal-col-text-subtle__deprecate: #9CA3AF;
+  --portal-col-text__deprecate: #F9FAFB;
+  --portal-col-highlight__deprecate: #269fb9;
+  --portal-col-highlight-subtle__deprecate: #0c4e66;
   /* SHADOWS */
   --map-shadow-md: 0 1px 9px -1px rgba(0, 0, 0, 0.2), 0 1px 2px 0px rgba(0, 0, 0, 0.5);
   /* Colors used in the 'loading-metrics.html' template, on Metrics page */
-  --m-chart-bkg: var(--portal-col-bkg-lighter);
-  --m-chart-lines: var(--portal-col-bkg-active);
-  --m-chart-bubble-bkg: var(--portal-col-highlight-subtle);
+  --m-chart-bkg: var(--portal-col-bkg-lighter__deprecate);
+  --m-chart-lines: var(--portal-col-bkg-active__deprecate);
+  --m-chart-bubble-bkg: var(--portal-col-highlight-subtle__deprecate);
 }
 
 .subtle {
-  color: var(--portal-col-text-subtle);
+  color: var(--portal-col-text-subtle__deprecate);
 }
 
 .portal-view, .Portal #Content, .PortalView #Content {
-  color: var(--portal-col-text);
-  background-color: var(--portal-col-bkg-lighter);
+  color: var(--portal-col-text__deprecate);
+  background-color: var(--portal-col-bkg-lighter__deprecate);
 }
 
 body, #portal-sections {
-  background-color: var(--portal-col-bkg);
+  background-color: var(--portal-col-bkg__deprecate);
 }
 
 #portal-sections{
@@ -34,7 +34,7 @@ body, #portal-sections {
 }
 
 .portal-view, .portal-view .portal-section-content, .portal-view h2, .portal-view h3, .portal-view h4, .portal-view h5, .portal-view h6 {
-  color: var(--portal-col-text);
+  color: var(--portal-col-text__deprecate);
 }
 
 .portal-view h2 {
@@ -50,35 +50,35 @@ body, #portal-sections {
 }
 
 .Portal.Editor #Navbar, .PortalView #Navbar, .Portal.Editor .navbar-inner, .PortalView .navbar-inner, .Portal .d1_nav, .PortalView .d1_nav {
-  color: var(--portal-col-text);
-  background-color: var(--portal-col-bkg-active);
+  color: var(--portal-col-text__deprecate);
+  background-color: var(--portal-col-bkg-active__deprecate);
 }
 
 .navbar-inner .nav>li>a, #nav-trigger, .header .nav li a, .Portal.Editor #Navbar .brand::before, .PortalView #Navbar .brand::before {
-  color: var(--portal-col-text);
+  color: var(--portal-col-text__deprecate);
 }
 
 .navbar-inner .nav>li>a:hover {
-  color: var(--portal-col-highlight)
+  color: var(--portal-col-highlight__deprecate)
 }
 
 #Navbar .nav .dropdown-toggle .caret {
-  border-top-color: var(--portal-col-text);
+  border-top-color: var(--portal-col-text__deprecate);
 }
 
 .Portal.Editor #Navbar #logo::after, .PortalView #Navbar #logo::after {
-  color: var(--portal-col-text-subtle);
+  color: var(--portal-col-text-subtle__deprecate);
 }
 
 .portal-view .portal-description {
-  color: var(--portal-col-text)
+  color: var(--portal-col-text__deprecate)
 }
 
 /* sign in button */
 
 .header .nav li a.btn.login {
   border-color: transparent;
-  color: var(--portal-col-text-subtle);
+  color: var(--portal-col-text-subtle__deprecate);
 }
 
 .header .nav li a.btn.login>.icon {
@@ -86,22 +86,22 @@ body, #portal-sections {
 }
 
 .navbar .login-container .login.btn {
-  color: var(--portal-col-text-subtle);
+  color: var(--portal-col-text-subtle__deprecate);
 }
 
 footer, #Footer {
-  color: var(--portal-col-text);
-  background-color: var(--portal-col-bkg);
+  color: var(--portal-col-text__deprecate);
+  background-color: var(--portal-col-bkg__deprecate);
   border: none;
 }
 
 footer .footnote, footer .adc-contact .contact-title {
-  color: var(--portal-col-text);
+  color: var(--portal-col-text__deprecate);
   opacity: 0.7;
 }
 
 a {
-  color: var(--portal-col-highlight)
+  color: var(--portal-col-highlight__deprecate)
 }
 
 .thumbnail {
@@ -111,27 +111,27 @@ a {
 }
 
 .table-hover tbody tr:hover>td, .table-hover tbody tr:hover>th {
-  background-color: var(--portal-col-bkg-active);
+  background-color: var(--portal-col-bkg-active__deprecate);
 }
 
 .table td, .table th {
-  border-color: var(--portal-col-bkg-active);
+  border-color: var(--portal-col-bkg-active__deprecate);
 }
 
 .portal-section-content thead tr {
   background-color: var(--portal-primary-color-transparent);
-  color: var(--portal-col-text)
+  color: var(--portal-col-text__deprecate)
 }
 
 .portal-section-content thead th {
   background-color: var(--portal-primary-color-transparent);
-  color: var(--portal-col-text)
+  color: var(--portal-col-text__deprecate)
 }
 
 /* Table of contents in portal markdown section */
 
 .portal-editor .toc-ul, .portal-view .toc-ul {
-  background-color: var(--portal-col-bkg-active);
+  background-color: var(--portal-col-bkg-active__deprecate);
   border-radius: 0.5rem;
   opacity: 0.85;
   margin-left: 0.8rem;
@@ -155,52 +155,52 @@ a {
 }
 
 .profile .stripe {
-  border-top: 1px solid var(--portal-col-bkg-active);
+  border-top: 1px solid var(--portal-col-bkg-active__deprecate);
 }
 
 /* info alerts in the portal */
 
 .alert-info {
-  background-color: var(--portal-col-highlight-subtle);
-  border-color: var(--portal-col-highlight-subtle);
+  background-color: var(--portal-col-highlight-subtle__deprecate);
+  border-color: var(--portal-col-highlight-subtle__deprecate);
   text-shadow: none;
 }
 
 /* SVG charts */
 
 .donut-title-text, svg .title, svg .tick text, .donut-arc-count, .portal-view .donut-title-count.data, .portal-view .donut-title-count.metadata, .portal-view .donut-title-text, .portal-view .donut-title-text {
-  color: var(--portal-col-text-subtle);
-  fill: var(--portal-col-text-subtle);
+  color: var(--portal-col-text-subtle__deprecate);
+  fill: var(--portal-col-text-subtle__deprecate);
 }
 
 .tick line {
-  stroke: var(--portal-col-bkg-lighter);
+  stroke: var(--portal-col-bkg-lighter__deprecate);
 }
 
 #metric-modal .metric-chart rect.no-data, .views-metrics .metric-chart rect.no-data, .downloads-metrics .metric-chart rect.no-data {
-  fill: var(--portal-col-bkg-lighter);
+  fill: var(--portal-col-bkg-lighter__deprecate);
 }
 
 #metric-modal .metric-chart text.no-data, .views-metrics .metric-chart text.no-data, .downloads-metrics .metric-chart text.no-data {
-  fill: var(--portal-col-text);
+  fill: var(--portal-col-text__deprecate);
 }
 
 .empty-citation-list {
-  background-color: var(--portal-col-bkg-lighter);
+  background-color: var(--portal-col-bkg-lighter__deprecate);
 }
 
 .no-activity h3, .no-activity h4, .no-activity h5, .no-activity h6, .no-activity p, .no-activity .summary-container p, .no-activity a, .no-activity .message, .no-activity svg .title, .no-activity svg .bar-label, .profile .no-activity .packages p {
-  color: var(--portal-col-text-subtle);
-  stroke: var(--portal-col-text-subtle);
-  fill: var(--portal-col-text-subtle);
+  color: var(--portal-col-text-subtle__deprecate);
+  stroke: var(--portal-col-text-subtle__deprecate);
+  fill: var(--portal-col-text-subtle__deprecate);
 }
 
 .donut.no-activity>g .donut-arc, .donut.data.no-activity>g .donut-arc, .donut.metadata.no-activity>g .donut-arc, .donut.no-activity .donut-title-count, .donut.no-activity .donut-title-text {
-  fill: var(--portal-col-buttons)
+  fill: var(--portal-col-buttons__deprecate)
 }
 
 #metric-modal .metric-chart rect.pane, .views-metrics .metric-chart rect.pane, .downloads-metrics .metric-chart rect.pane {
-  fill: var(--portal-col-bkg-lighter);
+  fill: var(--portal-col-bkg-lighter__deprecate);
 }
 
 .portal-view #metric-modal .metric-chart .bar, .portal-view .views-metrics .metric-chart .bar, .portal-view .downloads-metrics .metric-chart .bar, .portal-view #metric-modal .metric-chart .scale_button:hover rect, .portal-view #metric-modal .metric-chart .bar, .portal-view #metric-modal .metric-chart .bar_context, .portal-view .views-metrics .metric-chart .scale_button:hover rect, .portal-view .views-metrics .metric-chart .bar, .portal-view .views-metrics .metric-chart .bar_context, .portal-view .downloads-metrics .metric-chart .scale_button:hover rect, .portal-view .downloads-metrics .metric-chart .bar, .portal-view .downloads-metrics .metric-chart .bar_context {
@@ -208,81 +208,81 @@ a {
 }
 
 #metric-modal .metric-chart text, .views-metrics .metric-chart text, .downloads-metrics .metric-chart text {
-  fill: var(--portal-col-text-subtle)
+  fill: var(--portal-col-text-subtle__deprecate)
 }
 
 #metric-modal .metric-chart .y.axis line, .views-metrics .metric-chart .y.axis line, .downloads-metrics .metric-chart .y.axis line {
-  fill: var(--portal-col-text-subtle)
+  fill: var(--portal-col-text-subtle__deprecate)
 }
 
 #metric-modal .metric-chart .scale_button rect, .views-metrics .metric-chart .scale_button rect, .downloads-metrics .metric-chart .scale_button rect {
-  fill: var(--portal-col-bkg-active)
+  fill: var(--portal-col-bkg-active__deprecate)
 }
 
 /* members page */
 
 .portal-view #Members .row-fluid:nth-child(odd) {
-  background-color: var(--portal-col-bkg-lighter)
+  background-color: var(--portal-col-bkg-lighter__deprecate)
 }
 
 /* data page */
 
 #results-view {
-  background-color: var(--portal-col-bkg);
+  background-color: var(--portal-col-bkg__deprecate);
 }
 
 .result-row:nth-child(odd) {
-  background-color: var(--portal-col-bkg-lighter);
+  background-color: var(--portal-col-bkg-lighter__deprecate);
 }
 
 .result-row {
-  border-top: 1px solid var(--portal-col-bkg-active);
+  border-top: 1px solid var(--portal-col-bkg-active__deprecate);
 }
 
 .pagination ul>li>a, .pagination ul>li>span {
-  border: 1px solid var(--portal-col-bkg-active);
-  background-color: var(--portal-col-bkg);
+  border: 1px solid var(--portal-col-bkg-active__deprecate);
+  background-color: var(--portal-col-bkg__deprecate);
 }
 
 select, .uneditable-input, input[type=text], input[type=password], input[type=datetime], input[type=datetime-local], input[type=date], input[type=month], input[type=time], input[type=week], input[type=number], input[type=email], input[type=url], input[type=tel], input[type=color], input[type=search], textarea {
-  border: 1px solid var(--portal-col-bkg-active);
-  background-color: var(--portal-col-bkg-lighter);
-  color: var(--portal-col-text)
+  border: 1px solid var(--portal-col-bkg-active__deprecate);
+  background-color: var(--portal-col-bkg-lighter__deprecate);
+  color: var(--portal-col-text__deprecate)
 }
 
 .filter-groups .filter .btn:not(.btn-filter-editor) {
-  border-color: var(--portal-col-bkg-active);
-  color: var(--portal-col-text-subtle);
-  background-color: var(--portal-col-bkg-active);
+  border-color: var(--portal-col-bkg-active__deprecate);
+  color: var(--portal-col-text-subtle__deprecate);
+  background-color: var(--portal-col-bkg-active__deprecate);
 }
 
 .filter-group-link a, .nav-tabs .filter-group-link a, .nav-tabs .filter-group-link.active a {
-  background-color: var(--portal-col-bkg);
+  background-color: var(--portal-col-bkg__deprecate);
 }
 
 .nav-tabs .filter-group-link.active a {
-  background-color: var(--portal-col-bkg-lighter);
+  background-color: var(--portal-col-bkg-lighter__deprecate);
 }
 
 .nav-tabs .filter-group-link a:hover, .filter-group-link a, .nav-tabs .filter-group-link a, .nav-tabs .filter-group-link.active a {
-  border-color: var(--portal-col-bkg-lighter);
+  border-color: var(--portal-col-bkg-lighter__deprecate);
 }
 
 .filter-group-link, .nav>li>a:focus, .nav>li>a:hover {
-  background-color: var(--portal-col-bkg-lighter);
+  background-color: var(--portal-col-bkg-lighter__deprecate);
 }
 
 .filter-group-links, .nav-tabs {
-  border-color: var(--portal-col-bkg-lighter);
+  border-color: var(--portal-col-bkg-lighter__deprecate);
 }
 
 .well {
-  color: var(--portal-col-text-subtle);
+  color: var(--portal-col-text-subtle__deprecate);
 }
 
 .catalog-metrics .badge {
-  background-color: var(--portal-col-bkg-active);
-  color: var(--portal-col-text-subtle)
+  background-color: var(--portal-col-bkg-active__deprecate);
+  color: var(--portal-col-text-subtle__deprecate)
 }
 
 /* Various elements in the portal view that need to be a little bit lighter */
@@ -300,7 +300,7 @@ select, .uneditable-input, input[type=text], input[type=password], input[type=da
 }
 
 .citations-metrics-list > .metric-table.table.table-striped.table-condensed td {
-  background-color: var(--portal-col-bkg)
+  background-color: var(--portal-col-bkg__deprecate)
 }
 
 /* nav in dataone theme */
@@ -311,14 +311,14 @@ select, .uneditable-input, input[type=text], input[type=password], input[type=da
 
 /* loading */
 .notification.loading p, .notification.loading .icon, .stripe .notification.loading i {
-  color: var(--portal-col-text-subtle)
+  color: var(--portal-col-text-subtle__deprecate)
 }
 
 /* data page search results */
 
 #results-container {
-  background-color: var(--portal-col-bkg);
+  background-color: var(--portal-col-bkg__deprecate);
 }
 .map-toggle-container {
-  background-color: var(--portal-col-bkg-lighter);
+  background-color: var(--portal-col-bkg-lighter__deprecate);
 }

--- a/src/css/portal-themes/light.css
+++ b/src/css/portal-themes/light.css
@@ -60,23 +60,23 @@
   --portal-col-tooltip-background: var(--portal-grey-7);
   --portal-col-tooltip-text: white;
 
-  --portal-col-bkg: #111827;
-  --portal-col-bkg-lighter: #1F2937;
-  --portal-col-bkg-active: #374151;
-  --portal-col-buttons: #4B5563F2;
-  --portal-col-text-subtle: #9CA3AF;
-  --portal-col-text: #F9FAFB;
-  --portal-col-highlight: #269fb9;
-  --portal-col-highlight-subtle: #0c4e66;
+  --portal-col-bkg__deprecate: #111827;
+  --portal-col-bkg-lighter__deprecate: #1F2937;
+  --portal-col-bkg-active__deprecate: #374151;
+  --portal-col-buttons__deprecate: #4B5563F2;
+  --portal-col-text-subtle__deprecate: #9CA3AF;
+  --portal-col-text__deprecate: #F9FAFB;
+  --portal-col-highlight__deprecate: #269fb9;
+  --portal-col-highlight-subtle__deprecate: #0c4e66;
 
   --portal-no-brightness-or-opacity-tweaks: 1;
 
   /* SHADOWS */
   --portal-shadow-md: 0 2px 4px 0px rgba(0, 0, 0, 0.16);
   /* Colors used in the 'loading-metrics.html' template, on Metrics page */
-  --m-chart-bkg: var(--portal-col-bkg-lighter);
-  --m-chart-lines: var(--portal-col-bkg-active);
-  --m-chart-bubble-bkg: var(--portal-col-highlight-subtle);
+  --m-chart-bkg: var(--portal-col-bkg-lighter__deprecate);
+  --m-chart-lines: var(--portal-col-bkg-active__deprecate);
+  --m-chart-bubble-bkg: var(--portal-col-highlight-subtle__deprecate);
 
   /* FONTS */
   --portal-body-font: Barlow;
@@ -87,12 +87,12 @@ body {
 }
 
 .subtle {
-  color: var(--portal-col-text-subtle);
+  color: var(--portal-col-text-subtle__deprecate);
 }
 
 .portal-view, .Portal #Content, .PortalView #Content {
-  color: var(--portal-col-text);
-  background-color: var(--portal-col-bkg-lighter);
+  color: var(--portal-col-text__deprecate);
+  background-color: var(--portal-col-bkg-lighter__deprecate);
 }
 
 body, #portal-sections {
@@ -105,7 +105,7 @@ body, #portal-sections {
 }
 
 .portal-view, .portal-view .portal-section-content, .portal-view h2, .portal-view h3, .portal-view h4, .portal-view h5, .portal-view h6 {
-  color: var(--portal-col-text);
+  color: var(--portal-col-text__deprecate);
 }
 
 .portal-view h2 {
@@ -121,35 +121,35 @@ body, #portal-sections {
 }
 
 .Portal.Editor #Navbar, .PortalView #Navbar, .Portal.Editor .navbar-inner, .PortalView .navbar-inner, .Portal .d1_nav, .PortalView .d1_nav {
-  color: var(--portal-col-text);
-  background-color: var(--portal-col-bkg-active);
+  color: var(--portal-col-text__deprecate);
+  background-color: var(--portal-col-bkg-active__deprecate);
 }
 
 .navbar-inner .nav>li>a, #nav-trigger, .header .nav li a, .Portal.Editor #Navbar .brand::before, .PortalView #Navbar .brand::before {
-  color: var(--portal-col-text);
+  color: var(--portal-col-text__deprecate);
 }
 
 .navbar-inner .nav>li>a:hover {
-  color: var(--portal-col-highlight)
+  color: var(--portal-col-highlight__deprecate)
 }
 
 #Navbar .nav .dropdown-toggle .caret {
-  border-top-color: var(--portal-col-text);
+  border-top-color: var(--portal-col-text__deprecate);
 }
 
 .Portal.Editor #Navbar #logo::after, .PortalView #Navbar #logo::after {
-  color: var(--portal-col-text-subtle);
+  color: var(--portal-col-text-subtle__deprecate);
 }
 
 .portal-view .portal-description {
-  color: var(--portal-col-text)
+  color: var(--portal-col-text__deprecate)
 }
 
 /* sign in button */
 
 .header .nav li a.btn.login {
   border-color: transparent;
-  color: var(--portal-col-text-subtle);
+  color: var(--portal-col-text-subtle__deprecate);
 }
 
 .header .nav li a.btn.login>.icon {
@@ -157,22 +157,22 @@ body, #portal-sections {
 }
 
 .navbar .login-container .login.btn {
-  color: var(--portal-col-text-subtle);
+  color: var(--portal-col-text-subtle__deprecate);
 }
 
 footer, #Footer {
-  color: var(--portal-col-text);
-  background-color: var(--portal-col-bkg);
+  color: var(--portal-col-text__deprecate);
+  background-color: var(--portal-col-bkg__deprecate);
   border: none;
 }
 
 footer .footnote, footer .adc-contact .contact-title {
-  color: var(--portal-col-text);
+  color: var(--portal-col-text__deprecate);
   opacity: 0.7;
 }
 
 a {
-  color: var(--portal-col-highlight)
+  color: var(--portal-col-highlight__deprecate)
 }
 
 .thumbnail {
@@ -182,27 +182,27 @@ a {
 }
 
 .table-hover tbody tr:hover>td, .table-hover tbody tr:hover>th {
-  background-color: var(--portal-col-bkg-active);
+  background-color: var(--portal-col-bkg-active__deprecate);
 }
 
 .table td, .table th {
-  border-color: var(--portal-col-bkg-active);
+  border-color: var(--portal-col-bkg-active__deprecate);
 }
 
 .portal-section-content thead tr {
   background-color: var(--portal-primary-color-transparent);
-  color: var(--portal-col-text)
+  color: var(--portal-col-text__deprecate)
 }
 
 .portal-section-content thead th {
   background-color: var(--portal-primary-color-transparent);
-  color: var(--portal-col-text)
+  color: var(--portal-col-text__deprecate)
 }
 
 /* Table of contents in portal markdown section */
 
 .portal-editor .toc-ul, .portal-view .toc-ul {
-  background-color: var(--portal-col-bkg-active);
+  background-color: var(--portal-col-bkg-active__deprecate);
   border-radius: 0.5rem;
   opacity: 0.85;
   margin-left: 0.8rem;
@@ -226,52 +226,52 @@ a {
 }
 
 .profile .stripe {
-  border-top: 1px solid var(--portal-col-bkg-active);
+  border-top: 1px solid var(--portal-col-bkg-active__deprecate);
 }
 
 /* info alerts in the portal */
 
 .alert-info {
-  background-color: var(--portal-col-highlight-subtle);
-  border-color: var(--portal-col-highlight-subtle);
+  background-color: var(--portal-col-highlight-subtle__deprecate);
+  border-color: var(--portal-col-highlight-subtle__deprecate);
   text-shadow: none;
 }
 
 /* SVG charts */
 
 .donut-title-text, svg .title, svg .tick text, .donut-arc-count, .portal-view .donut-title-count.data, .portal-view .donut-title-count.metadata, .portal-view .donut-title-text, .portal-view .donut-title-text {
-  color: var(--portal-col-text-subtle);
-  fill: var(--portal-col-text-subtle);
+  color: var(--portal-col-text-subtle__deprecate);
+  fill: var(--portal-col-text-subtle__deprecate);
 }
 
 .tick line {
-  stroke: var(--portal-col-bkg-lighter);
+  stroke: var(--portal-col-bkg-lighter__deprecate);
 }
 
 #metric-modal .metric-chart rect.no-data, .views-metrics .metric-chart rect.no-data, .downloads-metrics .metric-chart rect.no-data {
-  fill: var(--portal-col-bkg-lighter);
+  fill: var(--portal-col-bkg-lighter__deprecate);
 }
 
 #metric-modal .metric-chart text.no-data, .views-metrics .metric-chart text.no-data, .downloads-metrics .metric-chart text.no-data {
-  fill: var(--portal-col-text);
+  fill: var(--portal-col-text__deprecate);
 }
 
 .empty-citation-list {
-  background-color: var(--portal-col-bkg-lighter);
+  background-color: var(--portal-col-bkg-lighter__deprecate);
 }
 
 .no-activity h3, .no-activity h4, .no-activity h5, .no-activity h6, .no-activity p, .no-activity .summary-container p, .no-activity a, .no-activity .message, .no-activity svg .title, .no-activity svg .bar-label, .profile .no-activity .packages p {
-  color: var(--portal-col-text-subtle);
-  stroke: var(--portal-col-text-subtle);
-  fill: var(--portal-col-text-subtle);
+  color: var(--portal-col-text-subtle__deprecate);
+  stroke: var(--portal-col-text-subtle__deprecate);
+  fill: var(--portal-col-text-subtle__deprecate);
 }
 
 .donut.no-activity>g .donut-arc, .donut.data.no-activity>g .donut-arc, .donut.metadata.no-activity>g .donut-arc, .donut.no-activity .donut-title-count, .donut.no-activity .donut-title-text {
-  fill: var(--portal-col-buttons)
+  fill: var(--portal-col-buttons__deprecate)
 }
 
 #metric-modal .metric-chart rect.pane, .views-metrics .metric-chart rect.pane, .downloads-metrics .metric-chart rect.pane {
-  fill: var(--portal-col-bkg-lighter);
+  fill: var(--portal-col-bkg-lighter__deprecate);
 }
 
 .portal-view #metric-modal .metric-chart .bar, .portal-view .views-metrics .metric-chart .bar, .portal-view .downloads-metrics .metric-chart .bar, .portal-view #metric-modal .metric-chart .scale_button:hover rect, .portal-view #metric-modal .metric-chart .bar, .portal-view #metric-modal .metric-chart .bar_context, .portal-view .views-metrics .metric-chart .scale_button:hover rect, .portal-view .views-metrics .metric-chart .bar, .portal-view .views-metrics .metric-chart .bar_context, .portal-view .downloads-metrics .metric-chart .scale_button:hover rect, .portal-view .downloads-metrics .metric-chart .bar, .portal-view .downloads-metrics .metric-chart .bar_context {
@@ -279,81 +279,81 @@ a {
 }
 
 #metric-modal .metric-chart text, .views-metrics .metric-chart text, .downloads-metrics .metric-chart text {
-  fill: var(--portal-col-text-subtle)
+  fill: var(--portal-col-text-subtle__deprecate)
 }
 
 #metric-modal .metric-chart .y.axis line, .views-metrics .metric-chart .y.axis line, .downloads-metrics .metric-chart .y.axis line {
-  fill: var(--portal-col-text-subtle)
+  fill: var(--portal-col-text-subtle__deprecate)
 }
 
 #metric-modal .metric-chart .scale_button rect, .views-metrics .metric-chart .scale_button rect, .downloads-metrics .metric-chart .scale_button rect {
-  fill: var(--portal-col-bkg-active)
+  fill: var(--portal-col-bkg-active__deprecate)
 }
 
 /* members page */
 
 .portal-view #Members .row-fluid:nth-child(odd) {
-  background-color: var(--portal-col-bkg-lighter)
+  background-color: var(--portal-col-bkg-lighter__deprecate)
 }
 
 /* data page */
 
 #results-view {
-  background-color: var(--portal-col-bkg);
+  background-color: var(--portal-col-bkg__deprecate);
 }
 
 .result-row:nth-child(odd) {
-  background-color: var(--portal-col-bkg-lighter);
+  background-color: var(--portal-col-bkg-lighter__deprecate);
 }
 
 .result-row {
-  border-top: 1px solid var(--portal-col-bkg-active);
+  border-top: 1px solid var(--portal-col-bkg-active__deprecate);
 }
 
 .pagination ul>li>a, .pagination ul>li>span {
-  border: 1px solid var(--portal-col-bkg-active);
-  background-color: var(--portal-col-bkg);
+  border: 1px solid var(--portal-col-bkg-active__deprecate);
+  background-color: var(--portal-col-bkg__deprecate);
 }
 
 select, .uneditable-input, input[type=text], input[type=password], input[type=datetime], input[type=datetime-local], input[type=date], input[type=month], input[type=time], input[type=week], input[type=number], input[type=email], input[type=url], input[type=tel], input[type=color], input[type=search], textarea {
-  border: 1px solid var(--portal-col-bkg-active);
-  background-color: var(--portal-col-bkg-lighter);
-  color: var(--portal-col-text)
+  border: 1px solid var(--portal-col-bkg-active__deprecate);
+  background-color: var(--portal-col-bkg-lighter__deprecate);
+  color: var(--portal-col-text__deprecate)
 }
 
 .filter-groups .filter .btn:not(.btn-filter-editor) {
-  border-color: var(--portal-col-bkg-active);
-  color: var(--portal-col-text-subtle);
-  background-color: var(--portal-col-bkg-active);
+  border-color: var(--portal-col-bkg-active__deprecate);
+  color: var(--portal-col-text-subtle__deprecate);
+  background-color: var(--portal-col-bkg-active__deprecate);
 }
 
 .filter-group-link a, .nav-tabs .filter-group-link a, .nav-tabs .filter-group-link.active a {
-  background-color: var(--portal-col-bkg);
+  background-color: var(--portal-col-bkg__deprecate);
 }
 
 .nav-tabs .filter-group-link.active a {
-  background-color: var(--portal-col-bkg-lighter);
+  background-color: var(--portal-col-bkg-lighter__deprecate);
 }
 
 .nav-tabs .filter-group-link a:hover, .filter-group-link a, .nav-tabs .filter-group-link a, .nav-tabs .filter-group-link.active a {
-  border-color: var(--portal-col-bkg-lighter);
+  border-color: var(--portal-col-bkg-lighter__deprecate);
 }
 
 .filter-group-link, .nav>li>a:focus, .nav>li>a:hover {
-  background-color: var(--portal-col-bkg-lighter);
+  background-color: var(--portal-col-bkg-lighter__deprecate);
 }
 
 .filter-group-links, .nav-tabs {
-  border-color: var(--portal-col-bkg-lighter);
+  border-color: var(--portal-col-bkg-lighter__deprecate);
 }
 
 .well {
-  color: var(--portal-col-text-subtle);
+  color: var(--portal-col-text-subtle__deprecate);
 }
 
 .catalog-metrics .badge {
-  background-color: var(--portal-col-bkg-active);
-  color: var(--portal-col-text-subtle)
+  background-color: var(--portal-col-bkg-active__deprecate);
+  color: var(--portal-col-text-subtle__deprecate)
 }
 
 /* Various elements in the portal view that need to be a little bit lighter */
@@ -376,7 +376,7 @@ select, .uneditable-input, input[type=text], input[type=password], input[type=da
 }
 
 .citations-metrics-list > .metric-table.table.table-striped.table-condensed td {
-  background-color: var(--portal-col-bkg)
+  background-color: var(--portal-col-bkg__deprecate)
 }
 
 /* nav in dataone theme */
@@ -387,14 +387,14 @@ select, .uneditable-input, input[type=text], input[type=password], input[type=da
 
 /* loading */
 .notification.loading p, .notification.loading .icon, .stripe .notification.loading i {
-  color: var(--portal-col-text-subtle)
+  color: var(--portal-col-text-subtle__deprecate)
 }
 
 /* data page search results */
 
 #results-container {
-  background-color: var(--portal-col-bkg);
+  background-color: var(--portal-col-bkg__deprecate);
 }
 .map-toggle-container {
-  background-color: var(--portal-col-bkg-lighter);
+  background-color: var(--portal-col-bkg-lighter__deprecate);
 }


### PR DESCRIPTION
We're starting to apply the new color variables outside of the map context. Marking these old variables as deprecate will help us differentiate the new and old as we make incremental progress.

Fixes: #2346 