### PR TITLE
Feature 2375 QGreenland portal

### DIFF
--- a/src/js/themes/dataone/config.js
+++ b/src/js/themes/dataone/config.js
@@ -142,6 +142,11 @@ MetacatUI.AppConfig = Object.assign(
         datasource: "urn:node:mnUCSB1",
         label: "9434702",
       },
+      {
+        seriesId: "urn:uuid:dfbfc37d-e907-45e8-913f-acb88f1b2e64",
+        datasource: "urn:node:ARCTIC",
+        label: "QGreenland",
+      },
     ],
 
     googleAnalyticsKey: "G-CR31GM016V",


### PR DESCRIPTION
Hi @robyngit - one of the tasks for #2375  was to make the QGreenland portal DataONE accessible. 

I've added the config for the same. Adding @mbjones as a reviewer to get his approval for the same. 

This is in draft state because I'm still waiting for the most recent changes from develop to sync this branch. I'll change the status once that is done. 

