### PR TITLE
Use EMLUtilities.getParentEML() in all EML models

### DIFF
--- a/src/js/models/metadata/eml211/EMLAttribute.js
+++ b/src/js/models/metadata/eml211/EMLAttribute.js
@@ -7,6 +7,7 @@ define([
   "models/metadata/eml211/EMLAnnotation",
   "collections/metadata/eml/EMLMissingValueCodes",
   "models/DataONEObject",
+  "common/EMLUtilities",
 ], (
   $,
   _,
@@ -16,6 +17,7 @@ define([
   EMLAnnotation,
   EMLMissingValueCodes,
   DataONEObject,
+  EMLUtilities,
 ) => {
   /**
    * @class EMLAttribute
@@ -664,16 +666,7 @@ define([
        * found
        */
       getParentEML() {
-        let emlModel = this.get("parentModel");
-        let tries = 0;
-
-        while (emlModel.type !== "EML" && tries < 6) {
-          emlModel = emlModel.get("parentModel");
-          tries += 1;
-        }
-
-        if (emlModel && emlModel.type === "EML") return emlModel;
-        return false;
+        return EMLUtilities.getParentEML(this);
       },
 
       /** Let the top level package know of attribute changes from this object */

--- a/src/js/models/metadata/eml211/EMLDataTable.js
+++ b/src/js/models/metadata/eml211/EMLDataTable.js
@@ -3,7 +3,8 @@ define([
   "underscore",
   "backbone",
   "models/metadata/eml211/EMLEntity",
-], function ($, _, Backbone, EMLEntity) {
+  "common/EMLUtilities",
+], function ($, _, Backbone, EMLEntity, EMLUtilities) {
   /**
    * @class EMLDataTable
    * @classdesc EMLDataTable represents a tabular data entity, corresponding
@@ -235,16 +236,7 @@ define([
        * @return {EML211 or false} - Returns the EML 211 Model or false if not found
        */
       getParentEML: function () {
-        var emlModel = this.get("parentModel"),
-          tries = 0;
-
-        while (emlModel.type !== "EML" && tries < 6) {
-          emlModel = emlModel.get("parentModel");
-          tries++;
-        }
-
-        if (emlModel && emlModel.type == "EML") return emlModel;
-        else return false;
+        return EMLUtilities.getParentEML(this);
       },
     },
   );

--- a/src/js/models/metadata/eml211/EMLDateTimeDomain.js
+++ b/src/js/models/metadata/eml211/EMLDateTimeDomain.js
@@ -1,9 +1,10 @@
-define(["jquery", "underscore", "backbone", "models/DataONEObject"], function (
-  $,
-  _,
-  Backbone,
-  DataONEObject,
-) {
+define([
+  "jquery",
+  "underscore",
+  "backbone",
+  "models/DataONEObject",
+  "common/EMLUtilities",
+], function ($, _, Backbone, DataONEObject, EMLUtilities) {
   /**
    * @classdesc EMLDateTimeDomain represents the measurement scale of a date/time
    * attribute.
@@ -349,16 +350,7 @@ define(["jquery", "underscore", "backbone", "models/DataONEObject"], function (
        * @return {EML211 or false} - Returns the EML 211 Model or false if not found
        */
       getParentEML: function () {
-        var emlModel = this.get("parentModel"),
-          tries = 0;
-
-        while (emlModel.type !== "EML" && tries < 6) {
-          emlModel = emlModel.get("parentModel");
-          tries++;
-        }
-
-        if (emlModel && emlModel.type == "EML") return emlModel;
-        else return false;
+        return EMLUtilities.getParentEML(this);
       },
 
       /* Let the top level package know of attribute changes from this object */

--- a/src/js/models/metadata/eml211/EMLDistribution.js
+++ b/src/js/models/metadata/eml211/EMLDistribution.js
@@ -1,9 +1,10 @@
-define(["jquery", "underscore", "backbone", "models/DataONEObject"], function (
-  $,
-  _,
-  Backbone,
-  DataONEObject,
-) {
+define([
+  "jquery",
+  "underscore",
+  "backbone",
+  "models/DataONEObject",
+  "common/EMLUtilities",
+], function ($, _, Backbone, DataONEObject, EMLUtilities) {
   /**
    * @class EMLDistribution
    * @classdesc Information on how the resource is distributed online and
@@ -308,16 +309,7 @@ define(["jquery", "underscore", "backbone", "models/DataONEObject"], function (
        * found
        */
       getParentEML: function () {
-        var emlModel = this.get("parentModel"),
-          tries = 0;
-
-        while (emlModel.type !== "EML" && tries < 6) {
-          emlModel = emlModel.get("parentModel");
-          tries++;
-        }
-
-        if (emlModel && emlModel.type == "EML") return emlModel;
-        else return false;
+        return EMLUtilities.getParentEML(this);
       },
 
       trickleUpChange: function () {

--- a/src/js/models/metadata/eml211/EMLEntity.js
+++ b/src/js/models/metadata/eml211/EMLEntity.js
@@ -5,7 +5,16 @@ define([
   "models/DataONEObject",
   "models/metadata/eml211/EMLAttribute",
   "models/metadata/eml211/EMLAttributeList",
-], ($, _, Backbone, DataONEObject, EMLAttribute, EMLAttributeList) => {
+  "common/EMLUtilities",
+], (
+  $,
+  _,
+  Backbone,
+  DataONEObject,
+  EMLAttribute,
+  EMLAttributeList,
+  EMLUtilities,
+) => {
   /**
    * @class EMLEntity
    * @classdesc EMLEntity represents an abstract data entity, corresponding with
@@ -595,16 +604,7 @@ define([
        * found
        */
       getParentEML() {
-        let emlModel = this.get("parentModel");
-        let tries = 0;
-
-        while (emlModel.type !== "EML" && tries < 6) {
-          emlModel = emlModel.get("parentModel");
-          tries += 1;
-        }
-
-        if (emlModel && emlModel.type === "EML") return emlModel;
-        return false;
+        return EMLUtilities.getParentEML(this);
       },
 
       /**

--- a/src/js/models/metadata/eml211/EMLGeoCoverage.js
+++ b/src/js/models/metadata/eml211/EMLGeoCoverage.js
@@ -1,9 +1,10 @@
-define(["jquery", "underscore", "backbone", "models/DataONEObject"], function (
-  $,
-  _,
-  Backbone,
-  DataONEObject,
-) {
+define([
+  "jquery",
+  "underscore",
+  "backbone",
+  "models/DataONEObject",
+  "common/EMLUtilities",
+], function ($, _, Backbone, DataONEObject, EMLUtilities) {
   /**
    * @class EMLGeoCoverage
    * @classdesc A description of geographic coverage of a dataset, per the EML
@@ -522,16 +523,7 @@ define(["jquery", "underscore", "backbone", "models/DataONEObject"], function (
        * found
        */
       getParentEML: function () {
-        var emlModel = this.get("parentModel"),
-          tries = 0;
-
-        while (emlModel.type !== "EML" && tries < 6) {
-          emlModel = emlModel.get("parentModel");
-          tries++;
-        }
-
-        if (emlModel && emlModel.type == "EML") return emlModel;
-        else return false;
+        return EMLUtilities.getParentEML(this);
       },
 
       /**

--- a/src/js/models/metadata/eml211/EMLKeywordSet.js
+++ b/src/js/models/metadata/eml211/EMLKeywordSet.js
@@ -1,9 +1,10 @@
-define(["jquery", "underscore", "backbone", "models/DataONEObject"], function (
-  $,
-  _,
-  Backbone,
-  DataONEObject,
-) {
+define([
+  "jquery",
+  "underscore",
+  "backbone",
+  "models/DataONEObject",
+  "common/EMLUtilities",
+], function ($, _, Backbone, DataONEObject, EMLUtilities) {
   var EMLKeywordSet = Backbone.Model.extend({
     type: "EMLKeywordSet",
 
@@ -106,16 +107,7 @@ define(["jquery", "underscore", "backbone", "models/DataONEObject"], function (
      * @return {EML211 or false} - Returns the EML 211 Model or false if not found
      */
     getParentEML: function () {
-      var emlModel = this.get("parentModel"),
-        tries = 0;
-
-      while (emlModel.type !== "EML" && tries < 6) {
-        emlModel = emlModel.get("parentModel");
-        tries++;
-      }
-
-      if (emlModel && emlModel.type == "EML") return emlModel;
-      else return false;
+      return EMLUtilities.getParentEML(this);
     },
 
     trickleUpChange: function () {

--- a/src/js/models/metadata/eml211/EMLMethods.js
+++ b/src/js/models/metadata/eml211/EMLMethods.js
@@ -5,7 +5,16 @@ define([
   "models/DataONEObject",
   "models/metadata/eml/EMLMethodStep",
   "models/metadata/eml211/EMLText",
-], function ($, _, Backbone, DataONEObject, EMLMethodStep, EMLText) {
+  "common/EMLUtilities",
+], function (
+  $,
+  _,
+  Backbone,
+  DataONEObject,
+  EMLMethodStep,
+  EMLText,
+  EMLUtilities,
+) {
   /**
   * @class EMLMethods
   * @classdesc Represents the EML Methods module. The methods field documents scientific methods
@@ -551,16 +560,7 @@ define([
        * @return {EML211|false} - Returns the EML 211 Model or false if not found
        */
       getParentEML: function () {
-        var emlModel = this.get("parentModel"),
-          tries = 0;
-
-        while (emlModel.type !== "EML" && tries < 6) {
-          emlModel = emlModel.get("parentModel");
-          tries++;
-        }
-
-        if (emlModel && emlModel.type == "EML") return emlModel;
-        else return false;
+        return EMLUtilities.getParentEML(this);
       },
 
       trickleUpChange: function () {

--- a/src/js/models/metadata/eml211/EMLNonNumericDomain.js
+++ b/src/js/models/metadata/eml211/EMLNonNumericDomain.js
@@ -1,9 +1,10 @@
-define(["jquery", "underscore", "backbone", "models/DataONEObject"], function (
-  $,
-  _,
-  Backbone,
-  DataONEObject,
-) {
+define([
+  "jquery",
+  "underscore",
+  "backbone",
+  "models/DataONEObject",
+  "common/EMLUtilities",
+], function ($, _, Backbone, DataONEObject, EMLUtilities) {
   /**
    * @class EMLNonNumericDomain
    * @classdesc EMLNonNumericDomain represents the measurement scale of a nominal
@@ -902,16 +903,7 @@ define(["jquery", "underscore", "backbone", "models/DataONEObject"], function (
        * @return {EML211 or false} - Returns the EML 211 Model or false if not found
        */
       getParentEML: function () {
-        var emlModel = this.get("parentModel"),
-          tries = 0;
-
-        while (emlModel.type !== "EML" && tries < 6) {
-          emlModel = emlModel.get("parentModel");
-          tries++;
-        }
-
-        if (emlModel && emlModel.type == "EML") return emlModel;
-        else return false;
+        return EMLUtilities.getParentEML(this);
       },
 
       removeCode: function (index) {

--- a/src/js/models/metadata/eml211/EMLNumericDomain.js
+++ b/src/js/models/metadata/eml211/EMLNumericDomain.js
@@ -1,9 +1,10 @@
-define(["jquery", "underscore", "backbone", "models/DataONEObject"], function (
-  $,
-  _,
-  Backbone,
-  DataONEObject,
-) {
+define([
+  "jquery",
+  "underscore",
+  "backbone",
+  "models/DataONEObject",
+  "common/EMLUtilities",
+], function ($, _, Backbone, DataONEObject, EMLUtilities) {
   /**
    * @class EMLNumericDomain
    * @classdesc EMLNumericDomain represents the measurement scale of an interval
@@ -408,16 +409,7 @@ define(["jquery", "underscore", "backbone", "models/DataONEObject"], function (
        * @return {EML211 or false} - Returns the EML 211 Model or false if not found
        */
       getParentEML: function () {
-        var emlModel = this.get("parentModel"),
-          tries = 0;
-
-        while (emlModel.type !== "EML" && tries < 6) {
-          emlModel = emlModel.get("parentModel");
-          tries++;
-        }
-
-        if (emlModel && emlModel.type == "EML") return emlModel;
-        else return false;
+        return EMLUtilities.getParentEML(this);
       },
 
       /* Let the top level package know of attribute changes from this object */

--- a/src/js/models/metadata/eml211/EMLOtherEntity.js
+++ b/src/js/models/metadata/eml211/EMLOtherEntity.js
@@ -3,7 +3,8 @@ define([
   "underscore",
   "backbone",
   "models/metadata/eml211/EMLEntity",
-], function ($, _, Backbone, EMLEntity) {
+  "common/EMLUtilities",
+], function ($, _, Backbone, EMLEntity, EMLUtilities) {
   /**
    * @class EMLOtherEntity
    * @classdesc EMLOtherEntity represents a generic data entity, corresponding
@@ -159,18 +160,7 @@ define([
        * @return {EML211 or false} - Returns the EML 211 Model or false if not found
        */
       getParentEML: function () {
-        var emlModel = this.get("parentModel"),
-          tries = 0;
-
-        if (!emlModel) return false;
-
-        while (emlModel.type !== "EML" && tries < 6) {
-          emlModel = emlModel.get("parentModel");
-          tries++;
-        }
-
-        if (emlModel && emlModel.type == "EML") return emlModel;
-        else return false;
+        return EMLUtilities.getParentEML(this);
       },
 
       /* Serialize the EML DOM to XML */

--- a/src/js/models/metadata/eml211/EMLParty.js
+++ b/src/js/models/metadata/eml211/EMLParty.js
@@ -1,9 +1,10 @@
-define(["jquery", "underscore", "backbone", "models/DataONEObject"], (
-  $,
-  _,
-  Backbone,
-  DataONEObject,
-) => {
+define([
+  "jquery",
+  "underscore",
+  "backbone",
+  "models/DataONEObject",
+  "common/EMLUtilities",
+], ($, _, Backbone, DataONEObject, EMLUtilities) => {
   /**
    * @class EMLParty
    * @classcategory Models/Metadata/EML211
@@ -1116,16 +1117,7 @@ define(["jquery", "underscore", "backbone", "models/DataONEObject"], (
        * @return {EML211 or false} - Returns the EML 211 Model or false if not found
        */
       getParentEML: function () {
-        var emlModel = this.get("parentModel"),
-          tries = 0;
-
-        while (emlModel.type !== "EML" && tries < 6) {
-          emlModel = emlModel.get("parentModel");
-          tries++;
-        }
-
-        if (emlModel && emlModel.type == "EML") return emlModel;
-        else return false;
+        return EMLUtilities.getParentEML(this);
       },
 
       /**

--- a/src/js/models/metadata/eml211/EMLProject.js
+++ b/src/js/models/metadata/eml211/EMLProject.js
@@ -4,7 +4,8 @@ define([
   "backbone",
   "models/DataONEObject",
   "models/metadata/eml211/EMLParty",
-], function ($, _, Backbone, DataONEObject, EMLParty) {
+  "common/EMLUtilities",
+], function ($, _, Backbone, DataONEObject, EMLParty, EMLUtilities) {
   var EMLProject = Backbone.Model.extend({
     defaults: {
       objectDOM: null,
@@ -236,16 +237,7 @@ define([
      * @return {EML211 or false} - Returns the EML 211 Model or false if not found
      */
     getParentEML: function () {
-      var emlModel = this.get("parentModel"),
-        tries = 0;
-
-      while (emlModel.type !== "EML" && tries < 6) {
-        emlModel = emlModel.get("parentModel");
-        tries++;
-      }
-
-      if (emlModel && emlModel.type == "EML") return emlModel;
-      else return false;
+      return EMLUtilities.getParentEML(this);
     },
 
     trickleUpChange: function () {

--- a/src/js/models/metadata/eml211/EMLTaxonCoverage.js
+++ b/src/js/models/metadata/eml211/EMLTaxonCoverage.js
@@ -1,9 +1,10 @@
-define(["jquery", "underscore", "backbone", "models/DataONEObject"], function (
-  $,
-  _,
-  Backbone,
-  DataONEObject,
-) {
+define([
+  "jquery",
+  "underscore",
+  "backbone",
+  "models/DataONEObject",
+  "common/EMLUtilities",
+], function ($, _, Backbone, DataONEObject, EMLUtilities) {
   /**
    * @typedef {Object} TaxonomicClassification
    * @property {string} taxonRankName - The name of the taxonomic rank, for
@@ -439,16 +440,7 @@ define(["jquery", "underscore", "backbone", "models/DataONEObject"], function (
        * found
        */
       getParentEML: function () {
-        var emlModel = this.get("parentModel"),
-          tries = 0;
-
-        while (emlModel.type !== "EML" && tries < 6) {
-          emlModel = emlModel.get("parentModel");
-          tries++;
-        }
-
-        if (emlModel && emlModel.type == "EML") return emlModel;
-        else return false;
+        return EMLUtilities.getParentEML(this);
       },
 
       trickleUpChange: function () {

--- a/src/js/models/metadata/eml211/EMLTemporalCoverage.js
+++ b/src/js/models/metadata/eml211/EMLTemporalCoverage.js
@@ -1,9 +1,10 @@
-define(["jquery", "underscore", "backbone", "models/DataONEObject"], function (
-  $,
-  _,
-  Backbone,
-  DataONEObject,
-) {
+define([
+  "jquery",
+  "underscore",
+  "backbone",
+  "models/DataONEObject",
+  "common/EMLUtilities",
+], function ($, _, Backbone, DataONEObject, EMLUtilities) {
   /**
    * @class EMLTemporalCoverage
    * @classcategory Models/Metadata/EML211
@@ -508,16 +509,7 @@ define(["jquery", "underscore", "backbone", "models/DataONEObject"], function (
        * @return {EML211 or false} - Returns the EML 211 Model or false if not found
        */
       getParentEML: function () {
-        var emlModel = this.get("parentModel"),
-          tries = 0;
-
-        while (emlModel.type !== "EML" && tries < 6) {
-          emlModel = emlModel.get("parentModel");
-          tries++;
-        }
-
-        if (emlModel && emlModel.type == "EML") return emlModel;
-        else return false;
+        return EMLUtilities.getParentEML(this);
       },
     },
   );

--- a/src/js/models/metadata/eml211/EMLText.js
+++ b/src/js/models/metadata/eml211/EMLText.js
@@ -1,9 +1,10 @@
-define(["jquery", "underscore", "backbone", "models/DataONEObject"], function (
-  $,
-  _,
-  Backbone,
-  DataONEObject,
-) {
+define([
+  "jquery",
+  "underscore",
+  "backbone",
+  "models/DataONEObject",
+  "common/EMLUtilities",
+], function ($, _, Backbone, DataONEObject, EMLUtilities) {
   /**
    * @class EMLText211
    * @classdesc A model that represents the EML 2.1.1 Text module
@@ -194,16 +195,7 @@ define(["jquery", "underscore", "backbone", "models/DataONEObject"], function (
        * @return {EML211|false} - Returns the EML 211 Model or false if not found
        */
       getParentEML: function () {
-        var emlModel = this.get("parentModel"),
-          tries = 0;
-
-        while (emlModel.type !== "EML" && tries < 6) {
-          emlModel = emlModel.get("parentModel");
-          tries++;
-        }
-
-        if (emlModel && emlModel.type == "EML") return emlModel;
-        else return false;
+        return EMLUtilities.getParentEML(this);
       },
 
       trickleUpChange: function () {


### PR DESCRIPTION
Instead of redefining the same function over a dozen times, import `EMLUtilities` and use the `getParentEML` function that is defined there once. Keeps the code DRY.

I tested creating a new EML model with all fields filled and had no issues. All of the functions replaced were identical, thus I don't expect this to have any functional changes.

Issue #2710.