### PR TITLE
ESlint: Allow some unused variables and don't enforce import resolution

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -29,6 +29,18 @@ const airbnbRulesOverrides = {
   // We are using the AMD/RequireJS module pattern
   "import/no-amd": "off",
   "import/no-commonjs": "off",
+  // We are using RequireJS
+  "import/no-unresolved": "off",
+  // Allow unused variables if they start with an underscore
+  "variables/no-unused-vars": [
+    "error",
+    {
+      vars: "all",
+      args: "after-used",
+      ignoreRestSiblings: true,
+      varsIgnorePattern: "^_",
+    },
+  ],
 };
 
 // ---------------------------------------------------------------------
@@ -46,7 +58,7 @@ const jsdocsRulesOverrides = {
 };
 
 // ---------------------------------------------------------------------
-// REQUIREJS
+// REQUIREJS:
 // Use all rules from the recommended config for RequireJS
 const requirejsConfig = {
   name: "requirejs",
@@ -59,7 +71,7 @@ const requirejsConfig = {
 };
 
 // ---------------------------------------------------------------------
-// METACATUI OVERRIDES
+// METACATUI OVERRIDES:
 const metacatuiConfig = {
   files: ["src/**/*.js"],
   languageOptions: {


### PR DESCRIPTION
Issue #2475