### PR TITLE
Update pin styles - ideas for further improvements

### DIFF
--- a/src/js/models/maps/assets/CesiumVectorData.js
+++ b/src/js/models/maps/assets/CesiumVectorData.js
@@ -7,42 +7,21 @@ define([
   "models/maps/AssetColor",
   "models/maps/AssetColorPalette",
   "collections/maps/VectorFilters",
+  "common/IconUtilities",
 ], function (
   _,
   Cesium,
   MapAsset,
   AssetColor,
   AssetColorPalette,
-  VectorFilters
+  VectorFilters,
+  IconUtilities
 ) {
   // Source: https://fontawesome.com/v6/icons/location-dot?f=classic&s=solid
   const PIN_SVG_STRING = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 384 512"><!--!Font Awesome Free 6.5.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M215.7 499.2C267 435 384 279.4 384 192C384 86 298 0 192 0S0 86 0 192c0 87.4 117 243 168.3 307.2c12.3 15.3 35.1 15.3 47.4 0zM192 128a64 64 0 1 1 0 128 64 64 0 1 1 0-128z"/></svg>';
   const PIN_OUTLINE_WIDTH = 30; // The width of the stroke around the pin is relative to the viewBox
   const PIN_OUTLINE_COLOR = "white";
-  const B64_START = 'data:image/svg+xml;base64,';
-  const PIN_SVG = convertFontAwesomeSvgForCesium(PIN_SVG_STRING, PIN_OUTLINE_WIDTH, PIN_OUTLINE_COLOR);
-
-  // Convert a Font Awesome SVG string to a SVG element that can be used as an image for a Cesium billboard
-  function convertFontAwesomeSvgForCesium(svgString, strokeWidth, strokeColor) {
-
-    const domParser = new DOMParser();
-    const svgElement = domParser.parseFromString(svgString, "image/svg+xml").querySelector("svg");
-
-    svgElement.removeChild(svgElement.firstChild);
-
-    svgElement.setAttribute("stroke-width", strokeWidth);
-    svgElement.setAttribute("stroke", strokeColor);
-
-    // Update the view box to accommodate the stroke width, otherwise the billboard will be clipped
-    let viewBox = svgElement.getAttribute("viewBox").split(" ");
-    viewBox[0] = parseFloat(viewBox[0]) - strokeWidth;
-    viewBox[1] = parseFloat(viewBox[1]) - strokeWidth;
-    viewBox[2] = parseFloat(viewBox[2]) + strokeWidth * 2;
-    viewBox[3] = parseFloat(viewBox[3]) + strokeWidth * 2;
-    svgElement.setAttribute("viewBox", viewBox.join(" "));
-
-    return svgElement;
-  }
+  const PIN_SVG = IconUtilities.formatSvgForCesiumBillboard(PIN_SVG_STRING, PIN_OUTLINE_WIDTH, PIN_OUTLINE_COLOR);
 
   /**
    * @classdesc A CesiumVectorData Model is a vector layer (excluding
@@ -639,7 +618,7 @@ define([
         PIN_SVG.setAttribute("height", size * 4);
         PIN_SVG.setAttribute("fill", styles.color.toCssHexString());
         entity.billboard = {
-          image: B64_START + btoa(PIN_SVG.outerHTML),
+          image: IconUtilities.svgToBase64(PIN_SVG),
           width: size,
           height: size
         };

--- a/src/js/models/maps/assets/CesiumVectorData.js
+++ b/src/js/models/maps/assets/CesiumVectorData.js
@@ -16,9 +16,33 @@ define([
   VectorFilters
 ) {
   // Source: https://fontawesome.com/v6/icons/location-dot?f=classic&s=solid
-  // !Font Awesome Free 6.5.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.
-  const PIN_SVG_STRING = "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 384 512'><path d='M215.7 499.2C267 435 384 279.4 384 192C384 86 298 0 192 0S0 86 0 192c0 87.4 117 243 168.3 307.2c12.3 15.3 35.1 15.3 47.4 0zM192 128a64 64 0 1 1 0 128 64 64 0 1 1 0-128z'/></svg>";
+  const PIN_SVG_STRING = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 384 512"><!--!Font Awesome Free 6.5.2 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M215.7 499.2C267 435 384 279.4 384 192C384 86 298 0 192 0S0 86 0 192c0 87.4 117 243 168.3 307.2c12.3 15.3 35.1 15.3 47.4 0zM192 128a64 64 0 1 1 0 128 64 64 0 1 1 0-128z"/></svg>';
+  const PIN_OUTLINE_WIDTH = 30; // The width of the stroke around the pin is relative to the viewBox
+  const PIN_OUTLINE_COLOR = "white";
   const B64_START = 'data:image/svg+xml;base64,';
+  const PIN_SVG = convertFontAwesomeSvgForCesium(PIN_SVG_STRING, PIN_OUTLINE_WIDTH, PIN_OUTLINE_COLOR);
+
+  // Convert a Font Awesome SVG string to a SVG element that can be used as an image for a Cesium billboard
+  function convertFontAwesomeSvgForCesium(svgString, strokeWidth, strokeColor) {
+
+    const domParser = new DOMParser();
+    const svgElement = domParser.parseFromString(svgString, "image/svg+xml").querySelector("svg");
+
+    svgElement.removeChild(svgElement.firstChild);
+
+    svgElement.setAttribute("stroke-width", strokeWidth);
+    svgElement.setAttribute("stroke", strokeColor);
+
+    // Update the view box to accommodate the stroke width, otherwise the billboard will be clipped
+    let viewBox = svgElement.getAttribute("viewBox").split(" ");
+    viewBox[0] = parseFloat(viewBox[0]) - strokeWidth;
+    viewBox[1] = parseFloat(viewBox[1]) - strokeWidth;
+    viewBox[2] = parseFloat(viewBox[2]) + strokeWidth * 2;
+    viewBox[3] = parseFloat(viewBox[3]) + strokeWidth * 2;
+    svgElement.setAttribute("viewBox", viewBox.join(" "));
+
+    return svgElement;
+  }
 
   /**
    * @classdesc A CesiumVectorData Model is a vector layer (excluding
@@ -608,20 +632,16 @@ define([
        * @since 2.25.0
        */
       styleBillboard: function (entity, styles) {
-        const pin = new DOMParser()
-            .parseFromString(PIN_SVG_STRING, "image/svg+xml")
-            .querySelector("svg");
-        pin.setAttribute("width", styles.markerSize);
-        pin.setAttribute("height", styles.markerSize);
-
-        const pinPath = pin.querySelector("path");
-        pinPath.setAttribute("fill", styles.color.toCssHexString());
-        pinPath.setAttribute("fill-rule", "evenodd");
-        pinPath.setAttribute("stroke", "white");
-        pinPath.setAttribute("stroke-width", styles.markerSize);
-
+        const size = styles.markerSize;
+        // Since we're converting to raster, start with a larger SVG and
+        // scale down so the resulting resolution is better
+        PIN_SVG.setAttribute("width", size * 4);
+        PIN_SVG.setAttribute("height", size * 4);
+        PIN_SVG.setAttribute("fill", styles.color.toCssHexString());
         entity.billboard = {
-          image: B64_START + btoa(pin.outerHTML),
+          image: B64_START + btoa(PIN_SVG.outerHTML),
+          width: size,
+          height: size
         };
         // To convert the automatically created billboards to points instead:
         // entity.billboard = undefined; entity.point = new

--- a/test/js/specs/unit/common/IconUtilities.spec.js
+++ b/test/js/specs/unit/common/IconUtilities.spec.js
@@ -48,5 +48,74 @@ define([
         expect(IconUtilities.sanitizeIcon("<p>svg</p>")).to.equal("svg");
       });
     });
+
+    describe("formatSvgForCesiumBillboard", () => {
+      it("returns null if svgElement is null", () => {
+        expect(IconUtilities.formatSvgForCesiumBillboard(null)).to.be.null;
+      });
+
+      it("returns svgElement with stroke properties", () => {
+        const svgString = "<svg></svg>";
+        const svgElement = document.createElement("svg");
+        const formattedSvgElement = IconUtilities.formatSvgForCesiumBillboard(svgString, 1, "black");
+        expect(formattedSvgElement.getAttribute("stroke-width")).to.equal("1");
+        expect(formattedSvgElement.getAttribute("stroke")).to.equal("black");
+      });
+
+      it("returns svgElement with viewBox adjusted", () => {
+        const svgString = "<svg viewBox='0 0 100 100'></svg>";
+        const svgElement = document.createElement("svg");
+        const formattedSvgElement = IconUtilities.formatSvgForCesiumBillboard(svgString, 1, "black");
+        expect(formattedSvgElement.getAttribute("viewBox")).to.equal("-1 -1 102 102");
+      });
+    });
+
+    describe("parseSvg", () => {
+      it("returns svg element", () => {
+        const svgString = "<svg></svg>";
+        const svgElement = IconUtilities.parseSvg(svgString);
+        expect(svgElement.tagName).to.equal("svg");
+      });
+    });
+
+    describe("removeCommentNodes", () => {
+      it("removes comment nodes", () => {
+        const svgElement = document.createElement("svg");
+        svgElement.appendChild(document.createComment("comment"));
+        IconUtilities.removeCommentNodes(svgElement);
+        expect(svgElement.childNodes.length).to.equal(0);
+      });
+    });
+
+    describe("setStrokeProperties", () => {
+      it("sets stroke properties", () => {
+        const svgElement = document.createElement("svg");
+        IconUtilities.setStrokeProperties(svgElement, 1, "black");
+        expect(svgElement.getAttribute("stroke-width")).to.equal("1");
+        expect(svgElement.getAttribute("stroke")).to.equal("black");
+      });
+    });
+
+    describe("adjustViewBox", () => {
+      it("adjusts viewBox", () => {
+        const svgElement = document.createElement("svg");
+        svgElement.setAttribute("viewBox", "0 0 100 100");
+        console.log(svgElement);
+        console.log(svgElement.getAttribute("viewBox"));
+        console.log(svgElement.getAttribute("viewBox").split(" ").map(parseFloat));
+        IconUtilities.adjustViewBox(svgElement, 1);
+        expect(svgElement.getAttribute("viewBox")).to.equal("-1 -1 102 102");
+      });
+    });
+
+    describe("svgToBase64", () => {
+      it("returns base64 encoded svg string", () => {
+        const svgElement = document.createElement("svg");
+        const base64 = IconUtilities.svgToBase64(svgElement);
+        expect(base64).to.equal("data:image/svg+xml;base64,PHN2Zz48L3N2Zz4=");
+      });
+    });
+
+
   });
 });


### PR DESCRIPTION
Changes:
- Prevent clipping at the edges of the pin image
- Pin image resolution is higher
- All the non-dynamic changes to the Font Awesome SVG happen only once, outside of the `styleBillboard` method
- Outline width is constant, scales better with changing markerSize
- Add attributes to SVG element not the PATH element
- Remove `fill-rule` (not needed)

Before:
<img width="590" alt="Lower resolution pins" src="https://github.com/NCEAS/metacatui/assets/26600641/8c79a3bf-408b-4446-bcef-dbc055100d75">

After:
<img width="590" alt="Higher resolution pins" src="https://github.com/NCEAS/metacatui/assets/26600641/f0a1f8e5-5293-4866-9715-80310e0828c2">

