### PR TITLE
Don't parse author strings in CitationModel

### DIFF
--- a/src/js/models/CitationModel.js
+++ b/src/js/models/CitationModel.js
@@ -629,7 +629,11 @@ define(["jquery", "underscore", "backbone", "collections/Citations"], (
           if (typeof author.toCSLJSON === "function") {
             author = author.toCSLJSON();
           } else if (typeof author === "string") {
-            author = this.nameStrToCSLJSON(author);
+            // author = this.nameStrToCSLJSON(author);
+
+            // It's too difficult to parse a string when it could be a name or
+            // an organization. Just return the string. See issue #2106
+            author = { literal: author };
           }
 
           return author;


### PR DESCRIPTION
Live for testing on https://metacatui.test.dataone.org/

Fixes #2548, Related to #2106