### PR TITLE
Add zoom presets UI to viewfinder behind showZoomPresets flag

### DIFF
--- a/src/js/collections/maps/viewfinder/ZoomPresets.js
+++ b/src/js/collections/maps/viewfinder/ZoomPresets.js
@@ -1,0 +1,70 @@
+'use strict';
+
+define(
+  [
+    'underscore',
+    'backbone',
+    'models/maps/viewfinder/ZoomPresetModel',
+  ],
+  function (_, Backbone, ZoomPresetModel) {
+    /**
+     * @class ZoomPresets
+     * @classdesc A ZoomPresets collection is a group of ZoomPresetModel models
+     * that provide a location and list of layers to make visible when the user
+     * selects.
+     * @class ZoomPresets
+     * @classcategory Collections/Maps
+     * @extends Backbone.Collection
+     * @since x.x.x
+     * @constructor
+     */
+    const ZoomPresets = Backbone.Collection.extend(
+    /** @lends ZoomPresets.prototype */ {
+        /** @inheritdoc */
+        model: ZoomPresetModel,
+
+        /**
+         * @param {Object[]} zoomPresets The raw list of objects that represent
+         * the zoom presets, to be converted into ZoomPresetModels.
+         * @param {MapAsset[]} allLayers All of the layers available for display
+         * in the map.
+         */
+        parse({ zoomPresetObjects, allLayers }) {
+          if (isNonEmptyArray(zoomPresetObjects)) {
+            const zoomPresets = zoomPresetObjects.map(zoomPresetObj => {
+              const enabledLayerIds = [];
+              const enabledLayerLabels = [];
+              for (const layer of allLayers) {
+                if (zoomPresetObj.layerIds?.find(id => id === layer.get('layerId'))) {
+                  enabledLayerIds.push(layer.get('layerId'));
+                  enabledLayerLabels.push(layer.get('label'));
+                }
+              }
+
+              return new ZoomPresetModel({
+                description: zoomPresetObj.description,
+                enabledLayerLabels,
+                enabledLayerIds,
+                position: {
+                  latitude: zoomPresetObj.latitude,
+                  longitude: zoomPresetObj.longitude,
+                  height: zoomPresetObj.height
+                },
+                title: zoomPresetObj.title,
+              }, { parse: true });
+            });
+
+            return zoomPresets;
+          }
+
+          return [];
+        },
+      }
+    );
+
+    function isNonEmptyArray(a) {
+      return a && a.length && Array.isArray(a);
+    }
+
+    return ZoomPresets;
+  });

