### PR TITLE
Fix layout issue with download panel in the cesium map

### DIFF
--- a/src/css/map-view.css
+++ b/src/css/map-view.css
@@ -1410,40 +1410,6 @@ other class: .ui-slider-range */
  * Panel for drawing polygons in the map
  *
  */
-.draw__tool-panel {
-  display: flex;
-  position: absolute; /* Or relative, fixed, or sticky based on your layout */
-  justify-content: center; /* Center horizontally */
-  align-items: center; /* Center vertically */
-  bottom: 5px; /* Adjust to move it down from the top */
-  width: 100%; /* Adjust the size of the container */
-  /* height: auto; */
-  height: 80px;
-  padding: 0.5rem;
-  /* border: 1px solid #191919;  */
-  /* border-top: 0.1px solid #948989; */
-  /* background-color: #7D7D7D; */
-  z-index: 1;
-  background-color: var(--portal-col-primary-1, var(--map-col-bkg__deprecate));
-  /* gap: 50px;  */
-}
-
-.draw-tool {
-  display: flex;
-  /* grid-auto-rows: min-content; */
-  /* grid-gap: 1rem; */
-  justify-content: center;
-  align-items: center;
-  /* margin: 0 50px; */
-}
-
-.icon-pencil {
-  color: var(--portal-col-primary-6, var(--map-col-text__deprecate)) !important;
-}
-
-.icon-trash {
-  color: var(--portal-col-primary-6, var(--map-col-text__deprecate)) !important;
-}
 
 .draw__button {
   position: relative;
@@ -1453,7 +1419,6 @@ other class: .ui-slider-range */
   margin: 0;
   overflow: visible;
   text-transform: none;
-  -webkit-appearance: button;
   border: 0;
   border-radius: 50%;
   background: var(--portal-col-neutral-00, var(--map-col-buttons__deprecate));
@@ -1463,7 +1428,20 @@ other class: .ui-slider-range */
   padding: 0.25rem 0.25rem;
   cursor: pointer;
   margin: 0 25px;
-  /* gap: 8px;  */
+}
+
+.draw-tool {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  .icon {
+    color: var(--portal-col-primary-6, var(--map-col-text__deprecate));
+  }
+
+  .draw__button--disable .icon {
+    color: var(--portal-col-neutral-4, var(--map-col-text__deprecate));
+  }
 }
 
 .draw__button--active {
@@ -1516,30 +1494,19 @@ other class: .ui-slider-range */
 
 .download-panel {
   display: flex;
-  /* position: absolute;  */
   position: fixed;
-  /* width: 100%; */
   width: var(--map-width-toolbar-wide);
   left: 0;
-  right: 0;
   flex-direction: column;
-  /* border: 1px solid #ccc; 
-  background-color: #fff; 
-  box-shadow: -2px 0 5px rgba(0, 0, 0, 0.2);  */
-  z-index: 2; /* Ensure it appears above other elements */
-  /* overflow: hidden;  */
+  padding-bottom: 1rem;
+  z-index: 2;
   align-items: center;
   justify-content: space-between; /* Pushes elements apart */
   gap: 20px;
-  bottom: 80px;
-  /* height: 200px; */
-  /* border: solid
-      var(--portal-col-neutral-3, var(--map-col-bkg-lightest__deprecate)); */
+  bottom: 0;
   border-width: 1px 0;
-  /* overflow: auto; */
   border-top: 1px solid
     var(--portal-col-neutral-2, var(--map-col-bkg-lightest__deprecate));
-  /* background-color: #f0eded;  */
   background-color: var(--portal-col-primary-1, var(--map-col-bkg__deprecate));
 }
 
@@ -1551,7 +1518,6 @@ other class: .ui-slider-range */
   margin: 0;
   overflow: visible;
   text-transform: none;
-  -webkit-appearance: button;
   border: 0;
   border-radius: var(--map-border-radius-big);
   background: var(--portal-col-neutral-00, var(--map-col-buttons__deprecate));
@@ -1570,7 +1536,6 @@ other class: .ui-slider-range */
   width: 100%;
   padding-top: 15px;
   margin-left: 30px;
-  /* margin-bottom: 5px; */
 }
 
 /* Group icon and label in a flex container */
