### PR TITLE
PR to test the GH action that auto switches the target branch for dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-branch.yml
+++ b/.github/workflows/dependabot-branch.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: Vankka/pr-target-branch-action@v3
         env:
-          GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
           target: main
           change-to: develop

--- a/.github/workflows/dependabot-branch.yml
+++ b/.github/workflows/dependabot-branch.yml
@@ -5,8 +5,8 @@ on:
       - opened
       - edited
 jobs:
-  if: startsWith(github.head_ref, 'dependabot/')    
   check-branch:
+    if: startsWith(github.head_ref, 'dependabot/')
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write

--- a/.github/workflows/dependabot-branch.yml
+++ b/.github/workflows/dependabot-branch.yml
@@ -1,0 +1,20 @@
+name: Change Dependabot branch to develop
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+    branches:
+      - dependabot/*
+jobs:
+  check-branch:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: Vankka/pr-target-branch-action@v3
+        env:
+          GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+        with:
+          target: main
+          change-to: develop

--- a/.github/workflows/dependabot-branch.yml
+++ b/.github/workflows/dependabot-branch.yml
@@ -1,4 +1,4 @@
-name: Change Dependabot branch to develop
+name: Change Dependabot branch to develop CHANGED FOR TESTING
 on:
   pull_request_target:
     types:

--- a/.github/workflows/dependabot-branch.yml
+++ b/.github/workflows/dependabot-branch.yml
@@ -4,6 +4,7 @@ on:
     types:
       - opened
       - edited
+  pull_request:
 jobs:
   check-branch:
     if: startsWith(github.head_ref, 'dependabot/') || startsWith(github.head_ref, 'fake-2456-test-gh-action')

--- a/.github/workflows/dependabot-branch.yml
+++ b/.github/workflows/dependabot-branch.yml
@@ -6,7 +6,7 @@ on:
       - edited
 jobs:
   check-branch:
-    if: startsWith(github.head_ref, 'dependabot/')
+    if: startsWith(github.head_ref, 'dependabot/') || startsWith(github.head_ref, 'fake-2456-test-gh-action')
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write

--- a/.github/workflows/dependabot-branch.yml
+++ b/.github/workflows/dependabot-branch.yml
@@ -4,7 +4,6 @@ on:
     types:
       - opened
       - edited
-  pull_request:
 jobs:
   check-branch:
     if: startsWith(github.head_ref, 'dependabot/') || startsWith(github.head_ref, 'fake-2456-test-gh-action')

--- a/.github/workflows/dependabot-branch.yml
+++ b/.github/workflows/dependabot-branch.yml
@@ -15,5 +15,5 @@ jobs:
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:
-          target: main
+          target: fake-2456-test-gh-action
           change-to: develop

--- a/.github/workflows/dependabot-branch.yml
+++ b/.github/workflows/dependabot-branch.yml
@@ -4,9 +4,8 @@ on:
     types:
       - opened
       - edited
-    branches:
-      - dependabot/*
 jobs:
+  if: startsWith(github.head_ref, 'dependabot/')    
   check-branch:
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
---

### ⚠️ DO NOT MERGE THIS PR! ⚠️

---

This is a branch to test the new GitHub action introduced in https://github.com/NCEAS/metacatui/pull/2457.

The action must use the `pull_request_target` trigger to run. The `pull_request_target` uses code from the target branch, not the PR branch. Therefore, to test this PR, we must target a branch that has the new GH action file in it.

The is being opened with the target test branch: `fake-2456-test-gh-action`. This test branch contains the workflow code, except that it has been modified to update the target branch of PRs from `fake-2456-test-gh-action` to develop instead of from `main` to develop.