--- a/src/js/models/maps/Map.js
+++ b/src/js/models/maps/Map.js
@@ -285,9 +285,7 @@ define([
 
             if (isNonEmptyArray(config.zoomPresets)) {
               const zoomPresets = config.zoomPresets.map(zoomPresetObj => {
-                const allLayers = this.get('layers')?.models ?? this.get('layerCategories')
-                  .getMapAssets().map(assets => assets.models).flat();
-
+                const allLayers = this.getAllLayers();
                 const enabledLayerIds = [];
                 const enabledLayerLabels = [];
                 for (const layer of allLayers) {
@@ -395,6 +393,24 @@ define([
           return this.get("layerCategories").getMapAssets();
         } else if (this.has("layers")) {
           return [this.get("layers")];
+        }
+        return [];
+      },
+
+      /**
+       * Get all of the layers regardless of presences of layerCategories in a
+       * flat list of MapAsset models.
+       * @returns {MapAsset[]} All of the layers, or empty array if no layers
+       * are configured.
+       */
+      getAllLayers() {
+        if (this.has("layerCategories")) {
+          return this.get("layerCategories")
+            .getMapAssets()
+            .map(assets => assets.models)
+            .flat();
+        } else if (this.has("layers")) {
+          return this.get("layers").models;
         }
         return [];
       },

--- a/src/js/models/maps/Map.js
+++ b/src/js/models/maps/Map.js
@@ -67,8 +67,6 @@ define([
        * viewfinder UI and viewfinder button in the toolbar. The ViewfinderView
        * requires a Google Maps API key present in the AppModel. In order to 
        * work properly the Geocoding API and Places API must be enabled. 
-       * @property {Boolean} [showZoomPresets=false] - Whether or not to show
-       * the zoom to preset location and layers UI within the viewfinder UI and
        * @property {Boolean} [toolbarOpen=false] - Whether or not the toolbar is
        * open when the map is initialized. Set to false by default, so that the
        * toolbar is hidden by default.
@@ -196,9 +194,6 @@ define([
        * home button in the toolbar. True by default.
        * @property {Boolean} [showViewfinder=false] - Whether or not to show the
        * viewfinder UI and viewfinder button in the toolbar. Defaults to false.
-       * @property {Boolean} [showZoomPresets=false] - Whether or not to show 
-       * the zoom to predefined location and layers UI within the viewfinder UI.
-       * Defaults to false.
        * @property {Boolean} [toolbarOpen=false] - Whether or not the toolbar is
        * open when the map is initialized. Set to false by default, so that the
        * toolbar is hidden by default.
@@ -244,7 +239,6 @@ define([
           showLayerList: true,
           showHomeButton: true,
           showViewfinder: false,
-          showZoomPresets: false,
           toolbarOpen: false,
           showScaleBar: true,
           showFeatureInfo: true,

--- a/src/js/models/maps/Map.js
+++ b/src/js/models/maps/Map.js
@@ -93,8 +93,9 @@ define([
        * @property {String} [globeBaseColor=null] - The base color of the globe when no
        * layer is shown.
        * @property {ZoomPresetModel[]} [zoomPresets=[]] - Predefined list of
-       * locations with an enabled list of layer IDs to be showin the zoom
-       * presets UI.
+       * locations with an enabled list of layer IDs to be shown the zoom
+       * presets UI. Requires `showViewfinder` to be true as this UI appears
+       * within the ViewfinderView. 
        *
        * @example
        * {

--- a/src/js/models/maps/Map.js
+++ b/src/js/models/maps/Map.js
@@ -402,6 +402,7 @@ define([
        * flat list of MapAsset models.
        * @returns {MapAsset[]} All of the layers, or empty array if no layers
        * are configured.
+       * @since x.x.x
        */
       getAllLayers() {
         if (this.has("layerCategories")) {

--- a/src/js/models/maps/viewfinder/ViewfinderModel.js
+++ b/src/js/models/maps/viewfinder/ViewfinderModel.js
@@ -6,7 +6,8 @@ define(
     'backbone',
     'cesium',
     'models/geocoder/GeocoderSearch',
-    'models/maps/GeoPoint'],
+    'models/maps/GeoPoint'
+  ],
   (_, Backbone, Cesium, GeocoderSearch, GeoPoint) => {
     const EMAIL = MetacatUI.appModel.get('emailContact');
     const NO_RESULTS_MESSAGE = 'No search results found, try using another place name.';
@@ -50,6 +51,13 @@ define(
       initialize({ mapModel }) {
         this.geocoderSearch = new GeocoderSearch();
         this.mapModel = mapModel;
+        this.allLayers = this.mapModel.get('layers')?.models ?? this.mapModel
+          .get('layerCategories')
+          .getMapAssets()
+          .map(assets => assets.models)
+          .flat();
+
+        this.set('zoomPresets', mapModel.get('zoomPresets'));
       },
 
       /** 
@@ -144,6 +152,21 @@ define(
             coords.north,
           )
         });
+      },
+
+      /**
+       * Select a ZoomPresetModel from the list of presets and navigate there.
+       * @param {ZoomPresetModel} preset A user selected preset for which to 
+       * enable layers and navigate.
+       */
+      selectZoomPreset(preset) {
+        const enabledLayerIds = preset.get('enabledLayerIds');
+        for (const layer of this.allLayers) {
+          const isVisible = enabledLayerIds.includes(layer.get('layerId'));
+          layer.set('visible', isVisible);
+        }
+
+        this.mapModel.zoomTo(preset.get('geoPoint'));
       },
 
       /**

--- a/src/js/models/maps/viewfinder/ViewfinderModel.js
+++ b/src/js/models/maps/viewfinder/ViewfinderModel.js
@@ -41,6 +41,7 @@ define(
           focusIndex: -1,
           predictions: [],
           query: '',
+          zoomPresets: [],
         }
       },
 

--- a/src/js/models/maps/viewfinder/ViewfinderModel.js
+++ b/src/js/models/maps/viewfinder/ViewfinderModel.js
@@ -54,7 +54,7 @@ define(
         this.mapModel = mapModel;
         this.allLayers = this.mapModel.getAllLayers();
 
-        this.set('zoomPresets', mapModel.get('zoomPresets'));
+        this.set('zoomPresets', mapModel.get('zoomPresetsCollection')?.models || []);
       },
 
       /** 

--- a/src/js/models/maps/viewfinder/ViewfinderModel.js
+++ b/src/js/models/maps/viewfinder/ViewfinderModel.js
@@ -51,11 +51,7 @@ define(
       initialize({ mapModel }) {
         this.geocoderSearch = new GeocoderSearch();
         this.mapModel = mapModel;
-        this.allLayers = this.mapModel.get('layers')?.models ?? this.mapModel
-          .get('layerCategories')
-          .getMapAssets()
-          .map(assets => assets.models)
-          .flat();
+        this.allLayers = this.mapModel.getAllLayers();
 
         this.set('zoomPresets', mapModel.get('zoomPresets'));
       },
@@ -156,6 +152,8 @@ define(
 
       /**
        * Select a ZoomPresetModel from the list of presets and navigate there.
+       * This function hides all layers that are not to be visible according to
+       * the ZoomPresetModel configuration.
        * @param {ZoomPresetModel} preset A user selected preset for which to 
        * enable layers and navigate.
        */
@@ -163,6 +161,7 @@ define(
         const enabledLayerIds = preset.get('enabledLayerIds');
         for (const layer of this.allLayers) {
           const isVisible = enabledLayerIds.includes(layer.get('layerId'));
+          // Show or hide the layer according to the preset.
           layer.set('visible', isVisible);
         }
 

--- a/src/js/models/maps/viewfinder/ZoomPresetModel.js
+++ b/src/js/models/maps/viewfinder/ZoomPresetModel.js
@@ -19,8 +19,10 @@ define(['underscore', 'backbone',], (_, Backbone) => {
        * including height information.
        * @property {string} description A brief description of the layers and
        * location.
-       * @property {string[]} enabledLayers A list of layer identifiers which are 
-       * to be enabled for this preset.
+       * @property {string[]} enabledLayerIds A list of layer IDs which are to
+       * be enabled for this preset.
+       * @property {string[]} enabledLayerLabels A list of layer labels which
+       * are enabled for this preset.
        */
 
       /**
@@ -32,6 +34,7 @@ define(['underscore', 'backbone',], (_, Backbone) => {
           title: '',
           geoPoint: null,
           description: '',
+          enabledLayerLabels: [],
           enabledLayers: [],
         }
       },

--- a/src/js/models/maps/viewfinder/ZoomPresetModel.js
+++ b/src/js/models/maps/viewfinder/ZoomPresetModel.js
@@ -1,44 +1,60 @@
 'use strict';
 
-define(['underscore', 'backbone',], (_, Backbone) => {
-  /**
-  * @class ZoomPresetModel
-  * @classdesc ZoomPresetModel represents a point of interest on a map that can
-  * be configured within a MapView.
-  * @classcategory Models/Maps
-  * @extends Backbone.Model
-  * @since x.x.x
-  */
-  const ZoomPresetModel = Backbone.Model.extend(
+define(
+  ['underscore', 'backbone', 'models/maps/GeoPoint'],
+  (_, Backbone, GeoPoint) => {
+    /**
+    * @class ZoomPresetModel
+    * @classdesc ZoomPresetModel represents a point of interest on a map that can
+    * be configured within a MapView.
+    * @classcategory Models/Maps
+    * @extends Backbone.Model
+    * @since x.x.x
+    */
+    const ZoomPresetModel = Backbone.Model.extend(
     /** @lends ZoomPresetModel.prototype */ {
 
-      /**
-       * @typedef {Object} ZoomPresetModelOptions
-       * @property {string} title The displayed title for the preset.
-       * @property {GeoPoint} geoPoint The location representing this preset,
-       * including height information.
-       * @property {string} description A brief description of the layers and
-       * location.
-       * @property {string[]} enabledLayerIds A list of layer IDs which are to
-       * be enabled for this preset.
-       * @property {string[]} enabledLayerLabels A list of layer labels which
-       * are enabled for this preset.
-       */
+        /**
+         * @typedef {Object} ZoomPresetModelOptions
+         * @property {string} title The displayed title for the preset.
+         * @property {GeoPoint} geoPoint The location representing this preset,
+         * including height information.
+         * @property {string} description A brief description of the layers and
+         * location.
+         * @property {string[]} enabledLayerIds A list of layer IDs which are to
+         * be enabled for this preset.
+         * @property {string[]} enabledLayerLabels A list of layer labels which
+         * are enabled for this preset.
+         */
 
-      /**
-       * @name ZoomPresetModel#defaults
-       * @type {ZoomPresetModelOptions}
-       */
-      defaults() {
-        return {
-          description: '',
-          enabledLayerIds: [],
-          enabledLayerLabels: [],
-          geoPoint: null,
-          title: '',
-        }
-      },
-    });
+        /**
+         * @name ZoomPresetModel#defaults
+         * @type {ZoomPresetModelOptions}
+         */
+        defaults() {
+          return {
+            description: '',
+            enabledLayerIds: [],
+            enabledLayerLabels: [],
+            geoPoint: null,
+            title: '',
+          }
+        },
 
-  return ZoomPresetModel;
-});
+        /**
+         * @param {Object} position The latitude, longitude, and height of this
+         * ZoomPresetModel's GeoPoint.
+         */
+        parse({ position, ...rest }) {
+          const geoPoint = new GeoPoint({
+            latitude: position.latitude,
+            longitude: position.longitude,
+            height: position.height
+          });
+
+          return { geoPoint, ...rest };
+        },
+      });
+
+    return ZoomPresetModel;
+  });

--- a/src/js/models/maps/viewfinder/ZoomPresetModel.js
+++ b/src/js/models/maps/viewfinder/ZoomPresetModel.js
@@ -31,11 +31,11 @@ define(['underscore', 'backbone',], (_, Backbone) => {
        */
       defaults() {
         return {
-          title: '',
-          geoPoint: null,
           description: '',
+          enabledLayerIds: [],
           enabledLayerLabels: [],
-          enabledLayers: [],
+          geoPoint: null,
+          title: '',
         }
       },
     });

--- a/src/js/templates/maps/viewfinder/viewfinder-zoom-preset.html
+++ b/src/js/templates/maps/viewfinder/viewfinder-zoom-preset.html
@@ -6,11 +6,11 @@
     <%= preset.description %>
   </div>
   <div class="<%= classNames.layers %>">
-    <% _.each(preset.enabledLayers, enabledLayer=> { %>
-      <div class="<%= classNames.layer %>" title="<%= enabledLayer %>">
+    <% _.each(preset.enabledLayerLabels, label => { %>
+      <div class="<%= classNames.layer %>" title="<%= label %>">
         <div class="<%= classNames.layerContent %>">
           <i class="icon icon-eye-open"></i>
-          <%= enabledLayer %>
+          <%= label %>
         </div>
       </div>
       <% }); %>

--- a/src/js/templates/maps/viewfinder/viewfinder.html
+++ b/src/js/templates/maps/viewfinder/viewfinder.html
@@ -1,3 +1,4 @@
 <div class="toolbar__content-header">Viewfinder</div>
 
 <div class="<%= classNames.searchView %>"></div>
+<div class="<%= classNames.zoomPresetsView %>"></div>

--- a/src/js/views/maps/viewfinder/SearchView.js
+++ b/src/js/views/maps/viewfinder/SearchView.js
@@ -89,7 +89,7 @@ define(
       },
 
       /**
-       * Helper function to focus input on the searh query input and ensure
+       * Helper function to focus input on the search query input and ensure
        * that the cursor is at the end of the text (as opposed to the beginning
        * which appears to be the default jQuery behavior).
        */

--- a/src/js/views/maps/viewfinder/ViewfinderView.js
+++ b/src/js/views/maps/viewfinder/ViewfinderView.js
@@ -6,6 +6,7 @@ define(
     'backbone',
     'text!templates/maps/viewfinder/viewfinder.html',
     'views/maps/viewfinder/SearchView',
+    'views/maps/viewfinder/ZoomPresetsListView',
     'views/maps/viewfinder/ExpansionPanelView',
     'models/maps/viewfinder/ExpansionPanelsModel',
     'models/maps/viewfinder/ViewfinderModel',
@@ -15,6 +16,7 @@ define(
     Backbone,
     Template,
     SearchView,
+    ZoomPresetsListView,
     ExpansionPanelView,
     ExpansionPanelsModel,
     ViewfinderModel,
@@ -24,6 +26,7 @@ define(
     // The HTML classes to use for this view's HTML elements.
     const CLASS_NAMES = {
       searchView: `${BASE_CLASS}__search`,
+      zoomPresetsView: `${BASE_CLASS}__zoom-presets`,
     };
 
 
@@ -66,7 +69,11 @@ define(
        */
       initialize({ model: mapModel }) {
         this.viewfinderModel = new ViewfinderModel({ mapModel });
-        this.panelsModel = new ExpansionPanelsModel();
+        this.panelsModel = new ExpansionPanelsModel({ isMulti: true });
+      },
+
+      getZoomPresets() {
+        return this.$el.find(`.${CLASS_NAMES.zoomPresetsView}`);
       },
 
       /**
@@ -77,14 +84,42 @@ define(
         return this.$el.find(`.${CLASS_NAMES.searchView}`);
       },
 
+      /**
+       * Helper function to focus input on the search query input and ensure
+       * that the cursor is at the end of the text (as opposed to the beginning
+       * which appears to be the default jQuery behavior).
+       */
+      focusInput() {
+        this.searchView.focusInput();
+      },
+
+      /** Render child ZoomPresetsView and append to DOM. */
+      renderZoomPresetsView() {
+        const zoomPresetsListView = new ZoomPresetsListView({
+          zoomPresets: this.viewfinderModel.get('zoomPresets'),
+          selectZoomPreset: preset => {
+            this.viewfinderModel.selectZoomPreset(preset);
+          },
+        });
+        const expansionPanel = new ExpansionPanelView({
+          contentViewInstance: zoomPresetsListView,
+          icon: 'icon-plane',
+          panelsModel: this.panelsModel,
+          title: 'Zoom to...',
+        });
+        expansionPanel.render();
+
+        this.getZoomPresets().append(expansionPanel.el);
+      },
+
       /** Render child SearchView and append to DOM. */
       renderSearchView() {
-        const searchView = new SearchView({
+        this.searchView = new SearchView({
           viewfinderModel: this.viewfinderModel,
         });
-        searchView.render();
+        this.searchView.render();
 
-        this.getSearch().append(searchView.el);
+        this.getSearch().append(this.searchView.el);
       },
 
       /**
@@ -96,6 +131,9 @@ define(
         this.el.innerHTML = _.template(Template)(this.templateVars);
 
         this.renderSearchView();
+        if (this.model.get('showZoomPresets')) {
+          this.renderZoomPresetsView();
+        }
       },
     });
 

--- a/src/js/views/maps/viewfinder/ViewfinderView.js
+++ b/src/js/views/maps/viewfinder/ViewfinderView.js
@@ -131,7 +131,7 @@ define(
         this.el.innerHTML = _.template(Template)(this.templateVars);
 
         this.renderSearchView();
-        if (this.model.get('showZoomPresets')) {
+        if (this.model.get('showZoomPresets') && this.viewfinderModel.get('zoomPresets').length) {
           this.renderZoomPresetsView();
         }
       },

--- a/src/js/views/maps/viewfinder/ViewfinderView.js
+++ b/src/js/views/maps/viewfinder/ViewfinderView.js
@@ -99,7 +99,10 @@ define(
         this.searchView.focusInput();
       },
 
-      /** Render child ZoomPresetsView and append to DOM. */
+      /**
+       * Render child ZoomPresetsView and append to DOM.
+       * @since x.x.x
+       */
       renderZoomPresetsView() {
         const zoomPresetsListView = new ZoomPresetsListView({
           zoomPresets: this.viewfinderModel.get('zoomPresets'),

--- a/src/js/views/maps/viewfinder/ViewfinderView.js
+++ b/src/js/views/maps/viewfinder/ViewfinderView.js
@@ -93,6 +93,7 @@ define(
        * Helper function to focus input on the search query input and ensure
        * that the cursor is at the end of the text (as opposed to the beginning
        * which appears to be the default jQuery behavior).
+       * @since x.x.x
        */
       focusInput() {
         this.searchView.focusInput();

--- a/src/js/views/maps/viewfinder/ViewfinderView.js
+++ b/src/js/views/maps/viewfinder/ViewfinderView.js
@@ -140,7 +140,7 @@ define(
         this.el.innerHTML = _.template(Template)(this.templateVars);
 
         this.renderSearchView();
-        if (this.model.get('showZoomPresets') && this.viewfinderModel.get('zoomPresets').length) {
+        if (this.viewfinderModel.get('zoomPresets').length) {
           this.renderZoomPresetsView();
         }
       },

--- a/src/js/views/maps/viewfinder/ViewfinderView.js
+++ b/src/js/views/maps/viewfinder/ViewfinderView.js
@@ -72,6 +72,11 @@ define(
         this.panelsModel = new ExpansionPanelsModel({ isMulti: true });
       },
 
+      /**
+       * Get the ZoomPresetsView element.
+       * @returns {JQuery} The ZoomPresetsView element.
+       * @since x.x.x
+       */
       getZoomPresets() {
         return this.$el.find(`.${CLASS_NAMES.zoomPresetsView}`);
       },

--- a/src/js/views/maps/viewfinder/ZoomPresetView.js
+++ b/src/js/views/maps/viewfinder/ZoomPresetView.js
@@ -88,7 +88,7 @@ define(
           this.templateVars.preset = {
             title: preset.get('title'),
             description: preset.get('description'),
-            enabledLayers: preset.get('enabledLayers'),
+            enabledLayerLabels: preset.get('enabledLayerLabels'),
           };
         },
 

--- a/test/config/tests.json
+++ b/test/config/tests.json
@@ -12,6 +12,7 @@
     "./js/specs/unit/views/maps/viewfinder/ZoomPresetView.spec.js",
     "./js/specs/unit/views/maps/viewfinder/ZoomPresetsListView.spec.js",
     "./js/specs/unit/views/maps/viewfinder/SearchView.spec.js",
+    "./js/specs/unit/views/maps/viewfinder/ViewfinderView.spec.js",
     "./js/specs/unit/collections/SolrResults.spec.js",
     "./js/specs/unit/models/Search.spec.js",
     "./js/specs/unit/models/filters/Filter.spec.js",

--- a/test/js/specs/unit/models/maps/Map.spec.js
+++ b/test/js/specs/unit/models/maps/Map.spec.js
@@ -49,7 +49,7 @@ define(
             layers: [{}]
           });
 
-          expect(map.get("zoomPresets")[0].get('title')).to.equal('Zoom 1');
+          expect(map.get("zoomPresetsCollection").at(0).get('title')).to.equal('Zoom 1');
         });
 
         it("sets zoomPresets from config with layerCategories", () => {
@@ -65,7 +65,7 @@ define(
             layerCategories: [{ layers: [{}] }]
           });
 
-          expect(map.get("zoomPresets")[0].get('title')).to.equal('Zoom 1');
+          expect(map.get("zoomPresetsCollection").at(0).get('title')).to.equal('Zoom 1');
         });
 
         it("filters out enabledLayerIds for layerIds that do not exist", () => {
@@ -82,7 +82,7 @@ define(
           });
 
           // Deep equality check with .to.eql
-          expect(map.get("zoomPresets")[0].get('enabledLayerIds')).to.eql(['layer1']);
+          expect(map.get("zoomPresetsCollection").at(0).get('enabledLayerIds')).to.eql(['layer1']);
         });
       });
 

--- a/test/js/specs/unit/models/maps/Map.spec.js
+++ b/test/js/specs/unit/models/maps/Map.spec.js
@@ -1,48 +1,109 @@
-define([
-  "models/maps/Map",
-  "models/maps/AssetCategory",
-  "collections/maps/AssetCategories",
-  "collections/maps/MapAssets",
-  "/test/js/specs/shared/clean-state.js",
-], (Map, AssetCategory, AssetCategories, MapAssets, cleanState) => {
-  const expect = chai.expect;
+define(
+  [
+    "models/maps/Map",
+    "models/maps/AssetCategory",
+    "collections/maps/AssetCategories",
+    "collections/maps/MapAssets",
+    "models/maps/viewfinder/ZoomPresetModel",
+    "models/maps/GeoPoint",
+    "/test/js/specs/shared/clean-state.js",
+  ],
+  (
+    Map,
+    AssetCategory,
+    AssetCategories,
+    MapAssets,
+    ZoomPresetModel,
+    GeoPoint,
+    cleanState,
+  ) => {
+    const expect = chai.expect;
 
-  describe("Map Test Suite", () => {
-    const state = cleanState(() => {
-      return { model: new Map() };
-    }, beforeEach);
+    describe("Map Test Suite", () => {
+      const state = cleanState(() => {
+        return { model: new Map() };
+      }, beforeEach);
 
-    describe("Initialization", () => {
-      it("creates an Map instance", () => {
-        expect(state.model).to.be.instanceof(Map);
+      describe("Initialization", () => {
+        it("creates an Map instance", () => {
+          expect(state.model).to.be.instanceof(Map);
+        });
+
+        it("ignores layers if layerCategories exist", () => {
+          const map = new Map({ layerCategories: [{ layers: [{}] }], layers: [{}] });
+
+          expect(map.has("layerCategories")).to.be.true;
+          expect(map.has("layers")).to.be.false;
+        });
+
+        it("sets zoomPresets from config with layers", () => {
+          const map = new Map({
+            zoomPresets: [{
+              latitude: 55,
+              longitude: 66,
+              height: 77,
+              description: 'Some zoom preset',
+              title: 'Zoom 1',
+              layerIds: ['layer1'],
+            }],
+            layers: [{}]
+          });
+
+          expect(map.get("zoomPresets")[0].get('title')).to.equal('Zoom 1');
+        });
+
+        it("sets zoomPresets from config with layerCategories", () => {
+          const map = new Map({
+            zoomPresets: [{
+              latitude: 55,
+              longitude: 66,
+              height: 77,
+              description: 'Some zoom preset',
+              title: 'Zoom 1',
+              layerIds: ['layer1'],
+            }],
+            layerCategories: [{ layers: [{}] }]
+          });
+
+          expect(map.get("zoomPresets")[0].get('title')).to.equal('Zoom 1');
+        });
+
+        it("filters out enabledLayerIds for layerIds that do not exist", () => {
+          const map = new Map({
+            zoomPresets: [{
+              latitude: 55,
+              longitude: 66,
+              height: 77,
+              description: 'Some zoom preset',
+              title: 'Zoom 1',
+              layerIds: ['layer1', 'layer2'],
+            }],
+            layerCategories: [{ layers: [{ layerId: 'layer1' }] }]
+          });
+
+          // Deep equality check with .to.eql
+          expect(map.get("zoomPresets")[0].get('enabledLayerIds')).to.eql(['layer1']);
+        });
       });
 
-      it("ignores layers if layerCategories exist", () => {
-        const map = new Map({ layerCategories: [{ layers: [{}] }], layers: [{}] });
+      describe("getLayerGroups", () => {
+        it("returns an array of MapAssets", () => {
+          const layers = new MapAssets([{}]);
+          state.model.set("layers", layers);
 
-        expect(map.has("layerCategories")).to.be.true;
-        expect(map.has("layers")).to.be.false;
-      });
-    });
+          expect(state.model.getLayerGroups()).to.have.lengthOf(1);
+          expect(state.model.getLayerGroups()[0]).to.equal(layers);
+        });
 
-    describe("getLayerGroups", () => {
-      it("returns an array of MapAssets", () => {
-        const layers = new MapAssets([{}]);
-        state.model.set("layers", layers);
+        it("ignores layers if layerCategories exist", () => {
+          state.model.set("layers", new MapAssets([{}]));
 
-        expect(state.model.getLayerGroups()).to.have.lengthOf(1);
-        expect(state.model.getLayerGroups()[0]).to.equal(layers);
-      });
-      
-      it("ignores layers if layerCategories exist", () => {
-        state.model.set("layers", new MapAssets([{}]));
+          const category1 = new AssetCategory({ layers: [{}] });
+          const category2 = new AssetCategory({ layers: [{}] });
+          state.model.set("layerCategories", new AssetCategories([category1, category2]));
 
-        const category1 = new AssetCategory({ layers: [{}] });
-        const category2 = new AssetCategory({ layers: [{}] });
-        state.model.set("layerCategories", new AssetCategories([category1, category2]));
-
-        expect(state.model.getLayerGroups()).to.have.lengthOf(2);
+          expect(state.model.getLayerGroups()).to.have.lengthOf(2);
+        });
       });
     });
   });
-});

--- a/test/js/specs/unit/models/maps/viewfinder/ViewfinderModel.spec.js
+++ b/test/js/specs/unit/models/maps/viewfinder/ViewfinderModel.spec.js
@@ -7,17 +7,37 @@ define(
     'models/maps/Map',
     'models/geocoder/Prediction',
     'models/geocoder/GeocodedLocation',
+    'models/maps/viewfinder/ZoomPresetModel',
+    'models/maps/GeoPoint',
     // The file extension is required for files loaded from the /test directory.
     '/test/js/specs/shared/clean-state.js',
   ],
-  (_, ViewfinderModel, Map, Prediction, GeocodedLocation, cleanState) => {
+  (
+    _,
+    ViewfinderModel,
+    Map,
+    Prediction,
+    GeocodedLocation,
+    ZoomPresetModel,
+    GeoPoint,
+    cleanState,
+  ) => {
     const should = chai.should();
     const expect = chai.expect;
 
     describe('ViewfinderModel Test Suite', () => {
       const state = cleanState(() => {
         const sandbox = sinon.createSandbox();
-        const model = new ViewfinderModel({ mapModel: new Map() });
+        const mapModel = new Map({
+          zoomPresets: [{
+            latitude: 55,
+            longitude: 66,
+            height: 77,
+            layerIds: ['layer1'],
+          }],
+          layers: [{ layerId: 'layer1' }, { layerId: 'layer2' }],
+        });
+        const model = new ViewfinderModel({ mapModel });
         const zoomSpy = sinon.spy(model.mapModel, 'zoomTo');
         const autocompleteSpy = sandbox.stub(model.geocoderSearch, 'autocomplete').returns([])
         const geocodeSpy = sandbox.stub(model.geocoderSearch, 'geocode').returns([]);
@@ -54,6 +74,34 @@ define(
 
       it('creates a ViewfinderModel instance', () => {
         state.model.should.be.instanceof(ViewfinderModel);
+      });
+
+      it('sets allLayers field from Map model layers', () => {
+        const model = new ViewfinderModel({
+          mapModel: new Map({ layers: [{ layerId: 'layer1' }] })
+        });
+
+        expect(model.allLayers[0].get('layerId')).to.equal('layer1');
+      });
+
+      it('sets allLayers field from Map model layerCategories', () => {
+        const model = new ViewfinderModel({
+          mapModel: new Map({
+            layerCategories: [{ layers: { layerId: 'layer1' } }],
+          })
+        });
+
+        expect(model.allLayers[0].get('layerId')).to.equal('layer1');
+      });
+
+      it('sets zoom presets field from Map model', () => {
+        const zoomPresets = [];
+        const model = new ViewfinderModel({
+          mapModel: new Map({ zoomPresets }),
+        });
+
+        // Reference equality.
+        expect(model.get('zoomPresets')).to.equal(zoomPresets);
       });
 
       describe('autocomplete search', () => {
@@ -309,6 +357,45 @@ define(
           await state.model.selectPrediction();
 
           expect(state.geocodeSpy.callCount).to.equal(0);
+        });
+      });
+
+      describe('selecting a zoom preset', () => {
+        it('shows all enabled layers', () => {
+          const setSpy = state.sandbox.spy(state.model.allLayers[0], 'set');
+          state.model.selectZoomPreset(new ZoomPresetModel({
+            latitude: 55,
+            longitude: 66,
+            height: 72,
+            enabledLayerIds: ['layer1']
+          }));
+
+          expect(setSpy.callCount).to.equal(1);
+          expect(setSpy.getCall(0).args).to.eql(['visible', true]);
+        });
+
+        it('hides all layers not inlcluded in enabled layers', () => {
+          const setSpy = state.sandbox.spy(state.model.allLayers[1], 'set');
+          state.model.selectZoomPreset(new ZoomPresetModel({
+            latitude: 55,
+            longitude: 66,
+            height: 72,
+            enabledLayerIds: ['layer1']
+          }));
+
+          expect(setSpy.callCount).to.equal(1);
+          expect(setSpy.getCall(0).args).to.eql(['visible', false]);
+        });
+
+        it('zooms to the location on the map', () => {
+          const geoPoint = new GeoPoint();
+          state.model.selectZoomPreset(new ZoomPresetModel({
+            enabledLayerIds: ['layer1'],
+            geoPoint,
+          }));
+
+          expect(state.zoomSpy.callCount).to.equal(1);
+          expect(state.zoomSpy.getCall(0).args[0]).to.eql(geoPoint);
         });
       });
 

--- a/test/js/specs/unit/views/maps/viewfinder/ViewfinderView.spec.js
+++ b/test/js/specs/unit/views/maps/viewfinder/ViewfinderView.spec.js
@@ -5,6 +5,7 @@ define(
     'underscore',
     'views/maps/viewfinder/ViewfinderView',
     'models/maps/Map',
+    'models/maps/viewfinder/ZoomPresetModel',
     // The file extension is required for files loaded from the /test directory.
     '/test/js/specs/unit/views/maps/viewfinder/ViewfinderViewHarness.js',
     '/test/js/specs/shared/clean-state.js',
@@ -13,6 +14,7 @@ define(
     _,
     ViewfinderView,
     Map,
+    ZoomPresetModel,
     ViewfinderViewHarness,
     cleanState,
   ) => {
@@ -50,7 +52,12 @@ define(
       });
 
       it('shows zoom presets UI when enabled in config', () => {
-        const view = new ViewfinderView({ model: new Map({ showZoomPresets: true }) });
+        const view = new ViewfinderView({
+          model: new Map({
+            showZoomPresets: true,
+            zoomPresets: [new ZoomPresetModel()]
+          })
+        });
         const harness = new ViewfinderViewHarness(view);
         view.render();
 

--- a/test/js/specs/unit/views/maps/viewfinder/ViewfinderView.spec.js
+++ b/test/js/specs/unit/views/maps/viewfinder/ViewfinderView.spec.js
@@ -1,0 +1,64 @@
+'use strict';
+
+define(
+  [
+    'underscore',
+    'views/maps/viewfinder/ViewfinderView',
+    'models/maps/Map',
+    // The file extension is required for files loaded from the /test directory.
+    '/test/js/specs/unit/views/maps/viewfinder/ViewfinderViewHarness.js',
+    '/test/js/specs/shared/clean-state.js',
+  ],
+  (
+    _,
+    ViewfinderView,
+    Map,
+    ViewfinderViewHarness,
+    cleanState,
+  ) => {
+    const should = chai.should();
+    const expect = chai.expect;
+
+    describe('ViewfinderView Test Suite', () => {
+      const state = cleanState(() => {
+        const sandbox = sinon.createSandbox();
+        const view = new ViewfinderView({ model: new Map() });
+        const harness = new ViewfinderViewHarness(view);
+        view.render();
+
+        // Actually render the view to document to test focus events.
+        const testContainer = document.createElement("div");
+        testContainer.id = "test-container";
+        testContainer.append(view.el);
+        document.body.append(testContainer);
+
+        return {
+          harness,
+          sandbox,
+          testContainer,
+          view,
+        };
+      }, beforeEach);
+
+      afterEach(() => {
+        state.sandbox.restore();
+        state.testContainer.remove();
+      });
+
+      it('creates a ViewfinderView instance', () => {
+        state.view.should.be.instanceof(ViewfinderView);
+      });
+
+      it('shows zoom presets UI when enabled in config', () => {
+        const view = new ViewfinderView({ model: new Map({ showZoomPresets: true }) });
+        const harness = new ViewfinderViewHarness(view);
+        view.render();
+
+        expect(harness.hasZoomPresets()).to.be.true;
+      });
+
+      it('does not show zoom presets UI when disabled in config', () => {
+        expect(state.harness.hasZoomPresets()).to.be.false;
+      });
+    });
+  });

--- a/test/js/specs/unit/views/maps/viewfinder/ViewfinderView.spec.js
+++ b/test/js/specs/unit/views/maps/viewfinder/ViewfinderView.spec.js
@@ -53,7 +53,7 @@ define(
 
       it('shows zoom presets UI when enabled in config', () => {
         const view = new ViewfinderView({
-          model: new Map({ showZoomPresets: true, zoomPresets: [{}] })
+          model: new Map({ zoomPresets: [{}] })
         });
         const harness = new ViewfinderViewHarness(view);
         view.render();

--- a/test/js/specs/unit/views/maps/viewfinder/ViewfinderView.spec.js
+++ b/test/js/specs/unit/views/maps/viewfinder/ViewfinderView.spec.js
@@ -5,7 +5,7 @@ define(
     'underscore',
     'views/maps/viewfinder/ViewfinderView',
     'models/maps/Map',
-    'models/maps/viewfinder/ZoomPresetModel',
+    'collections/maps/viewfinder/ZoomPresets',
     // The file extension is required for files loaded from the /test directory.
     '/test/js/specs/unit/views/maps/viewfinder/ViewfinderViewHarness.js',
     '/test/js/specs/shared/clean-state.js',
@@ -14,7 +14,7 @@ define(
     _,
     ViewfinderView,
     Map,
-    ZoomPresetModel,
+    ZoomPresets,
     ViewfinderViewHarness,
     cleanState,
   ) => {
@@ -53,10 +53,7 @@ define(
 
       it('shows zoom presets UI when enabled in config', () => {
         const view = new ViewfinderView({
-          model: new Map({
-            showZoomPresets: true,
-            zoomPresets: [new ZoomPresetModel()]
-          })
+          model: new Map({ showZoomPresets: true, zoomPresets: [{}] })
         });
         const harness = new ViewfinderViewHarness(view);
         view.render();

--- a/test/js/specs/unit/views/maps/viewfinder/ViewfinderViewHarness.js
+++ b/test/js/specs/unit/views/maps/viewfinder/ViewfinderViewHarness.js
@@ -1,0 +1,13 @@
+'use strict';
+
+define([], function () {
+  return class ViewFinderViewHarness {
+    constructor(view) {
+      this.view = view;
+    }
+
+    hasZoomPresets() {
+      return !!this.view.getZoomPresets().html();
+    }
+  }
+});

--- a/test/js/specs/unit/views/maps/viewfinder/ZoomPresetView.spec.js
+++ b/test/js/specs/unit/views/maps/viewfinder/ZoomPresetView.spec.js
@@ -18,13 +18,14 @@ define(
       const state = cleanState(() => {
         const sandbox = sinon.createSandbox();
         const title = "Some preset";
-        const geoPoint = new GeoPoint()
-          .set('latitude', 42.33)
-          .set('longigude', -83.05)
-          .set('height', 5000);
+        const geoPoint = new GeoPoint({
+          latitude: 42.33,
+          longigude: -83.05,
+          height: 5000
+        });
         const description = "For testing the view";
-        const enabledLayers = ["Layer 1", "Layer 2"];
-        const preset = new ZoomPresetModel({ title, geoPoint, description, enabledLayers });
+        const enabledLayerLabels = ["Layer 1", "Layer 2"];
+        const preset = new ZoomPresetModel({ title, geoPoint, description, enabledLayerLabels });
         const selectCallbackSpy = sandbox.spy();
         const view = new ZoomPresetView({ preset, selectCallback: selectCallbackSpy });
         view.render();

--- a/test/js/specs/unit/views/maps/viewfinder/ZoomPresetsListView.spec.js
+++ b/test/js/specs/unit/views/maps/viewfinder/ZoomPresetsListView.spec.js
@@ -26,24 +26,24 @@ define(
         const zoomPresets = [
           new ZoomPresetModel({
             title: 'Test 1',
-            geoPoint: new GeoPoint({
+            position: {
               latitude: 11,
               longitude: 111,
               height: 5000,
-            }),
+            },
             description: 'Test 1 description',
             enabledLayers: ['Layer 1', 'Layer 2'],
-          }),
+          }, { parse: true }),
           new ZoomPresetModel({
             title: 'Test 2',
-            geoPoint: new GeoPoint({
+            position: {
               latitude: 12,
               longitude: 112,
               height: 5000,
-            }),
+            },
             description: 'Test 1 description',
             enabledLayers: ['Layer 2', 'Layer 3'],
-          }),
+          }, { parse: true }),
         ];
         const selectZoomPresetSpy = sandbox.spy();
         const view = new ZoomPresetsListView({

--- a/test/js/specs/unit/views/maps/viewfinder/ZoomPresetsListView.spec.js
+++ b/test/js/specs/unit/views/maps/viewfinder/ZoomPresetsListView.spec.js
@@ -26,19 +26,21 @@ define(
         const zoomPresets = [
           new ZoomPresetModel({
             title: 'Test 1',
-            geoPoint: new GeoPoint()
-              .set('latitude', 11)
-              .set('longitude', 111)
-              .set('height', 5000),
+            geoPoint: new GeoPoint({
+              latitude: 11,
+              longitude: 111,
+              height: 5000,
+            }),
             description: 'Test 1 description',
             enabledLayers: ['Layer 1', 'Layer 2'],
           }),
           new ZoomPresetModel({
             title: 'Test 2',
-            geoPoint: new GeoPoint()
-              .set('latitude', 12)
-              .set('longitude', 112)
-              .set('height', 5000),
+            geoPoint: new GeoPoint({
+              latitude: 12,
+              longitude: 112,
+              height: 5000,
+            }),
             description: 'Test 1 description',
             enabledLayers: ['Layer 2', 'Layer 3'],
           }),


### PR DESCRIPTION
A subsequent PR will include the appropriate style changes including polish to expansion panels and zoom preset elements. 

This change includes the changes necessary to display a function zoom presets UI, and is hidden behind a Map configuration.