### PR TITLE
Metadata pid fix partial download

### DIFF
--- a/src/js/views/maps/DownloadPanelView.js
+++ b/src/js/views/maps/DownloadPanelView.js
@@ -732,7 +732,8 @@ define([
           if (
             value.attributes?.visible === true &&
             value.attributes.type === "WebMapTileServiceImageryProvider" &&
-            value.attributes.label !== "Alaska High Resolution Imagery"
+            value.attributes.label !== "Alaska High Resolution Imagery" &&
+            "metadataPid" in value.attributes
           ) {
             let wmtsDownloadLink;
             // Get WMTS service from map config
@@ -1586,7 +1587,6 @@ define([
                       message: "Download Complete!",
                       progress: 100,
                     });
-
                     // Create a download link for the ZIP file
                     const link = document.createElement("a");
                     link.href = URL.createObjectURL(zipBlob);


### PR DESCRIPTION
Currently layers that aren't hosted on the ADC (e.g., carbon layer) do not have a metadata pid associated with them in a map config. The partial download fails for these datasets. This PR is to check if the metadataPid exists before trying to include it in the download. 