### PR TITLE
Helm chart theme auto upgrade

### DIFF
--- a/helm/README.md
+++ b/helm/README.md
@@ -69,8 +69,13 @@ in the [admin](./admin) directory.
 
 Once you've got the chart deployed (see above), next steps are:
 
-1. Copy your theme files to a directory on a filesystem that is accessible from your Kubernetes
-   cluster
+1. Starting with a directory on a filesystem that is accessible from your Kubernetes cluster:
+   1. EITHER: Manually copy your theme files to that directory,
+   2. OR: Set `customTheme.autoUpdate: true` in values.yaml, to automatically pull the theme from
+      the [NCEAS/metacatui-themes repository](https://github.com/NCEAS/metacatui-themes/tree/main)
+      `main` branch to your filesystem, and to automatically update it on each chart upgrade. The
+      `global.metacatUiThemeName` is used to determine what to check out, and you can also override
+      the default branch/tag and/or the repository URL.
 2. Create a Persistent Volume (PV) pointing to the correct directory on the filesystem
 3. Create a PVC for the PV, and edit the `customTheme:` section in values.yaml
 4. upgrade the helm chart

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -36,20 +36,23 @@ spec:
       {{- if ne $source "pvc" }}
       initContainers:
         - name: get-source
-          {{- if or ( eq $source "git" ) .Values.customTheme.enabled }}
-          image: alpine/git:latest
-          {{- else }}
-          image: busybox:latest
-          {{- end }}
+{{/*          {{- if eq $source "git" }}*/}}
+          image: ubuntu:latest
+{{/*          {{- else }}*/}}
+{{/*          image: busybox:latest*/}}
+{{/*          {{- end }}*/}}
           command:
             - sh
             - -c
-            - >
+            - |
               start=$(date +%s);
               echo "Starting at $start";
               DEST="/metacatui{{ include "metacatui.clean.root" . }}";
               mkdir -p $DEST;
               {{- if eq $source "git" }}
+              ######################################################################################
+              ## Clone MetacatUI files from git repository
+              ######################################################################################
                 {{- $repoUrl := "" }}
                 {{- $revision := "" }}
                 {{- if and .Values.source .Values.source.git }}
@@ -59,10 +62,13 @@ spec:
               REPO='{{ $repoUrl | default "https://github.com/NCEAS/metacatui.git" }}';
               REV='{{ $revision | default .Chart.AppVersion }}';
               git clone -b $REV --depth 1 $REPO /tmp/metacatui/;
-              mv /tmp/metacatui/src/* $DEST;
+              mv /tmp/metacatui/src/* ${DEST};
               finish=$(date +%s);
               echo "git clone -b {{ $revision }} --depth 1 took $((finish - start)) sec";
               {{- else }}
+              ######################################################################################
+              ## Download and expand MetacatUI zip archive
+              ######################################################################################
                 {{- $version := "" }}
                 {{- $location := "" }}
                 {{- if and .Values.source .Values.source.package }}
@@ -70,56 +76,79 @@ spec:
                   {{- $location = .Values.source.package.location }}
                 {{- end }}
               VERSION={{ $version | default .Chart.AppVersion }};
-              FILENAME=$VERSION.zip;
+              FILENAME=${VERSION}.zip;
               LOC='{{ $location | default "https://github.com/NCEAS/metacatui/archive" }}';
-              wget -O ./$FILENAME $LOC/$FILENAME;
-              unzip $FILENAME -d /tmp/;
-              mv /tmp/metacatui-$VERSION/src/* $DEST;
+              echo "Downloading MetacatUI version ${VERSION} from ${LOC}/${FILENAME}";
+              echo "command: wget -O ./${FILENAME} ${LOC}/${FILENAME};"
+              echo "ALERT: SLEEPING!"
+              echo "ALERT: SLEEPING!"
+              echo "ALERT: SLEEPING!"
+              while true; do sleep 20; done;
+              wget -O ./${FILENAME} ${LOC}/${FILENAME};
+              unzip ${FILENAME} -d /tmp/;
+              mv /tmp/metacatui-${VERSION}/src/* $DEST;
               finish=$(date +%s);
-              echo "$FILENAME download and install took $((finish - start)) sec";
+              echo "${FILENAME} download and install took $((finish - start)) sec";
               {{- end }}
+              ######################################################################################
+              ## Fix config.js location in index.html
+              ######################################################################################
               sed -i \
                's|"/config/config.js"|"{{ include "metacatui.clean.root" . }}/config/config.js"|g' \
                "${DEST}"/index.html;
-              {{- if .Values.customTheme.enabled }}
-              tstart=$(date +%s);
-              echo "Starting custom theme update at $tstart";
-
-
-
-
-
-
-
-
-              DEST="/metacatui-theme/{{ .Values.customTheme.repoRootSubPath }}";
-              mkdir -p $DEST;
-              {{- if eq $source "git" }}
-               {{- $themeRepoUrl := "" }}
-               {{- $themeRev := "" }}
-               {{- if and .Values.customTheme .Values.customTheme.git }}
-                 {{- $themeRepoUrl = .Values.customTheme.gitRepoUrl }}
-                 {{- $themeRev = .Values.customTheme.gitRevision }}
-               {{- end }}
-              REPO='{{ $repoUrl | default "https://github.com/NCEAS/metacatui-themes.git" }}';
-              REV='{{ $revision | default "main" }}';
-              git clone -b $REV --depth 1 $REPO /tmp/metacatui/;
-              mv /tmp/metacatui/src/* $DEST;
-              finish=$(date +%s);
-              echo "git clone -b {{ $revision }} --depth 1 took $((finish - start)) sec";
-
+              ######################################################################################
+              ## Clone and/or Auto-update theme files if enabled
+              ######################################################################################
+              {{- if and .Values.customTheme.enabled .Values.customTheme.autoUpdate }}
+              ctstart=$(date +%s);
+              echo "Starting custom theme clone/update at $ctstart";
+              CTDEST="/mounted-theme/{{ .Values.customTheme.repoRootSubPath }}";
+              mkdir -p $CTDEST;
+              {{- $themeRepoUrl := .Values.customTheme.gitRepoUrl }}
+              {{- $themeRev := .Values.customTheme.gitRevision }}
+              CTREPO='{{ $themeRepoUrl | default "https://github.com/NCEAS/metacatui-themes.git"}}';
+              CTREV='{{ $themeRev | default "main" }}';
+              cd $CTDEST;
+              if git rev-parse --is-inside-work-tree > /dev/null 2>&1; then
+                echo "Found existing git repo at ${CTDEST}";
+                echo "Updating and doing hard reset to ${CTREV}";
+                git fetch origin;
+                git reset --hard origin/${CTREV};
+                ctfinish=$(date +%s);
+                echo "git fetch & reset of ${CTREPO} ${CTREV} took $((ctfinish - ctstart)) sec";
+              else
+                echo "No git repo found at ${CTDEST}.";
+                echo "Cloning new theme repository from ${CTREPO} ${CTREV}";
+                git init -b ${CTREV};
+                ## Enable sparse checkout
+                git config core.sparseCheckout true;
+                git remote add -f origin ${CTREPO};
+                ## Configure sparse-checkout
+                echo "src/{{ .Values.global.metacatUiThemeName }}/" > .git/info/sparse-checkout;
+                git sparse-checkout reapply;
+                ## Pull the data
+                git checkout ${CTREV};
+                git pull;
+                ## Set up read-only mode
+                git config receive.denyCurrentBranch true;
+                ## Allow others Read-Only access
+                chmod -R o+r ..;
+                find . -type d -print0 | xargs -0 chmod o+x`;
+                ctfinish=$(date +%s);
+                echo "git sparse checkout of ${CTREPO} ${CTREV} took $((ctfinish - ctstart)) sec";
+              fi;
               {{- end }}
+
           volumeMounts:
             - name: {{ .Release.Name }}-mcui-source-files
               mountPath: /metacatui
-              {{- if .Values.customTheme.enabled }}
+              {{- if and .Values.customTheme.enabled .Values.customTheme.autoUpdate }}
             - name: {{ .Release.Name }}-mcui-custom-theme-files
-              mountPath: /metacatui-theme
-                {{- if .Values.customTheme.repoRootSubPath }}
-              subPath: {{ .Values.customTheme.repoRootSubPath }}
-                {{- end }}
+              mountPath: /mounted-theme
+{{/*                {{- if .Values.customTheme.repoRootSubPath }}*/}}
+{{/*              subPath: {{ .Values.customTheme.repoRootSubPath }}*/}}
+{{/*                {{- end }}*/}}
               {{- end }}
