### PR TITLE
Update toolbar options to reflect updated ordering and home behavior

### DIFF
--- a/src/js/models/maps/Map.js
+++ b/src/js/models/maps/Map.js
@@ -342,6 +342,16 @@ define([
       },
 
       /**
+       * Reset the visibility of all layers to the value that was in the intial
+       * configuration.
+       */
+      resetLayerVisibility: function () {
+        for (const layer of this.getAllLayers()) {
+          layer.set("visible", layer.get('originalVisibility'));
+        }
+      },
+
+      /**
        * Reset the layers to the default layers. This will set a new MapAssets
        * collection on the layer attribute.
        * @returns {MapAssets} The new layers collection.

--- a/src/js/models/maps/assets/MapAsset.js
+++ b/src/js/models/maps/assets/MapAsset.js
@@ -351,6 +351,7 @@ define([
             }
           }
 
+          this.set("originalVisibility", this.get("visible"));
           this.setListeners();
         } catch (e) {
           console.log("Error initializing a MapAsset model", e);
@@ -393,7 +394,6 @@ define([
        * @since 2.27.0
        */
       handleError: function () {
-        this.set("originalVisibility", this.get("visible"));
         this.set("visible", false);
         this.stopListening(this, "change:visible");
       },

--- a/src/js/models/maps/viewfinder/ExpansionPanelsModel.js
+++ b/src/js/models/maps/viewfinder/ExpansionPanelsModel.js
@@ -40,7 +40,7 @@ define([], () => {
        * @property {ExpansionPanelView} openedPanel The expansion panel view that 
        * should remain open.
        */
-      collapseOthers(openedPanel) {
+      maybeCollapseOthers(openedPanel) {
         const isSingleOpenMode = !this.get('isMulti');
         for (const panel of this.get('panels')) {
           if (isSingleOpenMode && panel !== openedPanel) {

--- a/src/js/views/maps/ToolbarView.js
+++ b/src/js/views/maps/ToolbarView.js
@@ -175,11 +175,7 @@ define(
             icon: 'rotate-left',
             action: function (view, model) {
               model.flyHome();
-              
-              // Reset the visibility of all layers.
-              for (const layer of model.getAllLayers()) {
-                layer.set("visible", layer.get('originalVisibility'));
-              }
+              model.resetLayerVisibility();
             },
             isVisible(model) {
               return model.get("showHomeButton");

--- a/src/js/views/maps/ToolbarView.js
+++ b/src/js/views/maps/ToolbarView.js
@@ -150,6 +150,19 @@ define(
          */
         sectionOptions: [
           {
+            label: 'Viewfinder',
+            icon: 'globe',
+            view: ViewfinderView,
+            action(view, model) {
+              const sectionEl = this;
+              view.defaultActivationAction(sectionEl);
+              sectionEl.sectionView.focusInput();
+            },
+            isVisible(model) {
+              return MetacatUI.mapKey && model.get("showViewfinder");
+            },
+          },
+          {
             label: 'Layers',
             icon: '<svg xmlns="http://www.w3.org/2000/svg" fill="currentColor" viewBox="0 0 24 24"><path d="m3.2 7.3 8.6 4.6a.5.5 0 0 0 .4 0l8.6-4.6a.4.4 0 0 0 0-.8L12.1 3a.5.5 0 0 0-.4 0L3.3 6.5a.4.4 0 0 0 0 .8Z"/><path d="M20.7 10.7 19 9.9l-6.7 3.6a.5.5 0 0 1-.4 0L5 9.9l-1.8.8a.5.5 0 0 0 0 .8l8.5 5a.5.5 0 0 0 .5 0l8.5-5a.5.5 0 0 0 0-.8Z"/><path d="m20.7 15.1-1.5-.7-7 3.8a.5.5 0 0 1-.4 0l-7-3.8-1.5.7a.5.5 0 0 0 0 .9l8.5 5a.5.5 0 0 0 .5 0l8.5-5a.5.5 0 0 0 0-.9Z"/></svg>',
             view: LayersPanelView,
@@ -174,19 +187,6 @@ define(
           //   view: DrawTool,
           //   viewOptions: {}
           // },
-          {
-            label: 'Viewfinder',
-            icon: 'search',
-            view: ViewfinderView,
-            action(view, model) {
-              const sectionEl = this;
-              view.defaultActivationAction(sectionEl);
-              sectionEl.sectionView.focusInput();
-            },
-            isVisible(model) {
-              return MetacatUI.mapKey && model.get("showViewfinder");
-            },
-          },
           {
             label: 'Help',
             icon: 'question-sign',

--- a/src/js/views/maps/ToolbarView.js
+++ b/src/js/views/maps/ToolbarView.js
@@ -171,10 +171,15 @@ define(
             },
           },
           {
-            label: 'Home',
-            icon: 'home',
+            label: 'Reset',
+            icon: 'rotate-left',
             action: function (view, model) {
               model.flyHome();
+              
+              // Reset the visibility of all layers.
+              for (const layer of model.getAllLayers()) {
+                layer.set("visible", layer.get('originalVisibility'));
+              }
             },
             isVisible(model) {
               return model.get("showHomeButton");

--- a/src/js/views/maps/viewfinder/ExpansionPanelView.js
+++ b/src/js/views/maps/viewfinder/ExpansionPanelView.js
@@ -67,12 +67,15 @@ define(
          * visible.
          * @property {ExpansionPanelsModel} [panelsModel] Optional model for
          * coordinating the expanded/collapsed state among many panels. 
+         * @property {boolean} startOpen Whether the panel should be expanded by
+         * default. 
          */
-        initialize({ title, contentViewInstance, icon, panelsModel }) {
+        initialize({ title, contentViewInstance, icon, panelsModel, startOpen }) {
           this.templateVars.title = title;
           this.templateVars.icon = icon;
           this.contentViewInstance = contentViewInstance;
           this.panelsModel = panelsModel;
+          this.startOpen = !!startOpen;
 
           this.panelsModel?.register(this);
         },
@@ -93,6 +96,7 @@ define(
         /** Force the panel's content to be shown. */
         open() {
           this.$el.addClass('show-content');
+          this.panelsModel?.collapseOthers(this);
         },
 
         /** Toggle the visibility of the panel's content. */
@@ -101,7 +105,6 @@ define(
             this.collapse();
           } else {
             this.open();
-            this.panelsModel?.collapseOthers(this);
           }
         },
 
@@ -114,6 +117,9 @@ define(
           this.el.innerHTML = _.template(Template)(this.templateVars);
           this.contentViewInstance.render();
           this.getContent().append(this.contentViewInstance.el);
+          if (this.startOpen) {
+            this.open();
+          }
         },
       });
 

--- a/src/js/views/maps/viewfinder/ExpansionPanelView.js
+++ b/src/js/views/maps/viewfinder/ExpansionPanelView.js
@@ -96,7 +96,7 @@ define(
         /** Force the panel's content to be shown. */
         open() {
           this.$el.addClass('show-content');
-          this.panelsModel?.collapseOthers(this);
+          this.panelsModel?.maybeCollapseOthers(this);
         },
 
         /** Toggle the visibility of the panel's content. */

--- a/src/js/views/maps/viewfinder/ViewfinderView.js
+++ b/src/js/views/maps/viewfinder/ViewfinderView.js
@@ -115,6 +115,7 @@ define(
           icon: 'icon-plane',
           panelsModel: this.panelsModel,
           title: 'Zoom to...',
+          startOpen: true,
         });
         expansionPanel.render();
 

--- a/test/js/specs/unit/views/maps/viewfinder/ExpansionPanelView.spec.js
+++ b/test/js/specs/unit/views/maps/viewfinder/ExpansionPanelView.spec.js
@@ -43,6 +43,20 @@ define(
           expect(state.harness.isContentVisible()).to.be.false;
         });
 
+        it('shows the content initially when startOpen is true', () => {
+          const view = new ExpansionPanelView({
+            title: 'Some title',
+            icon: 'leaf',
+            contentViewInstance: new TestView(),
+            startOpen: true,
+          });
+          view.render();
+
+          const harness = new ExpansionPanelViewHarness(view);
+
+          expect(harness.isContentVisible()).to.be.true;
+        });
+
         it('shows content when toggled', () => {
           state.harness.clickToggle();
 


### PR DESCRIPTION
Additionally, viewfinder's zoom presets should start visible. This PR adds support for starting an expansion panel in an expanded (open) state.

NCEAS/metacatui#2397

![toolbar-changes](https://github.com/NCEAS/metacatui/assets/4664309/d8e877ab-1a04-4d70-84e2-7c8469609e89)

