### PR TITLE
Fix listener on the ANY/ALL select in QueryBuilder

### DIFF
--- a/src/js/views/queryBuilder/QueryBuilderView.js
+++ b/src/js/views/queryBuilder/QueryBuilderView.js
@@ -393,7 +393,7 @@ define([
         );
         this.stopListening(operatorInput.model);
         this.listenTo(
-          operatorInput,
+          operatorInput.model,
           "change:selected",
           function (_model, newValues) {
             this.filterGroup.set("operator", newValues[0]);


### PR DESCRIPTION
The view was listening to the select view rather than the select model. Any/All queries not work as expected in the query builder.

Fixes #2587