-
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -36,7 +36,7 @@ spec:
       {{- if ne $source "pvc" }}
       initContainers:
         - name: get-source
-          {{- if eq $source "git" }}
+          {{- if or ( eq $source "git" ) .Values.customTheme.enabled }}
           image: alpine/git:latest
           {{- else }}
           image: busybox:latest
@@ -81,9 +81,45 @@ spec:
               sed -i \
                's|"/config/config.js"|"{{ include "metacatui.clean.root" . }}/config/config.js"|g' \
                "${DEST}"/index.html;
+              {{- if .Values.customTheme.enabled }}
+              tstart=$(date +%s);
+              echo "Starting custom theme update at $tstart";
+
+
+
+
+
+
+
+
+              DEST="/metacatui-theme/{{ .Values.customTheme.repoRootSubPath }}";
+              mkdir -p $DEST;
+              {{- if eq $source "git" }}
+               {{- $themeRepoUrl := "" }}
+               {{- $themeRev := "" }}
+               {{- if and .Values.customTheme .Values.customTheme.git }}
+                 {{- $themeRepoUrl = .Values.customTheme.gitRepoUrl }}
+                 {{- $themeRev = .Values.customTheme.gitRevision }}
+               {{- end }}
+              REPO='{{ $repoUrl | default "https://github.com/NCEAS/metacatui-themes.git" }}';
+              REV='{{ $revision | default "main" }}';
+              git clone -b $REV --depth 1 $REPO /tmp/metacatui/;
+              mv /tmp/metacatui/src/* $DEST;
+              finish=$(date +%s);
+              echo "git clone -b {{ $revision }} --depth 1 took $((finish - start)) sec";
+
+              {{- end }}
           volumeMounts:
             - name: {{ .Release.Name }}-mcui-source-files
               mountPath: /metacatui
+              {{- if .Values.customTheme.enabled }}
+            - name: {{ .Release.Name }}-mcui-custom-theme-files
+              mountPath: /metacatui-theme
+                {{- if .Values.customTheme.repoRootSubPath }}
+              subPath: {{ .Values.customTheme.repoRootSubPath }}
+                {{- end }}
+              {{- end }}
+
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -100,16 +100,21 @@ spec:
               CTREPO='{{ $themeRepoUrl | default "https://github.com/NCEAS/metacatui-themes.git"}}';
               CTREV='{{ $themeRev | default "main" }}';
               cd $CTDEST;
-              if git rev-parse --is-inside-work-tree > /dev/null 2>&1; then
+              CTCFG="/mounted-theme/{{ .Values.customTheme.subPath }}/config.js";
+              if [ -f "$CTCFG" ] && git rev-parse --is-inside-work-tree > /dev/null 2>&1; then
                 echo "Found existing git repo at ${CTDEST}";
                 echo "Updating and doing hard reset to ${CTREV}";
-                git fetch origin;
-                git reset --hard origin/${CTREV};
+                git fetch --all --tags --prune
+                git checkout "${CTREV}"
+                git reset --hard
+                git clean -fd
                 ctfinish=$(date +%s);
                 echo "git fetch & reset of ${CTREPO} ${CTREV} took $((ctfinish - ctstart)) sec";
               else
-                echo "No git repo found at ${CTDEST}.";
-                echo "Cloning new theme repository from ${CTREPO} ${CTREV}";
+                echo "Specified git repo not found at ${CTDEST}.";
+                echo "Doing a sparse checkout of a new theme from ${CTREPO} ${CTREV}";
+                echo "Theme name: {{ .Values.global.metacatUiThemeName }}";
+                rm -rf ${CTDEST}/.git;
                 git init -b ${CTREV};
                 ## Enable sparse checkout
                 git config core.sparseCheckout true;
@@ -118,8 +123,10 @@ spec:
                 echo "src/{{ .Values.global.metacatUiThemeName }}/" > .git/info/sparse-checkout;
                 git sparse-checkout reapply;
                 ## Pull the data
-                git checkout ${CTREV};
-                git pull;
+                git fetch --all --tags --prune
+                git checkout "${CTREV}"
+                git reset --hard
+                git clean -fd
                 ## Set up read-only mode
                 git config receive.denyCurrentBranch true;
                 ## Allow others Read-Only access

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -3,35 +3,35 @@ kind: Deployment
 metadata:
   name: {{ include "metacatui.fullname" . }}
   labels:
-    {{- include "metacatui.labels" . | nindent 4 }}
+    {{ include "metacatui.labels" . | nindent 4 }}
 spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
   selector:
     matchLabels:
-      {{- include "metacatui.selectorLabels" . | nindent 6 }}
+      {{ include "metacatui.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       annotations:
         {{- $configfiles := (.Files.Glob "config/*").AsConfig }}
         checksum/config: {{ printf "%s" $configfiles | sha256sum }}
         {{- with .Values.podAnnotations }}
-          {{- toYaml . | nindent 8 }}
+          {{ toYaml . | nindent 8 }}
         {{- end }}
       labels:
-        {{- include "metacatui.labels" . | nindent 8 }}
+        {{ include "metacatui.labels" . | nindent 8 }}
         {{- with .Values.podLabels }}
-        {{- toYaml . | nindent 8 }}
+        {{ toYaml . | nindent 8 }}
         {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
-        {{- toYaml . | nindent 8 }}
+        {{ toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "metacatui.serviceAccountName" . }}
       securityContext:
-        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+        {{ toYaml .Values.podSecurityContext | nindent 8 }}
       {{- $source := (include "metacatui.source.from" .) }}
       {{- if ne $source "pvc" }}
       initContainers:
@@ -140,13 +140,11 @@ spec:
               mountPath: /mounted-theme
         {{- end }}
       {{- end }}
-
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
-            {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository | default "nginx" }}:
-                        {{- .Values.image.tag | default "latest" }}"
+            {{ toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository | default "nginx" }}:{{ .Values.image.tag | default "latest" }}"
           imagePullPolicy: {{ .Values.image.pullPolicy | default "IfNotPresent" }}
           ports:
             - name: http
@@ -156,7 +154,7 @@ spec:
           livenessProbe:
           {{- if .Values.livenessProbe }}
             {{- with .Values.livenessProbe }}
-            {{- toYaml . | nindent 12 }}
+            {{ toYaml . | nindent 12 }}
             {{- end }}
           {{- else }}
             httpGet:
@@ -168,7 +166,7 @@ spec:
           readinessProbe:
           {{- if .Values.readinessProbe }}
             {{- with .Values.readinessProbe }}
-            {{- toYaml . | nindent 12 }}
+            {{ toYaml . | nindent 12 }}
             {{- end }}
           {{- else }}
             httpGet:
@@ -177,10 +175,10 @@ spec:
           {{- end }}
           {{- end }}
           resources:
-            {{- toYaml .Values.resources | nindent 12 }}
+            {{ toYaml .Values.resources | nindent 12 }}
           volumeMounts:
             {{- with .Values.volumeMounts }}
-              {{- toYaml . | nindent 12 }}
+              {{ toYaml . | nindent 12 }}
             {{- end }}
             - name: {{ .Release.Name }}-mcui-source-files
               mountPath: /usr/share/nginx/html
@@ -219,17 +217,17 @@ spec:
             claimName: {{ required "claimName_REQUIRED" .Values.customTheme.claimName }}
           {{- end }}
           {{- with .Values.volumes }}
-            {{- toYaml . | nindent 8 }}
+            {{ toYaml . | nindent 8 }}
           {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
-        {{- toYaml . | nindent 8 }}
+        {{ toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.affinity }}
       affinity:
-        {{- toYaml . | nindent 8 }}
+        {{ toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.tolerations }}
       tolerations:
-        {{- toYaml . | nindent 8 }}
+        {{ toYaml . | nindent 8 }}
       {{- end }}

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -36,23 +36,20 @@ spec:
       {{- if ne $source "pvc" }}
       initContainers:
         - name: get-source
-{{/*          {{- if eq $source "git" }}*/}}
-          image: ubuntu:latest
-{{/*          {{- else }}*/}}
-{{/*          image: busybox:latest*/}}
-{{/*          {{- end }}*/}}
+          {{- if eq $source "git" }}
+          image: alpine/git:latest
+          {{- else }}
+          image: busybox:latest
+          {{- end }}
           command:
             - sh
             - -c
