### PR TITLE
fix: use POST for Solr queries to resolve issues with long GET requests

### DIFF
--- a/docs/docs/SolrResults.html
+++ b/docs/docs/SolrResults.html
@@ -338,7 +338,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="src_js_collections_SolrResults.js.html">src/js/collections/SolrResults.js</a>, <a href="src_js_collections_SolrResults.js.html#line348">line 348</a>
+        <a href="src_js_collections_SolrResults.js.html">src/js/collections/SolrResults.js</a>, <a href="src_js_collections_SolrResults.js.html#line339">line 339</a>
     </li></ul></dd>
     
 
@@ -453,7 +453,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="src_js_collections_SolrResults.js.html">src/js/collections/SolrResults.js</a>, <a href="src_js_collections_SolrResults.js.html#line374">line 374</a>
+        <a href="src_js_collections_SolrResults.js.html">src/js/collections/SolrResults.js</a>, <a href="src_js_collections_SolrResults.js.html#line365">line 365</a>
     </li></ul></dd>
     
 
@@ -565,7 +565,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="src_js_collections_SolrResults.js.html">src/js/collections/SolrResults.js</a>, <a href="src_js_collections_SolrResults.js.html#line240">line 240</a>
+        <a href="src_js_collections_SolrResults.js.html">src/js/collections/SolrResults.js</a>, <a href="src_js_collections_SolrResults.js.html#line236">line 236</a>
     </li></ul></dd>
     
 
@@ -680,7 +680,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="src_js_collections_SolrResults.js.html">src/js/collections/SolrResults.js</a>, <a href="src_js_collections_SolrResults.js.html#line396">line 396</a>
+        <a href="src_js_collections_SolrResults.js.html">src/js/collections/SolrResults.js</a>, <a href="src_js_collections_SolrResults.js.html#line387">line 387</a>
     </li></ul></dd>
     
 
@@ -795,7 +795,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="src_js_collections_SolrResults.js.html">src/js/collections/SolrResults.js</a>, <a href="src_js_collections_SolrResults.js.html#line324">line 324</a>
+        <a href="src_js_collections_SolrResults.js.html">src/js/collections/SolrResults.js</a>, <a href="src_js_collections_SolrResults.js.html#line315">line 315</a>
     </li></ul></dd>
     
 
@@ -913,7 +913,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="src_js_collections_SolrResults.js.html">src/js/collections/SolrResults.js</a>, <a href="src_js_collections_SolrResults.js.html#line333">line 333</a>
+        <a href="src_js_collections_SolrResults.js.html">src/js/collections/SolrResults.js</a>, <a href="src_js_collections_SolrResults.js.html#line324">line 324</a>
     </li></ul></dd>
     
 
@@ -1028,7 +1028,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="src_js_collections_SolrResults.js.html">src/js/collections/SolrResults.js</a>, <a href="src_js_collections_SolrResults.js.html#line405">line 405</a>
+        <a href="src_js_collections_SolrResults.js.html">src/js/collections/SolrResults.js</a>, <a href="src_js_collections_SolrResults.js.html#line396">line 396</a>
     </li></ul></dd>
     
 
@@ -1147,7 +1147,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="src_js_collections_SolrResults.js.html">src/js/collections/SolrResults.js</a>, <a href="src_js_collections_SolrResults.js.html#line383">line 383</a>
+        <a href="src_js_collections_SolrResults.js.html">src/js/collections/SolrResults.js</a>, <a href="src_js_collections_SolrResults.js.html#line374">line 374</a>
     </li></ul></dd>
     
 
@@ -1262,7 +1262,7 @@
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="src_js_collections_SolrResults.js.html">src/js/collections/SolrResults.js</a>, <a href="src_js_collections_SolrResults.js.html#line361">line 361</a>
+        <a href="src_js_collections_SolrResults.js.html">src/js/collections/SolrResults.js</a>, <a href="src_js_collections_SolrResults.js.html#line352">line 352</a>
     </li></ul></dd>
     
 
@@ -1378,7 +1378,7 @@ to be sent in a fetch() is different at all from the last url that was fetched.
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="src_js_collections_SolrResults.js.html">src/js/collections/SolrResults.js</a>, <a href="src_js_collections_SolrResults.js.html#line415">line 415</a>
+        <a href="src_js_collections_SolrResults.js.html">src/js/collections/SolrResults.js</a>, <a href="src_js_collections_SolrResults.js.html#line406">line 406</a>
     </li></ul></dd>
     
 
