### PR TITLE
Fix saving dataset after bad canonical id is set

### DIFF
--- a/src/js/models/metadata/eml211/EML211.js
+++ b/src/js/models/metadata/eml211/EML211.js
@@ -174,7 +174,9 @@ define([
        */
       updateCanonicalDataset() {
         let uri = this.get("canonicalDataset");
-        uri = uri?.length ? uri[0] : null;
+        if (uri && Array.isArray(uri) && uri.length) {
+          [uri] = uri;
+        }
         let annotations = this.get("annotations");
         if (!annotations) {
           annotations = new EMLAnnotations();


### PR DESCRIPTION
The `updateCanonicalDataset` function in the EML211 model expected the `canonicalDataset` property in the model to be an array, but sometimes it gets set as a string. When it was a string, then it was updating the annotation models with the first letter in the string (as opposed to the first item in the array). One letter is not a valid URI, which was why we were sometimes seeing an error. Corrected the function so that it handles both cases, when the `canonicalDataset` property is a string OR when it is an array.

Closes #2616