### PR TITLE
Replace hardcoded value to gate Solr POST over GET with config option

### DIFF
--- a/src/js/collections/SolrResults.js
+++ b/src/js/collections/SolrResults.js
@@ -44,6 +44,7 @@ define([
         this.maxYear = options.maxYear || new Date().getFullYear();
         this.queryServiceUrl =
           options.queryServiceUrl || MetacatUI.appModel.get("queryServiceUrl");
+        this.maxQueryLengthGETs = MetacatUI.appModel.get("maxQueryLengthGETs");
 
         if (MetacatUI.appModel.get("defaultSearchFields")?.length)
           this.fields = MetacatUI.appModel.get("defaultSearchFields").join(",");
@@ -270,7 +271,7 @@ define([
 
         let usePOST =
           this.usePOST ||
-          (this.currentquery.length > 1500 &&
+          (this.currentquery.length > this.maxQueryLengthGETs &&
             !MetacatUI.appModel.get("disableQueryPOSTs"));
 
         if (usePOST) {

--- a/src/js/models/AppModel.js
+++ b/src/js/models/AppModel.js
@@ -255,6 +255,15 @@ define(["jquery", "underscore", "backbone"], function ($, _, Backbone) {
            */
           disableQueryPOSTs: false,
 
+          /**
+           * If set to a value smaller than or equal to the current Solr query
+           * length, the app will send POST HTTP requests to the
+           * Solr search index via the `/query/solr` DataONE API.
+           * Set disableQueryPOSTs to true if using Metacat 2.10.2 or earlier
+           * @type {number}
+           */
+          maxQueryLengthGETs: 1500,
+
           /** If set to true, some parts of the app will use the Solr Join Query syntax
            * when sending queries to the `/query/solr` DataONE API.
            * If this is not enabled, then some parts of the UI may not work if a query has too


### PR DESCRIPTION
Adds maxQueryLengthGETs config option to replace 1500 value in SolrResults that is used in combination with POST flag to control POST behavior for long Solr GET queries.

The default value remains the same 1500 value for backward compatibility.  Setting a low value for maxQueryLengthGETs will trigger POST for Solr queries.

This leaves it up to a deployment to control POST behavior without breaking older deployments.

Related to issue #1998 