### PR TITLE
Add support for collapsible sections in Markdown

### DIFF
--- a/src/components/showdown/extensions/showdown-xss-filter/showdown-xss-filter.js
+++ b/src/components/showdown/extensions/showdown-xss-filter/showdown-xss-filter.js
@@ -75,6 +75,7 @@ define(['showdown', 'xss'], function (showdown, xss) {
         sub: [],
         sup: [],
         strong: [],
+        summary: [],
         svg: ["viewbox", "xmlns", "preserveAspectRatio"],
         table: ["width", "border", "align", "valign"],
         tbody: ["align", "valign", "style"],

--- a/src/js/templates/markdown.html
+++ b/src/js/templates/markdown.html
@@ -1,3 +1,4 @@
+<!-- This template is not used. The content is embedded into the markdown view directly. -->
 <div class = "markdown">
     <%= markdown %>
 </div>

--- a/src/js/templates/portals/editor/MarkdownExample.md
+++ b/src/js/templates/portals/editor/MarkdownExample.md
@@ -18,11 +18,11 @@ print(my_string)
 ```
 
 Here is how to make a table:
-| Tables | Are | Cool |
+| Tables | Are | Cool  |
 | ------ | --- | ----- |
-| x | a | $1600 |
-| y | b | $12 |
-| z | c | $1600 |
+| x      | a   | $1600 |
+| y      | b   | $12   |
+| z      | c   | $1600 |
 
 The following is an unordered list:
 
@@ -43,6 +43,18 @@ To quote some text, just start a line with a `>` character. In the words of Grac
 > information is more valuable than the hardware which processes it.
 
 You can even add emojis :smile:!
+
+Add a collapsible section like so:
+
+<details>
+<summary>Click to expand</summary>
+
+This content will be hidden until the user clicks.
+
+- You can include Markdown formatting inside
+- Lists, **bold**, etc.
+
+</details>
 
 ### More help with markdown
 

--- a/src/js/views/ImageUploaderView.js
+++ b/src/js/views/ImageUploaderView.js
@@ -217,8 +217,6 @@ define([
           // Insert the main template for this view
           view.$el.html(dropzoneTemplate);
 
-          console.log(view.model.get("imageURL"), view.model.url());
-
           // Add upload & drag and drop functionality to the dropzone div.
           // For config details, see: https://www.dropzonejs.com/#configuration
           var $dropZone = view.$(".dropzone").dropzone({

--- a/src/js/views/MarkdownEditorView.js
+++ b/src/js/views/MarkdownEditorView.js
@@ -22,6 +22,11 @@ define([
   // So that we can assign properties to Woofmark
   const woofmark = Woofmark;
 
+  // Set the default text for collapsible sections
+  Woofmark.strings.placeholders.detailsSummary = "Click to expand/collapse";
+  Woofmark.strings.placeholders.detailsContent = "Details here";
+  Woofmark.strings.titles.details = "Collapsible section";
+
   /**
    * @class MarkdownEditorView
    * @classdesc A view of an HTML textarea with markdown editor UI and preview tab
@@ -288,6 +293,20 @@ define([
             function: view.addTable,
             insertDividerAfter: true,
           },
+          details: {
+            icon: "collapse",
+            title: Woofmark.strings.titles.details,
+            function(e, mode, chunks, _id) {
+              // Add a collapsible section to the markdown
+              const summary = Woofmark.strings.placeholders.detailsSummary;
+              const content =
+                chunks.selection ||
+                Woofmark.strings.placeholders.detailsContent;
+              const details = `<details>\n  <summary>${summary}</summary>\n  ${content}\n</details>`;
+              chunks.selection = details;
+              chunks.skip({ before: 0, after: 0 });
+            },
+          },
         };
 
         const buttonKeys = Object.keys(buttonOptions);
@@ -406,22 +425,9 @@ define([
 
         chunks.findTags(/#+[ ]*/, /[ ]*#+/);
 
-        // let level = 0;
-        // if (/#+/.test(chunks.startTag)) {
-        //   level = RegExp.lastMatch.length;
-        // }
-
         chunks.startTag = "";
         chunks.endTag = "";
         chunks.findTags(null, /\s?(-+|=+)/);
-
-        // if (/=+/.test(chunks.endTag)) {
-        //   level = 1;
-        // }
-
-        // if (/-+/.test(chunks.endTag)) {
-        //   level = 2;
-        // }
 
         // chunks.startTag = chunks.endTag = "";
         chunks.skip({ before: 1, after: 1 });
@@ -431,12 +437,6 @@ define([
         }
       },
 
-      /**
-       * addDivider – Add or remove a divider
-       * @param {Event}   e          The original event object
-       * @param {string}  mode       markdown | html | wysiwyg   (currently unused)
-       * @param {object}  chunksObj  Woofmark “chunks” describing the editor state
-       */
       /**
        * addDivider – add or remove a horizontal-rule divider.
        * @param {Event}  e          original event (unused here)

--- a/src/js/views/portals/editor/PortEditorMdSectionView.js
+++ b/src/js/views/portals/editor/PortEditorMdSectionView.js
@@ -240,8 +240,8 @@ define([
           });
         } catch (e) {
           console.log(
-            "The portal editor markdown section view could not be rendered, error message: " +
-              e,
+            "The portal editor markdown section view could not be rendered, error message: ",
+            e,
           );
         }
       },


### PR DESCRIPTION
Collapsible sections are added with `<details>` and `<summary>` tags, allowing users to hide or show content as needed. To allow this, the only change needed was to the `showdown-xss-filter` configuration, which now includes `summary` as an allowed tag (`details` is already allowed).

In addition to the collapsible sections, there is now a button in the markdown editor toolbar to insert these sections easily. There is also an example in the Markdown editor example file to demonstrate how to use this feature.

Additional changes include:
- Fixing all linting errors.
- Moved the very short markdown template into the markdown view directly instead of using a separate template file and increasing the number of HTTP requests.