-            - |
+            - >
               start=$(date +%s);
               echo "Starting at $start";
               DEST="/metacatui{{ include "metacatui.clean.root" . }}";
               mkdir -p $DEST;
               {{- if eq $source "git" }}
-              ######################################################################################
-              ## Clone MetacatUI files from git repository
-              ######################################################################################
                 {{- $repoUrl := "" }}
                 {{- $revision := "" }}
                 {{- if and .Values.source .Values.source.git }}
@@ -62,13 +59,10 @@ spec:
               REPO='{{ $repoUrl | default "https://github.com/NCEAS/metacatui.git" }}';
               REV='{{ $revision | default .Chart.AppVersion }}';
               git clone -b $REV --depth 1 $REPO /tmp/metacatui/;
-              mv /tmp/metacatui/src/* ${DEST};
+              mv /tmp/metacatui/src/* $DEST;
               finish=$(date +%s);
               echo "git clone -b {{ $revision }} --depth 1 took $((finish - start)) sec";
               {{- else }}
-              ######################################################################################
-              ## Download and expand MetacatUI zip archive
-              ######################################################################################
                 {{- $version := "" }}
                 {{- $location := "" }}
                 {{- if and .Values.source .Values.source.package }}
@@ -76,30 +70,27 @@ spec:
                   {{- $location = .Values.source.package.location }}
                 {{- end }}
               VERSION={{ $version | default .Chart.AppVersion }};
-              FILENAME=${VERSION}.zip;
+              FILENAME=$VERSION.zip;
               LOC='{{ $location | default "https://github.com/NCEAS/metacatui/archive" }}';
-              echo "Downloading MetacatUI version ${VERSION} from ${LOC}/${FILENAME}";
-              echo "command: wget -O ./${FILENAME} ${LOC}/${FILENAME};"
-              echo "ALERT: SLEEPING!"
-              echo "ALERT: SLEEPING!"
-              echo "ALERT: SLEEPING!"
-              while true; do sleep 20; done;
-              wget -O ./${FILENAME} ${LOC}/${FILENAME};
-              unzip ${FILENAME} -d /tmp/;
-              mv /tmp/metacatui-${VERSION}/src/* $DEST;
+              wget -O ./$FILENAME $LOC/$FILENAME;
+              unzip $FILENAME -d /tmp/;
+              mv /tmp/metacatui-$VERSION/src/* $DEST;
               finish=$(date +%s);
-              echo "${FILENAME} download and install took $((finish - start)) sec";
+              echo "$FILENAME download and install took $((finish - start)) sec";
               {{- end }}
-              ######################################################################################
-              ## Fix config.js location in index.html
-              ######################################################################################
               sed -i \
                's|"/config/config.js"|"{{ include "metacatui.clean.root" . }}/config/config.js"|g' \
                "${DEST}"/index.html;
-              ######################################################################################
-              ## Clone and/or Auto-update theme files if enabled
-              ######################################################################################
-              {{- if and .Values.customTheme.enabled .Values.customTheme.autoUpdate }}
+          volumeMounts:
+            - name: {{ .Release.Name }}-mcui-source-files
+              mountPath: /metacatui
+        {{- if and .Values.customTheme.enabled .Values.customTheme.autoUpdate }}
+        - name: update-theme
+          image: alpine/git:latest
+          command:
+            - sh
+            - -c
+            - >
               ctstart=$(date +%s);
               echo "Starting custom theme clone/update at $ctstart";
               CTDEST="/mounted-theme/{{ .Values.customTheme.repoRootSubPath }}";
@@ -133,23 +124,16 @@ spec:
                 git config receive.denyCurrentBranch true;
                 ## Allow others Read-Only access
                 chmod -R o+r ..;
-                find . -type d -print0 | xargs -0 chmod o+x`;
+                find . -type d -print0 | xargs -0 chmod o+x;
                 ctfinish=$(date +%s);
                 echo "git sparse checkout of ${CTREPO} ${CTREV} took $((ctfinish - ctstart)) sec";
               fi;
-              {{- end }}
-
           volumeMounts:
-            - name: {{ .Release.Name }}-mcui-source-files
-              mountPath: /metacatui
-              {{- if and .Values.customTheme.enabled .Values.customTheme.autoUpdate }}
             - name: {{ .Release.Name }}-mcui-custom-theme-files
               mountPath: /mounted-theme
-{{/*                {{- if .Values.customTheme.repoRootSubPath }}*/}}
-{{/*              subPath: {{ .Values.customTheme.repoRootSubPath }}*/}}
-{{/*                {{- end }}*/}}
-              {{- end }}
+        {{- end }}
       {{- end }}
