### PR TITLE
Add GOA and ESA themes to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@ src/js/themes/drp
 src/js/themes/sctld
 src/js/themes/smithsonian
 src/js/themes/cib
+src/js/themes/esa
+src/js/themes/goa
 node_modules
 src/config/dev
 docs/_site


### PR DESCRIPTION
For development purposes, we add symlinks to the themes directory, but we don’t want them in the remote Git repository, so we typically add them to .gitignore.