@@ -1581,25 +1546,24 @@ other class: .ui-slider-range */
 }
 
 .download__label {
-  /* the important is needed to overwrite more specific styles set on portal title tags */
-  color: var(--portal-col-primary-6, var(--map-col-text__deprecate)) !important;
   margin: 0;
-  /* font-size: 1.33rem; */
   font-size: 20px;
   font-weight: 700;
-  /* line-height: 1.25; */
-  /* padding: 1rem 1.5rem; */
   text-transform: capitalize;
   flex-grow: 1; /* Allows it to take up available space */
-  /* text-align: center;  */
   vertical-align: middle; /* Ensures inline alignment */
   margin-bottom: 3px;
 }
 
+.download-panel .label-container {
+  color: var(--portal-col-primary-6, var(--map-col-text__deprecate)) !important;
+  .download__label {
+    color: currentColor;
+  }
+}
+
 .icon-download-alt {
   font-size: 20px; /* Adjust icon size */
-  color: var(--portal-col-primary-6, var(--map-col-text__deprecate)) !important;
-  /* margin-left: 30px; */
   vertical-align: bottom; /* Ensures inline alignment */
 }
 
@@ -1922,6 +1886,12 @@ other class: .ui-slider-range */
   /* background-color: gray; */
   color: gray;
   cursor: not-allowed;
+  trash {
+    color: var(
+      --portal-col-primary-6,
+      var(--map-col-text__deprecate)
+    ) !important;
+  }
 }
 #copyWMTS {
   background: none;

--- a/src/js/templates/maps/download-panel.html
+++ b/src/js/templates/maps/download-panel.html
@@ -1,20 +1,16 @@
-<div class="download-panel">
-    <div class="header-container">
-        <div class="label-container">
-        <i class="icon-download-alt"></i><h3 class="download__label">Partial Data Download</h3>
-        </div>  
-        <!-- <button class="layer-details__toggle map-view__button"> -->
-        <button class="download-panel-close__button">
-            <i class="icon-remove"></i>
-        </button>
+<div class="header-container">
+    <div class="label-container">
+    <i class="icon-download-alt"></i>
+    <h3 class="download__label">Partial Data Download</h3>
     </div>
-    <div class="download-data-list__panel">Draw Area of Interest: Single-click to add vertices, double-click to complete.</div>
-    <div class="download-data-list"></div>
-
-<div class="draw-tool"></div> 
-</div> 
-
-
-
-
-
+    <!-- <button class="layer-details__toggle map-view__button"> -->
+    <button class="download-panel-close__button">
+    <i class="icon-remove"></i>
+    </button>
+</div>
+<div class="download-data-list__panel">
+    Draw Area of Interest: Single-click to add vertices, double-click to
+    complete.
+</div>
+<div class="download-data-list"></div>
+<div class="draw-tool"></div>