+
       containers:
         - name: {{ .Chart.Name }}
           securityContext:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -102,41 +102,42 @@ customTheme:
   ##
   claimName: "Your-Pre-Configured-pvc-name"
 
-  ## @param customTheme.subPath path to theme directory, within mounted filesystem
+  ## @param customTheme.subPath path to the specific theme directory, relative to mount point
   ## Ignored unless customTheme is enabled
   ##
-  ## Example: if you cloned https://github.com/NCEAS/metacatui-themes to the root of your
-  ## shared drive, it would look like this:
+  ## Example: if you mounted a volume at /my/mountdir, and then cloned the metacatui-themes
+  ## repo (https://github.com/NCEAS/metacatui-themes) to it at /my/mountdir/mydir/metacatui-themes,
+  ## it would look like this:
   ##
-  ## /metacatui-themes
-  ##     └── src
-  ##         ├── cerp
-  ##         │ └── js
-  ##         │     └── themes
-  ##         │         └── cerp
-  ##         │             ├── config.js
-  ##         │             ├── css
-  ##         │             ├── ...etc
-  ##         ├── drp
-  ##         │ └── js
-  ##         │     └── themes
-  ##         │         └── drp
-  ##         │             ├── config.js
-  ##         │             ├── css
-  ##       ...etc          ├── ...etc
+  ## /my/mountdir/mydir/metacatui-themes
+  ##                       └── src
+  ##                           ├── cerp
+  ##                           │ └── js
+  ##                           │     └── themes
+  ##                           │         └── cerp
+  ##                           │             ├── ...etc
+  ##                           ├── drp
+  ##                           │ └── js
+  ##                           │     └── themes
+  ##                           │         └── drp
+  ##                           │             ├── config.js
+  ##                         ...etc          ├── ...etc
   ##
