### PR TITLE
feat(editor): enhance button tooltips with dynamic messages

### DIFF
--- a/src/js/views/EditorView.js
+++ b/src/js/views/EditorView.js
@@ -413,14 +413,22 @@ define([
           .removeClass("btn-disabled")
           .parent()
           .tooltip("destroy");
+        this.$(".addFiles")
+          .removeClass("btn-disabled")
+          .parent()
+          .tooltip("destroy");
       },
 
       /**
        * Disable the Save button and display a message to explain why
        * @param {string} [message] - A short text message to display in the Save button
+       * @param {string} tooltipMessage -- A message that is the reason for buttons being disabled. This message will be displayed in a tooltip.
        * @since 2.17.1
        */
-      disableControls: function (message) {
+      disableControls: function (
+        message,
+        tooltipMessage = "Files are uploading.",
+      ) {
         //When the package is saved, revert the Save button back to normal
         this.$("#save-editor")
           .html(message || "Waiting for files to finish uploading...")
@@ -430,8 +438,21 @@ define([
             placement: "top",
             trigger: "hover focus click",
             html: false,
+            title: "Saving is disabled. " + tooltipMessage + " Please wait...",
+            container: "body",
+            delay: 600,
+          });
+        //When the package is saved, revert the Add button back to normal
+        this.$(".addFiles")
+          .addClass("btn-disabled")
+          .parent()
+          //Add a tooltip to the parent element since tooltips won't work on a disabled button
+          .tooltip({
+            placement: "top",
+            trigger: "hover focus click",
+            html: false,
             title:
-              "Saving is disabled while files are uploading. Please wait...",
+              "Adding files disabled. " + tooltipMessage + " Please wait...",
             container: "body",
             delay: 600,
           });

--- a/src/js/views/EditorView.js
+++ b/src/js/views/EditorView.js
@@ -438,7 +438,7 @@ define([
             placement: "top",
             trigger: "hover focus click",
             html: false,
-            title: "Saving is disabled. " + tooltipMessage + " Please wait...",
+            title: `Saving is disabled. ${  tooltipMessage  } Please wait...`,
             container: "body",
             delay: 600,
           });

--- a/src/js/views/EditorView.js
+++ b/src/js/views/EditorView.js
@@ -442,7 +442,7 @@ define([
             container: "body",
             delay: 600,
           });
-        //When the package is saved, revert the Add button back to normal
+        // When the package is saved, revert the Add button back to normal
         this.$(".addFiles")
           .addClass("btn-disabled")
           .parent()

--- a/src/js/views/EditorView.js
+++ b/src/js/views/EditorView.js
@@ -452,7 +452,7 @@ define([
             trigger: "hover focus click",
             html: false,
             title:
-              "Adding files disabled. " + tooltipMessage + " Please wait...",
+              `Adding files disabled. ${  tooltipMessage  } Please wait...`,
             container: "body",
             delay: 600,
           });

--- a/src/js/views/EditorView.js
+++ b/src/js/views/EditorView.js
@@ -446,7 +446,7 @@ define([
         this.$(".addFiles")
           .addClass("btn-disabled")
           .parent()
-          //Add a tooltip to the parent element since tooltips won't work on a disabled button
+          // Add a tooltip to the parent element since tooltips won't work on a disabled button
           .tooltip({
             placement: "top",
             trigger: "hover focus click",

--- a/src/js/views/metadata/EML211EditorView.js
+++ b/src/js/views/metadata/EML211EditorView.js
@@ -1237,7 +1237,7 @@ define([
         } else if (isLoadingMetadata) {
           const noun = numLoadingMetadata > 1 ? "files" : "file";
           const message = `Waiting for metadata from ${numLoadingMetadata} ${noun} to load...`;
-          this.disableControls(message);
+          this.disableControls(message, "File metadata is loading.");
         } else {
           this.enableControls();
         }


### PR DESCRIPTION
- Enable tooltips for the "Add Files" button similar to the "Save" button.
- Introduce a `tooltipMessage` parameter to `disableControls` method to display customized messages for disabled buttons.
- Update the `disableControls` call in `EML211EditorView` to include a specific tooltip message.

Closes #2623