@@ -1490,7 +1490,7 @@ to be sent in a fetch() is different at all from the last url that was fetched.
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="src_js_collections_SolrResults.js.html">src/js/collections/SolrResults.js</a>, <a href="src_js_collections_SolrResults.js.html#line155">line 155</a>
+        <a href="src_js_collections_SolrResults.js.html">src/js/collections/SolrResults.js</a>, <a href="src_js_collections_SolrResults.js.html#line151">line 151</a>
     </li></ul></dd>
     
 
@@ -1584,7 +1584,7 @@ to be sent in a fetch() is different at all from the last url that was fetched.
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="src_js_collections_SolrResults.js.html">src/js/collections/SolrResults.js</a>, <a href="src_js_collections_SolrResults.js.html#line173">line 173</a>
+        <a href="src_js_collections_SolrResults.js.html">src/js/collections/SolrResults.js</a>, <a href="src_js_collections_SolrResults.js.html#line169">line 169</a>
     </li></ul></dd>
     
 
@@ -1727,7 +1727,7 @@ to be sent in a fetch() is different at all from the last url that was fetched.
     
     <dt class="tag-source">Source:</dt>
     <dd class="tag-source"><ul class="dummy"><li>
-        <a href="src_js_collections_SolrResults.js.html">src/js/collections/SolrResults.js</a>, <a href="src_js_collections_SolrResults.js.html#line192">line 192</a>
+        <a href="src_js_collections_SolrResults.js.html">src/js/collections/SolrResults.js</a>, <a href="src_js_collections_SolrResults.js.html#line188">line 188</a>
     </li></ul></dd>
     
 

--- a/docs/docs/src_js_collections_SolrResults.js.html
+++ b/docs/docs/src_js_collections_SolrResults.js.html
@@ -99,13 +99,9 @@
         if (MetacatUI.appModel.get("disableQueryPOSTs")) {
           this.usePOST = false;
         }
-        //If this collection was initialized with the usePOST option, use POSTs here
-        else if (options.usePOST) {
-          this.usePOST = true;
-        }
-        //Otherwise default to using GET
+        //Otherwise default to using POST
         else {
-          this.usePOST = false;
+          this.usePOST = true;
         }
       },
 
@@ -314,12 +310,7 @@
           reset: true,
         };
 
-        let usePOST =
-          this.usePOST ||
-          (this.currentquery.length > 1500 &amp;&amp;
-            !MetacatUI.appModel.get("disableQueryPOSTs"));
-
-        if (usePOST) {
+        if (this.usePOST) {
           options.type = "POST";
 
           var queryData = new FormData();

--- a/src/js/collections/SolrResults.js
+++ b/src/js/collections/SolrResults.js
@@ -53,13 +53,9 @@ define([
         if (MetacatUI.appModel.get("disableQueryPOSTs")) {
           this.usePOST = false;
         }
-        //If this collection was initialized with the usePOST option, use POSTs here
-        else if (options.usePOST) {
-          this.usePOST = true;
-        }
-        //Otherwise default to using GET
+        //Otherwise default to using POST
         else {
-          this.usePOST = false;
+          this.usePOST = true;
         }
       },
 
@@ -268,12 +264,7 @@ define([
           reset: true,
         };
 
-        let usePOST =
-          this.usePOST ||
-          (this.currentquery.length > 1500 &&
-            !MetacatUI.appModel.get("disableQueryPOSTs"));
-
-        if (usePOST) {
+        if (this.usePOST) {
           options.type = "POST";
 
           var queryData = new FormData();

--- a/src/js/views/DataCatalogView.js
+++ b/src/js/views/DataCatalogView.js
@@ -642,7 +642,6 @@ define([
         const provSearchResults = new SearchResults(null, {
           query: provSearchModel.getQuery(),
           searchLogs: false,
-          usePOST: true,
           rows: 150,
           fields: `${provSearchModel.getProvFlList()},id,resourceMap`,
         });


### PR DESCRIPTION
Fixes issue #1998

Simplifies usePOST logic in SolrResults.js to use POST for queries unless disableQueryPOSTs is true.  Docs are also updated to reflect the change.