-  ## ...so to use the drp theme, you would set the subPath to:
-  ##     subPath: "metacatui-themes/src/drp/js/themes/drp" # (do NOT include initial "/" in subPath)
+  ## ...so to use the drp theme, you would set the subPath (relative to mount point) to:
+  ##     subPath: "mydir/metacatui-themes/src/drp/js/themes/drp"    ## (do NOT include leading "/"!)
   ##
   subPath: ""
 
-  ## @param customTheme.subPath path to 'metacatui-themes' dir (git-repo root) in mounted filesystem
-  ## Ignored unless customTheme is enabled
-  repoRootSubPath: "metacatui-themes"
+  ## @param customTheme.autoUpdate Automatically clone/update theme files from git repo? (destructive)
+  ## If true, the theme files will be automatically updated from the git repo specified below,
+  ## OVERWRITING ANY LOCAL CHANGES.
+  ##
+  autoUpdate: true
 
   ## @param customTheme.gitRepoUrl
-  ## Ignored unless customTheme is enabled
+  ## Ignored unless customTheme is enabled AND customTheme.autoUpdate is true.
   gitRepoUrl: "https://github.com/NCEAS/metacatui-themes.git"
+#  gitRepoSshUrl: "git@github.com:NCEAS/metacatui-themes.git"
 
   ## @param customTheme.gitRevision Any string that makes sense after the command `git checkout`
   ## - for example:
