### PR TITLE
Styling Polish: Fixups

### DIFF
--- a/src/css/map-view.css
+++ b/src/css/map-view.css
@@ -692,6 +692,11 @@ represents 1 unit of the given distance measurement. */
   .layers-panel__search {
     margin: 0 1.5rem;
   }
+
+  .layers-panel__layers {
+    border: solid var(--map-col-section-divider, var(--map-col-bkg-lightest__deprecate));
+    border-width: 1px 0;
+  }
 }
 
 /*****************************************************************************************
@@ -709,8 +714,6 @@ represents 1 unit of the given distance measurement. */
   grid-template-rows: auto;
   width: 100%;
   height: min-content;
-  border: solid var(--map-col-section-divider, var(--map-col-bkg-lightest__deprecate));
-  border-width: 1px 0;
 }
 
 /* A layer-item is one item in the layer-list */
@@ -861,9 +864,6 @@ represents 1 unit of the given distance measurement. */
  */
 
 .layer-category-list {
-  border: solid var(--map-col-section-divider, var(--map-col-bkg-lightest__deprecate));
-  border-width: 1px 0;
-
   .layer-category-item {
     box-shadow: 0 1px var(--map-col-item-divider, var(--map-col-bkg-lightest__deprecate)) inset;
 

--- a/src/js/views/maps/FeatureInfoView.js
+++ b/src/js/views/maps/FeatureInfoView.js
@@ -211,7 +211,7 @@ define(
                 body {
                   background-color: transparent;
                   color: var(--map-col-text-body, var(--map-col-text__deprecate));
-                  font-family: "Helvetica Nueue", "Helvetica", "Arial", "Lato", "sans serif";
+                  font-family: var(--portal-body-font, "Helvetica Nueue", "Helvetica", "Arial", "Lato", "sans serif");
                   margin: 0;
                   box-sizing: border-box;
                 }


### PR DESCRIPTION
Two very small css changes so I'll just put them in one branch.

1. #2344 : Use portal font for feature info iframe when available (Barlow for PDG)
2. #2277 : .layers-panel__layers can host either .layer-list or .layer-category-list. I needed a border for it and wasn't thinking so I added to the children instead. .layer-list is a sharable component so it caused an unwanted border in a different scenario.