### PR TITLE
Feature 1770 filter by attribute active filters

### DIFF
--- a/src/css/map-view.css
+++ b/src/css/map-view.css
@@ -846,7 +846,8 @@ represents 1 unit of the given distance measurement. */
   padding: 0 1.5rem;
   cursor: pointer;
 
-  .layer-item__visibility-toggle {
+  .layer-item__visibility-toggle,
+  .layer-item__filter-icon {
     opacity: var(--map-no-brightness-or-opacity-tweaks, 0.85);
     padding: 0;
     margin: 0.25rem;
@@ -909,12 +910,6 @@ represents 1 unit of the given distance measurement. */
           );
         }
       }
-
-      .icon-filter--active {
-        fill: transparent;
-        color: var(--portal-col-neutral-4, currentColor);
-        background-color: transparent;
-      }
     }
 
     .layer-item__settings {
@@ -922,6 +917,10 @@ represents 1 unit of the given distance measurement. */
       display: flex;
       border: 1px solid var(--portal-col-primary-2);
     }
+  }
+
+  .layer-item__filter-icon--active {
+    color: var(--portal-col-primary-6);
   }
 
   .layer-item__settings {

--- a/src/js/collections/maps/VectorFilters.js
+++ b/src/js/collections/maps/VectorFilters.js
@@ -25,6 +25,14 @@ define([
       model: VectorFilter,
 
       /**
+       * Checks if there are any active filters in the collection.
+       * @returns {boolean} Returns true if there are active filters, false otherwise.
+       */
+      hasActiveFilters() {
+        return this.some((filter) => filter.get("active"));
+      },
+
+      /**
        * This function is used to determine if a feature should be shown or hidden based
        * on the current filters.
        * @param {Object} properties The properties of the feature to be filtered.

--- a/src/js/models/maps/VectorFilter.js
+++ b/src/js/models/maps/VectorFilter.js
@@ -121,15 +121,23 @@ define(["jquery", "underscore", "backbone"], function ($, _, Backbone) {
           // Store a copy of the initial value selection as a default
           this.set("defaultValues", [...modelValues]);
 
-          // If neither values nor allValues exist, then filterModelAvailable is set to false.
-          // This is used to show/hide the Filter by Property panel.
-          // This has to be tested in the future with other portal configs, where this might be the case
-          // if (!hasValues && !hasAllValues) {
-          //   this.set("filterModelAvailable", false);
-          // } else {
-          //   this.set("filterModelAvailable", true);
-          // }
+          // Active status is set conditionally based on whether any features are filtered
+          const filterEvents =
+            "change:values change:min change:max change:filterType";
+          this.stopListening(this, filterEvents);
+          this.listenTo(this, filterEvents, this.setActiveState);
+          // Set the initial active state
+          this.setActiveState();
         }
+      },
+
+      /**
+       * Sets the active state of the filter based values (for categorical
+       * filters) or min/max (for numeric filters).
+       * @since 0.0.0
+       */
+      setActiveState() {
+        this.set("active", this.isActive() === true);
       },
 
       /**
@@ -169,89 +177,34 @@ define(["jquery", "underscore", "backbone"], function ($, _, Backbone) {
         }
       },
 
-      // /**
-      //  * Executed when a new VectorFilter model is created.
-      //  * @param {Object} [attributes] The initial values of the attributes, which will
-      //  * be set on the model.
-      //  * @param {Object} [options] Options for the initialize function.
-      //  */
-      // initialize: function (attributes, options) {
-      //   try {
-
-      //   }
-      //   catch (error) {
-      //     console.log(
-      //       'There was an error initializing a VectorFilter model' +
-      //       '. Error details: ' + error
-      //     );
-      //   }
-      // },
-
-      // /**
-      //  * Parses the given input into a JSON object to be set on the model.
-      //  *
-      //  * @param {TODO} input - The raw response object
-      //  * @return {TODO} - The JSON object of all the VectorFilter attributes
-      //  */
-      // parse: function (input) {
-
-      //   try {
-
-      //     var modelJSON = {};
-
-      //     return modelJSON
-
-      //   }
-      //   catch (error) {
-      //     console.log(
-      //       'There was an error parsing a VectorFilter model' +
-      //       '. Error details: ' + error
-      //     );
-      //   }
-
-      // },
-
-      // /**
-      //  * Overrides the default Backbone.Model.validate.function() to check if this if
-      //  * the values set on this model are valid.
-      //  *
-      //  * @param {Object} [attrs] - A literal object of model attributes to validate.
-      //  * @param {Object} [options] - A literal object of options for this validation
-      //  * process
-      //  *
-      //  * @return {Object} - Returns a literal object with the invalid attributes and
-      //  * their corresponding error message, if there are any. If there are no errors,
-      //  * returns nothing.
-      //  */
-      // validate: function (attrs, options) {
-      //   try {
-
-      //   }
-      //   catch (error) {
-      //     console.log(
-      //       'There was an error validating a VectorFilter model' +
-      //       '. Error details: ' + error
-      //     );
-      //   }
-      // },
-
-      // /**
-      //  * Creates a string using the values set on this model's attributes.
-      //  * @return {string} The VectorFilter string
-      //  */
-      // serialize: function () {
-      //   try {
-      //     var serializedVectorFilter = '';
-
-      //     return serializedVectorFilter;
-      //   }
-      //   catch (error) {
-      //     console.log(
-      //       'There was an error serializing a VectorFilter model' +
-      //       '. Error details: ' + error
-      //     );
-      //   }
-      // },
+      /**
+       * This function checks if the filter is active based on its configuration.
+       * A filter is considered active if it has values set (for categorical filters)
+       * or if it has a min or max set (for numeric filters).
+       * @returns {boolean} Returns true if the filter is active, false otherwise.
+       * @since 0.0.0
+       */
+      isActive() {
+        const isDefinedNumber = (num) => num && num !== 0;
+        const type = this.get("filterType");
+        if (type === "categorical") {
+          // A filter is active if it has values set, or if it has a min or max set
+          const values = this.get("values");
+          const allValues = this.get("allValues");
+          return (
+            Array.isArray(values) &&
+            values.length &&
+            values.length < allValues.length
+          );
+        }
+        if (type === "numeric") {
+          // A numeric filter is active if it has a min or max set
+          const min = this.get("min");
+          const max = this.get("max");
+          return isDefinedNumber(min) || isDefinedNumber(max);
+        }
+        return false; // If filterType is not recognized, return false
+      },
     },
   );
 

--- a/src/js/models/maps/assets/Cesium3DTileset.js
+++ b/src/js/models/maps/assets/Cesium3DTileset.js
@@ -199,21 +199,15 @@ define([
           // When opacity, color, or visibility changes (will also update the filters)
           this.stopListening(
             this,
-            "change:opacity change:color change:visible",
+            "change:opacity change:color change:visible change:filters",
           );
           this.listenTo(
             this,
-            "change:opacity change:color change:visible",
+            "change:opacity change:color change:visible change:filters",
             this.updateAppearance,
           );
 
-          // When filters change
-          this.stopListening(this.get("filters"), "update");
-          this.listenTo(
-            this.get("filters"),
-            "update",
-            this.updateFeatureVisibility,
-          );
+          this.listenTo(this, "change:filters", this.updateFeatureVisibility);
         } catch (error) {
           console.log(
             "There was an error setting listeners in a Cesium3DTileset" +
@@ -282,6 +276,8 @@ define([
           const model = this;
           const cesiumModel = this.get("cesiumModel");
           const filters = this.get("filters");
+
+          if (!cesiumModel) return;
 
           // If there are no filters, just set the show property to true
           if (!filters || !filters.length) {

--- a/src/js/models/maps/assets/MapAsset.js
+++ b/src/js/models/maps/assets/MapAsset.js
@@ -454,6 +454,15 @@ define([
           this.createCesiumModel(true);
         });
 
+        // When any filter models in the filters collection change, then trigger
+        // an event on the asset model that allows models & views to easily
+        // react to filter changes, including replacement of the filter
+        // collection itself.
+        this.stopListening(this.get("filters"), "change");
+        this.listenTo(this.get("filters"), "change", () => {
+          this.trigger("change:filters", this);
+        });
+
         this.listenToSelectedFeatures();
       },
 

--- a/src/js/views/maps/LayerItemView.js
+++ b/src/js/views/maps/LayerItemView.js
@@ -166,19 +166,25 @@ define([
         // Similar to above, add or remove the shown class when the layer's
         // visibility changes
         this.stopListening(this.model, "change:visible");
-        this.listenTo(this.model, "change:visible", this.showVisibility);
+        this.listenTo(this.model, "change:visible", () => {
+          this.showVisibility();
+          this.toggleFilterIconVisibility();
+        });
 
         // Update the item in the list to show when it is loading, loaded, or there's
         // been an error.
         this.stopListening(this.model, "change:status");
         this.listenTo(this.model, "change:status", this.showStatus);
 
-        this.stopListening(this.model, "change:defaultFilterActive");
+        this.stopListening(this.model, "change:filters");
         this.listenTo(
           this.model,
-          "change:defaultFilterActive",
+          "change:filters",
           this.toggleFilterIconVisibility,
         );
+
+        // Set the initial visibility of the filter icon
+        this.toggleFilterIconVisibility();
 
         return this;
       },
@@ -226,13 +232,16 @@ define([
        * filters is selected. Default filters indicated all values on the layer are visible and
        * not user-selected filters are applied. The icon also is set to transparent when the
        * layer visibility is toggled off.
+       * @since 0.0.0
        */
-
       toggleFilterIconVisibility() {
         const filterIconEl = this.$(
           `.${this.classes.visibilityToggle}.${this.classes.button} .${this.classes.filterIcon}`,
         );
-        if (this.model.get("defaultFilterActive")) {
+        if (
+          this.model.get("filters").hasActiveFilters() &&
+          this.model.isVisible()
+        ) {
           filterIconEl.addClass(this.classes.active);
         } else {
           if (filterIconEl.hasClass(this.classes.active)) {
@@ -274,11 +283,7 @@ define([
           layerModel.set("visible", false);
           // Show if hidden
         } else {
-          // If user is trying to make the layer visible, make sure the opacity is not 0
-          if (layerModel.get("opacity") === 0) {
-            layerModel.set("opacity", 0.5);
-          }
-          layerModel.set("visible", true);
+          layerModel.show();
         }
       },
 

--- a/src/js/views/maps/LayerItemView.js
+++ b/src/js/views/maps/LayerItemView.js
@@ -84,8 +84,8 @@ define([
         badge: "map-view__badge",
         tooltip: "map-tooltip",
         button: "map-view__button",
-        filterIcon: "icon-filter",
-        active: "icon-filter--active",
+        filterIcon: "layer-item__filter-icon",
+        filterIconActive: "layer-item__filter-icon--active",
       },
 
       /**
@@ -213,17 +213,20 @@ define([
       },
 
       /**
-       * Insert the filter icon to the right of the label element text.
-       * This icon appears for layers that are "filterable" based on their atrributes.
-       * Filter attributes for each layer are defined in the map model.
-       * Layer items with this icon will have the Filter feature (built using VectorFilterView).
+       * Insert the filter icon to the right of the label element text. This
+       * icon appears for layers that are "filterable" based on their
+       * atrributes. Filter attributes for each layer are defined in the map
+       * model. Layer items with this icon will have the Filter feature (built
+       * using VectorFilterView).
+       * @since 0.0.0
        */
       insertFilterIcon() {
-        const filterIconEl = document.createElement("button");
-        filterIconEl.className = `${this.classes.visibilityToggle} ${this.classes.button}`;
+        const filterIconEl = document.createElement("span");
+        const classes = [this.classes.icon, this.classes.filterIcon];
+        filterIconEl.classList.add(...classes);
         filterIconEl.title = "Filter by property"; // add tooltip
         // filterIconEl.className = `${this.classes.button}`;
-        filterIconEl.innerHTML = `<i class="${this.classes.filterIcon}"></i>`;
+        filterIconEl.innerHTML = `<i class="icon icon-filter"></i>`;
         this.labelEl.appendChild(filterIconEl);
       },
 
@@ -235,18 +238,19 @@ define([
        * @since 0.0.0
        */
       toggleFilterIconVisibility() {
-        const filterIconEl = this.$(
-          `.${this.classes.visibilityToggle}.${this.classes.button} .${this.classes.filterIcon}`,
-        );
+        const filterIconEl = this.$(`.${this.classes.filterIcon}`);
+        if (!filterIconEl?.length || !filterIconEl[0]) {
+          return;
+        }
+
+        const activeClass = this.classes.filterIconActive;
         if (
           this.model.get("filters").hasActiveFilters() &&
           this.model.isVisible()
         ) {
-          filterIconEl.addClass(this.classes.active);
-        } else {
-          if (filterIconEl.hasClass(this.classes.active)) {
-            filterIconEl.removeClass(this.classes.active);
-          }
+          filterIconEl.addClass(activeClass);
+        } else if (filterIconEl.hasClass(activeClass)) {
+          filterIconEl.removeClass(activeClass);
         }
       },
 

--- a/src/js/views/maps/VectorFilterView.js
+++ b/src/js/views/maps/VectorFilterView.js
@@ -178,8 +178,6 @@ define([
        * During initialization, the filterStatus is false, and the "values"
        */
       renderFilterPropertyValueSelect() {
-        const defaultFilterStatus = this.model.get("defaultFilterActive");
-        const isLayerVisible = this.model.get("visible");
         const propertyAllValuesOptions = [];
 
         const propertyAllValues = this.filterModel.get("allValues") || [];
@@ -191,14 +189,7 @@ define([
             });
           });
         }
-        let selectedValues = [];
-
-        // If the layer visibility is turned on, and if the defaultFilterActive is false
-        // then set selectedValues as the filter model's values.
-        // Otherwise no values are pre-selected in the dropdown.
-        if (isLayerVisible && !defaultFilterStatus) {
-          selectedValues = [...(this.filterModel.get("values") || [])];
-        }
+        const selectedValues = [...(this.filterModel.get("values") || [])];
 
         const valuesSelectContainer = this.$(
           `.${this.classes.valuesDropdownContainer}`,
@@ -253,41 +244,23 @@ define([
        */
 
       handleFilterValuesSelectionChange(selectedValues) {
-        let filterValues = (selectedValues || []).filter(
+        const filterValues = (selectedValues || []).filter(
           (value) => value !== "",
         ); // filterValues will be 0 when everything is cleared
 
-        const isLayerVisible = this.model.get("visible");
+        this.filterModel.set("values", [...filterValues]);
 
-        if (isLayerVisible || filterValues.length) {
-          // When the filter is active, and the layer is visible the filter icon is always turned on (i.e., blue)
-          this.model.set("defaultFilterActive", false);
-
-          if (!filterValues?.length) {
-            filterValues = this.filterModel.get("allValues");
-            // When all filter values are de-selected, the default filter is true, which means all layer values are visible.
-            // This variable is used to toggle the filter icon to be off (i.e., transparent).
-            // This variable is also used later when re-rendering the filter values dropdown.
-            this.model.set("defaultFilterActive", true);
-          } else {
-            // this.filterModel.set("defaultFilterActive", false);
-          }
-          this.filterModel.set("values", filterValues);
-
-          // If there is any value selected in the Filter by Property feature, then make sure the asset is
-          // also visible. This updates the layer toggle visibility icon (i.e., eye icon).
-          if (filterValues?.length && !this.model.get("visible")) {
-            this.model.set("visible", true);
-          }
-
-          // Set visibility of the layer to false when all values are cleared from the attribute values dropdown
-          if (!filterValues?.length) {
-            this.model.set("visible", false);
-          }
-
-          // manually trigger listener for updating layer visibility.
-          this.model.trigger("change:opacity");
-          this.model.trigger("change:defaultFilterActive");
+        // If there is any value selected in the Filter by Property feature,
+        // then make sure the asset is also visible. This updates the layer
+        // toggle visibility icon (i.e., eye icon) and makes the layer visible
+        // on the map.
+        if (filterValues?.length && !this.model.isVisible()) {
+          this.model.show();
+        } else if (!filterValues?.length && this.model.isVisible()) {
+          // When all values are cleared from the attribute values dropdown,
+          // the layer visibility is set to false, and the filter icon is
+          // turned off (i.e., transparent).
+          this.model.set("visible", false);
         }
       },
     },


### PR DESCRIPTION
This PR builds on #1770 and makes several refinements across the filter model, collection, and views to make state handling and UI behaviour a little more consistent and robust. These changes were made with the goal of supporting multiple filters in mind, while also simplifying some of the complexity around how filters are applied and how we defined if a a layer has active filters or not.

I made these changes directly (rather than requesting them) since we're on a tight timeline, but I've added plent of details in the commit messages and comments to help explain the reasoning behind each change.

The main changes include:
- Cleaned up the `VectorFilterView` to avoid redundant checks, simplify logic, and clarify naming.
- Delegated filter icon visibility logic to `LayerItemView` and the filters collection, so it now reacts to all filters, not just those tied to a single view.
- Introduced an active property on each filter model and a `hasActiveFilters()` method in the collection to standardize how active filters are tracked.
- Ensured `MapAsset` responds to any change in filter models via a centralized `change:filters` event.
- Cleaned up CSS and DOM semantics for the filter icon.

Here are the commits and their purposes. Each has lots of details in the commit messages, so please check those for more context:

- [`a4c19b7`](https://github.com/NCEAS/metacatui/commit/a4c19b714b929d43001042c845aafd4e5f3040a9) – Added `active` status and `hasActiveFilters()` method.
- [`0a2ad21`](https://github.com/NCEAS/metacatui/commit/0a2ad211c8be53ab3cc821f86c082cb66b584dad) – Centralized `change:filters` event for `MapAsset`.
- [`3c53f19`](https://github.com/NCEAS/metacatui/commit/3c53f19719fcdc5ba6d0776485e892900221a247) – Updated filter icon logic using `hasActiveFilters()`.
- [`04d5c22`](https://github.com/NCEAS/metacatui/commit/04d5c2280969f3d565679ca6e5b05350f5ce38b5) – Fixed filter icon CSS and semantics.
- [`de4c57c`](https://github.com/NCEAS/metacatui/commit/de4c57c7a5986fa6c9655dc04fb45354831a554d) – Simplified filter value selection and application.
- [`169d44f`](https://github.com/NCEAS/metacatui/commit/169d44f45d9f099240d4d984ec9e32175d5f75f7) – Cleaned up `VectorFilterView` logic and naming.

Let me know if these changes work, if they make sense, if anything needs adjustment. Happ to walk through any part of it if needed!