@@ -145,6 +146,34 @@ customTheme:
   ## Ignored unless customTheme is enabled
   ##
   gitRevision: "main"
+
+  ## @param customTheme.subPath path to 'metacatui-themes' dir (repo root), relative to mount point
+  ## Ignored unless customTheme is enabled AND customTheme.autoUpdate is true.
+  ##
+  ## Example: if you mounted a volume at /my/mountdir, and then cloned the metacatui-themes
+  ## repo (https://github.com/NCEAS/metacatui-themes) to it at /my/mountdir/mydir/metacatui-themes,
+  ## it would look like this:
+  ##
+  ## /my/mountdir/mydir/metacatui-themes
+  ##                       └── src
+  ##                           ├── cerp
+  ##                           │ └── js
+  ##                           │     └── themes
+  ##                           │         └── cerp
+  ##                           │             ├── ...etc
+  ##                           ├── drp
+  ##                           │ └── js
+  ##                         ...etc
+  ##
+  ## ...so you'd set the repoRootSubPath to point at the root of the metacatui-themes repo (relative
+  ## to the mount point):
+  ##     subPath: "mydir/metacatui-themes"    ## (do NOT include leading "/"!)
+  ##
+  ## IMPORTANT: This repoRootSubPath must be pre-existing on the mounted volume, otherwise the
+  ## mount will fail
+  ##
+  repoRootSubPath: "metacatui-themes"
+
 
 ## @param livenessProbeEnabled Enable livenessProbe. Autoconfigured using .Values.appConfig.root
 ## To override autoconfig, keep 'livenessProbeEnabled: true', and define a livenessProbe; e.g:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -188,6 +188,7 @@ customTheme:
 ##      port: http
 ##
 livenessProbeEnabled: true
