### PR TITLE
Fix issues with Analytics while loading the editor

### DIFF
--- a/src/js/common/EventLog.js
+++ b/src/js/common/EventLog.js
@@ -15,6 +15,17 @@ define(["models/analytics/Analytics"], (Analytics) => {
     warning: 1,
     error: 2,
   };
+
+  // Helper function to get or create a default analytics instance
+  const getDefaultAnalytics = () => {
+    // Try to use the global analytics instance first
+    if (typeof MetacatUI !== 'undefined' && MetacatUI.analytics) {
+      return MetacatUI.analytics;
+    }
+    // Fallback to creating a basic Analytics instance
+    return new Analytics();
+  };
+  
   /**
    * @class EventLog
    * @classdesc A utility class for recording events and grouping by context.
@@ -38,11 +49,10 @@ define(["models/analytics/Analytics"], (Analytics) => {
     constructor({
       consoleLevel = DEFAULT_CONSOLE_LEVEL,
       maxEvents = DEFAULT_MAX_EVENTS,
-      analyticsModel = new Analytics(),
+      analyticsModel = null,
     } = {}) {
       this.logs = new Map();
-      this.analytics =
-        analyticsModel instanceof Analytics ? analyticsModel : new Analytics();
+      this.analytics = analyticsModel || getDefaultAnalytics();
       this.maxEvents =
         Number.isInteger(maxEvents) && maxEvents > 0
           ? maxEvents


### PR DESCRIPTION
While trying to edit an existing dataset, the editor runs into the following error while checking for authorization:

```
Uncaught (in promise) TypeError: Analytics is not a constructor
    EventLog EventLog.js:41
    ResourceMapResolver ResourceMapResolver.js:98
    get ResourceMapResolver.js:483
    getDataPackage EML211EditorView.js:400
    render EML211EditorView.js:234
    p/t[e]< Backbone
    before Underscore
    Backbone 5
    jQuery 6
    Backbone 4
    fetch ScienceMetadata.js:159
    fetchModel EML211EditorView.js:327
    afterAccountChecked EML211EditorView.js:258
    render EML211EditorView.js:263
    showView AppView.js:263
    jQuery 16
    showView AppView.js:251
    renderEditor router.js:343
    execCb require.js:1635
    check require.js:871
    enable require.js:1112
    bind require.js:129
    emit require.js:1155
    each require.js:57
    emit require.js:1154
    check require.js:925
    enable require.js:1112
    bind require.js:129
    emit require.js:1155
    each require.js:57
    emit require.js:1154
    check require.js:925
    enable require.js:1112
    bind require.js:129
    emit require.js:1155
```

The following changes adds a fix and loads up the dataset successfully in the editor.