--- a/src/js/views/maps/DownloadPanelView.js
+++ b/src/js/views/maps/DownloadPanelView.js
@@ -41,8 +41,7 @@ define([
        * The HTML classes to use for this view's element
        * @type {string}
        */
-      // className: "draw-tool",
-      className: "draw__tool-panel",
+      className: "download-panel",
 
       /**
        * Class to use for the buttons
@@ -206,8 +205,6 @@ define([
         toolbarLink: ".toolbar__links",
         toolbarLinkActive: "toolbar__link--active",
         toolbarContentActive: "toolbar__content--active",
-        drawPanel: ".draw__tool-panel",
-        downloadPanel: ".download-panel",
         layerItemPanel: "download-expansion-panel",
         layerItemPanelToggle: "download-expansion-panel__toggle",
         layerItemCheckbox: "download-expansion-panel__checkbox",
@@ -619,7 +616,6 @@ define([
       renderToolbar() {
         // alert("Rendering draw toolbar");
         const view = this;
-        const { el } = this;
         const drawContainer = this.el.querySelector(".draw-tool");
         if (!drawContainer) return;
         // Create the buttons
@@ -639,7 +635,7 @@ define([
           });
           if (!view.buttonEls) view.buttonEls = {};
           view.buttonEls[`${options.name}Button`] = button;
-          el.appendChild(button);
+          drawContainer.appendChild(button);
         });
         const saveButtonEl = this.buttonEls.saveButton;
         const clearButtonEl = this.buttonEls.clearButton;
@@ -663,12 +659,7 @@ define([
         sectionEl.classList.remove(this.classes.toolbarLinkActive); // Change the toolbar link to inactive
         sectionEl.classList.remove(this.classes.toolbarContentActive);
         this.reset();
-        const drawPanel = document.querySelector(this.classes.drawPanel);
-        const downloadPanel = document.querySelector(
-          this.classes.downloadPanel,
-        );
-        drawPanel.style.visibility = this.displayOptions.invisible; // this needs to be moved to CSS
-        downloadPanel.style.visibility = this.displayOptions.invisible; // this needs to be moved to CSS
+        this.el.style.visibility = this.displayOptions.invisible; // this needs to be moved to CSS
       },
 
       /**

--- a/src/js/views/maps/ToolbarView.js
+++ b/src/js/views/maps/ToolbarView.js
@@ -1,7 +1,6 @@
 "use strict";
 
 define([
-  "jquery",
   "underscore",
   "backbone",
   "text!templates/maps/toolbar.html",
@@ -10,12 +9,10 @@ define([
   // Sub-views - TODO: import these as needed
   "views/maps/LayersPanelView",
   "views/maps/HelpPanelView",
-  "views/maps/DrawToolView",
   "views/maps/DownloadPanelView",
   "views/maps/viewfinder/ViewfinderView",
   "views/maps/ShareUrlView",
 ], (
-  $,
   _,
   Backbone,
   Template,
@@ -24,7 +21,6 @@ define([
   // Sub-views
   LayersPanelView,
   HelpPanel,
-  DrawTool,
   DownloadPanelView,
   ViewfinderView,
   ShareUrlView,
@@ -100,11 +96,6 @@ define([
         linkActive: "toolbar__link--active",
         content: "toolbar__content",
         contentActive: "toolbar__content--active",
-        layerPanel: "layers-panel",
-        drawButton: ".draw__button",
-        drawButtonActive: "draw__button--active",
-        drawToolPanel: ".draw__tool-panel",
-        // drawContainer: "draw__all-content",
       },
 
       /**
@@ -185,12 +176,27 @@ define([
         {
           label: "Download",
           icon: "cloud-download",
-          // view: DownloadTool,
           view: DownloadPanelView,
           viewOptions: {},
-          // viewOptions: {
-          //   showDownloadPanel: "model.showDownloadPanel",
-          // }
+          action(view) {
+            // Show both the layer and download panels
+            const layerSectionEl = view.sectionElements.find(
+              (sectionEl) => sectionEl.linkEl.textContent === "Layers",
+            );
+            const downloadSectionEl = view.sectionElements.find(
+              (sectionEl) => sectionEl.linkEl.textContent === "Download",
+            );
+            view.inactivateAllSections();
+            view.defaultActivationAction(layerSectionEl);
+            view.defaultActivationAction(downloadSectionEl);
+          },
+          isVisible(_model) {
+            // TODO: Add an option to show or hide the download panel
+            // to the map model. It should be false by default, but
+            // we should update the PDG portal to true.
+            // return model.get("showDownloadPanel");
+            return true;
+          },
         },
         {
           label: "Help",
@@ -301,6 +307,7 @@ define([
         this.sections.forEach((sectionOption) => {
           // Render the link and content elements
           const linkEl = view.renderSectionLink(sectionOption);
+
           const { action } = sectionOption;
           let contentEl = null;
           let sectionView;
@@ -365,46 +372,11 @@ define([
        */
       handleLinkClick(sectionEl) {
         const toolbarOpen = this.isOpen;
-        let sectionActive = sectionEl.isActive;
-        const drawPanel = document.querySelector(this.classes.drawToolPanel); // check if there is another way to get this from sectionEl
-        const downloadPanel = document.querySelector(".download-panel");
-
-        this.sectionElements.forEach((section) => {
-          const els = section.contentEl?.querySelectorAll("*") || [];
-          const hasLayerClass = Array.from(els).some((el) =>
-            el.classList.contains("layers-panel"),
-          );
-          const hasDrawClass = Array.from(els).some((el) =>
-            el.classList.contains("draw__tool-panel"),
-          );
-          if (hasLayerClass) {
-            this.layerSection = section;
-          }
-          if (hasDrawClass) {
-            this.drawSection = section;
-          }
-        });
-
-        if (
-          sectionEl.contentEl.querySelector(".draw__tool-panel") &&
-          sectionActive
-        ) {
-          sectionActive = false;
-        }
-        if (
-          toolbarOpen &&
-          sectionActive &&
-          !sectionEl.contentEl.querySelector(this.classes.drawToolPanel)
-        ) {
+        const sectionActive = sectionEl.isActive;
+        if (toolbarOpen && sectionActive) {
           this.close();
-          if (drawPanel.style.visibility === "visible") {
-            drawPanel.style.visibility = "hidden";
-            downloadPanel.style.visibility = "hidden";
-            this.drawSection.linkEl.classList.remove(this.classes.linkActive); // Change the toolbar link to inactive
-          }
           return;
         }
-
         if (!toolbarOpen && sectionEl.contentEl) {
           this.open();
         }
@@ -413,38 +385,6 @@ define([
             this.inactivateAllSections();
           }
           this.activateSection(sectionEl);
-
-          if (
-            !sectionEl.contentEl.querySelector(this.classes.drawToolPanel) &&
-            drawPanel.style.visibility === "visible"
-          ) {
-            drawPanel.style.visibility = "hidden";
-            downloadPanel.style.visibility = "hidden";
-            this.drawSection.linkEl.classList.remove(this.classes.linkActive); // Change the toolbar link to inactive
-          }
-
-          if (
-            sectionEl.contentEl.querySelector(this.classes.drawToolPanel) &&
-            !sectionActive
-          ) {
-            if (drawPanel.style.visibility === "") {
-              drawPanel.style.visibility = "visible";
-              downloadPanel.style.visibility = "visible";
-            } else if (drawPanel.style.visibility === "visible") {
-              drawPanel.style.visibility = "hidden";
-              downloadPanel.style.visibility = "hidden";
-              this.drawSection.linkEl.classList.remove(this.classes.linkActive); // Change the toolbar link to inactive
-            } else if (drawPanel.style.visibility === "hidden") {
-              // const drawButtonEl = document.querySelector(".draw__button");
-              drawPanel.style.visibility = "visible";
-              downloadPanel.style.visibility = "visible";
-              // drawButtonEl.classList.add(this.classes.drawButtonActive);
-            }
-            // Activate the Layer Panel when Draw Tool is selected
-            this.activateSection(this.layerSection);
-          }
-
-          // this.activateSection(sectionEl);
         }
       },
 


### PR DESCRIPTION
This PR fixes the layout issue where sometimes the download panel had a large gap between the buttons and other content. To fix it, I had to simplify the layout & css somewhat. Here are the details of the changes I made:

- The `download-panel` view was wrapped in a `draw__tool-panel` div, which added complexity because we were toggling the visibility of both divs to show/hide the download panel. Removing the outer `draw__tool-panel` div made it easier to debug the CSS issues. I could also then remove the CSS rules for the `draw__tool-panel` div and then only needed to adjust the positioning of the `download-panel` div. 

  i.e. before:

  ```html
  <div class="toolbar__content toolbar__content--active">
  <div class="draw__tool-panel" style="visibility: visible">
    <div class="download-panel" style="visibility: visible">
    ...
  ```
  after:
  
  ```html
  <div class="toolbar__content toolbar__content--active">
    <div class="download-panel">
      ...
  ```
- The draw buttons were being appending to the end of the main download panel div, but I think the intention was to add them to the `draw-tool` container. I moved them which helped simplify the CSS rules. 

- With the above changed, only the `download-panel` div needed to be toggled to show/hide the download panel. This made it possible to both simplify and move the logic for showing/hiding the download panel to the `action` property in the `section` option in the Toolbar View.

- Removed some unused imports
- Simplified some other CSS rules to avoid using `!important` unnecessarily.
- Removed some unused CSS rules
- Made the buttons grey when disabled

Related to issue #1889 