+livenessProbe: {}    ## Uses default (HTTP GET to global.metacatUiWebRoot) unless defined here
 
 ## @param readinessProbeEnabled Enable readinessProbe. Autoconfigured using .Values.appConfig.root
 ## To override autoconfig, keep 'readinessProbeEnabled: true', and define a readinessProbe; e.g:
@@ -197,6 +198,7 @@ livenessProbeEnabled: true
 ##      port: http
 ##
 readinessProbeEnabled: true
+readinessProbe: {}    ## Uses default (HTTP GET to global.metacatUiWebRoot) unless defined here
 
 service:
   type: ClusterIP
@@ -296,7 +298,9 @@ autoscaling:
 image:
   ## NGINX image version to use. Setting a specific value is safer than using "LATEST"
   ## See dockerhub for versions: https://hub.docker.com/_/nginx
-  tag: 1.27.0
+  tag: 1.29.0
+  repository: "nginx"
+  pullPolicy: "IfNotPresent"
 
 nodeSelector: {}
 tolerations: []
@@ -310,3 +314,5 @@ podLabels: {}
 podSecurityContext: {}
 securityContext: {}
 resources: {}
+volumes: []
+volumeMounts: []

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -89,7 +89,7 @@ appConfig:
   ##
   enabled: true
 
-## @param themeFilesClaimName Provide source files for a custom Theme (also see 'appConfig.theme').
+## @param customTheme Provide source files for a custom Theme
 ## NOTE that global.metacatUiThemeName MUST match the theme of your custom theme
 ##
 customTheme:
@@ -129,6 +129,22 @@ customTheme:
   ##     subPath: "metacatui-themes/src/drp/js/themes/drp" # (do NOT include initial "/" in subPath)
   ##
   subPath: ""
+
+  ## @param customTheme.subPath path to 'metacatui-themes' dir (git-repo root) in mounted filesystem
+  ## Ignored unless customTheme is enabled
+  repoRootSubPath: "metacatui-themes"
+
+  ## @param customTheme.gitRepoUrl
+  ## Ignored unless customTheme is enabled
+  gitRepoUrl: "https://github.com/NCEAS/metacatui-themes.git"
+
+  ## @param customTheme.gitRevision Any string that makes sense after the command `git checkout`
+  ## - for example:
+  ##     revision: "tags/2.29.0"    =>     git checkout tags/2.29.0
+  ##     revision: "develop"        =>     git checkout develop
+  ## Ignored unless customTheme is enabled
+  ##
+  gitRevision: "main"
 
 ## @param livenessProbeEnabled Enable livenessProbe. Autoconfigured using .Values.appConfig.root
 ## To override autoconfig, keep 'livenessProbeEnabled: true', and define a livenessProbe; e.g:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -100,6 +100,13 @@ customTheme:
   ##
   enabled: false
 
+  ## @param customTheme.autoUpdate (Destructive!) Auto clone/update of theme files from git repo?
+  ## If true, the theme files will be automatically updated from the git repo specified below,
+  ## OVERWRITING ANY LOCAL CHANGES. Typically used for DataONE hosted instances, which should always
+  ## have the latest version of the metacatui-themes repo.
+  ##
+  autoUpdate: false
+
   ## @param customTheme.themeClaimName substitute your own PVC name
   ## Ignored unless customTheme is enabled
   ##
@@ -126,32 +133,29 @@ customTheme:
   ##                           │             ├── config.js
   ##                         ...etc          ├── ...etc
   ##
-  ## ...so to use the drp theme, you would set the subPath (relative to mount point) to:
+  ## ...so to use the drp theme, for example, the subPath (relative to the mount point) would be:
   ##     subPath: "mydir/metacatui-themes/src/drp/js/themes/drp"    ## (do NOT include leading "/"!)
   ##
-  subPath: ""
-
-  ## @param customTheme.autoUpdate Automatically clone/update theme files from git repo? (destructive)
-  ## If true, the theme files will be automatically updated from the git repo specified below,
-  ## OVERWRITING ANY LOCAL CHANGES.
-  ##
-  autoUpdate: true
+  subPath: "metacatui-themes/src/theme-boilerplate/js/themes/theme-boilerplate"
 
   ## @param customTheme.gitRepoUrl
-  ## Ignored unless customTheme is enabled AND customTheme.autoUpdate is true.
+  ## NOTE: Ignored unless customTheme is enabled AND customTheme.autoUpdate is true.
+  ##
   gitRepoUrl: "https://github.com/NCEAS/metacatui-themes.git"
 
   ## @param customTheme.gitRevision Any string that makes sense after the command `git checkout`
-  ## - for example:
+  ## NOTE: Ignored unless customTheme is enabled AND customTheme.autoUpdate is true.
+  ## - Examples:
   ##     revision: "tags/2.29.0"    =>     git checkout tags/2.29.0
   ##     revision: "develop"        =>     git checkout develop
-  ## Ignored unless customTheme is enabled
   ##
   gitRevision: "main"
 
-  ## @param customTheme.subPath path to 'metacatui-themes' dir (repo root), relative to mount point
-  ## Ignored unless customTheme is enabled AND customTheme.autoUpdate is true.
+  ## @param customTheme.repoRootSubPath path to git repo root, relative to the mount point
+  ## (The git repo root for DataONE hosted instances is typically the 'metacatui-themes' directory)
+  ## NOTE: Ignored unless customTheme is enabled AND customTheme.autoUpdate is true.
   ##
+  ## Should always be a subset of customTheme.subPath!
   ## Example: if you mounted a volume at /my/mountdir, and then cloned the metacatui-themes
   ## repo (https://github.com/NCEAS/metacatui-themes) to it at /my/mountdir/mydir/metacatui-themes,
   ## it would look like this:
@@ -169,13 +173,12 @@ customTheme:
   ##
   ## ...so you'd set the repoRootSubPath to point at the root of the metacatui-themes repo (relative
   ## to the mount point):
-  ##     subPath: "mydir/metacatui-themes"    ## (do NOT include leading "/"!)
+  ##     repoRootSubPath: "mydir/metacatui-themes"    ## (do NOT include leading "/"!)
   ##
-  ## IMPORTANT: This repoRootSubPath must be pre-existing on the mounted volume, otherwise the
-  ## mount will fail
+  ## (...which matches the beginning of customTheme.subPath:
+  ##     "mydir/metacatui-themes/src/drp/js/themes/drp", as required above)
   ##
   repoRootSubPath: "metacatui-themes"
-
 
 ## @param livenessProbeEnabled Enable livenessProbe. Autoconfigured using .Values.appConfig.root
 ## To override autoconfig, keep 'livenessProbeEnabled: true', and define a livenessProbe; e.g:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -90,7 +90,10 @@ appConfig:
   enabled: true
 
 ## @param customTheme Provide source files for a custom Theme
-## NOTE that global.metacatUiThemeName MUST match the theme of your custom theme
+## IMPORTANT NOTES:
+## 1. If source.from is set to "pvc", the customTheme settings are ignored - you will need to
+##    provide your own theme files on the PVC, along with the metacatui source files
+## 2. global.metacatUiThemeName MUST match the name of your custom theme
 ##
 customTheme:
   ## @param customTheme.enabled Provide custom Theme files on a pre-configured PVC
@@ -137,7 +140,6 @@ customTheme:
   ## @param customTheme.gitRepoUrl
   ## Ignored unless customTheme is enabled AND customTheme.autoUpdate is true.
   gitRepoUrl: "https://github.com/NCEAS/metacatui-themes.git"
-#  gitRepoSshUrl: "git@github.com:NCEAS/metacatui-themes.git"
 
   ## @param customTheme.gitRevision Any string that makes sense after the command `git checkout`
   ## - for example:


### PR DESCRIPTION
see #2627 - allows user to enable auto-updates for custom themes. If a git repo alredy exists a the path specified in values.yaml, it is updated to the provided tag, or the head of the provided branch. If no repo is found, it is automatically checked out (sparsely, so it contains only the required theme).

PR Also bumps nginx image version from 1.27.0 to 1.29.0