### PR TITLE
Use POST by default for all solr queries

### DIFF
--- a/src/js/common/QueryService.js
+++ b/src/js/common/QueryService.js
@@ -1,0 +1,300 @@
+"use strict";
+
+define(["jquery"], ($) => {
+  const DEFAULT_MAX_QUERY_LEN = 2000;
+
+  /**
+   *
+   * @typedef {object} QueryOptions
+   * @property {string}  q Solr query (Lucene syntax). Default `*:*`.
+   * @property {string[]|string} [filterQueries] Filter queries (fq) to apply.
+   * @property {string[]|string} [fields] Fields to return (fl).
+   * @property {string} [sort] Sort clause, e.g., `'dateUploaded desc'`.
+   * @property {number} [rows] Result row count. Default `25`.
+   * @property {number} [start] Result offset. Default `0`.
+   * @property {string[]} [facets] Fields to facet on.
+   * @property {string[]} [facetQueries] Facet queries (fq) to apply.
+   * @property {string[]} [statsFields] Fields for statistics (stats.field).
+   * @property {number} [facetLimit] Default `-1` (no limit).
+   * @property {number} [facetMinCount] Default `1`.
+   * @property {boolean} [usePost] Force POST / GET (overrides auto-choice).
+   * @property {boolean} [useAuth=true] Inject MetacatUI auth headers?
+   */
+
+  /**
+   * QueryService provides methods to execute Solr queries against the
+   * configured query service URL. It supports both GET and POST requests,
+   * handles query parameters, and can include facets, filter queries, and
+   * statistics fields.
+   * @class QueryService
+   * @example
+   */
+  class QueryService {
+    // --------------------------------------------------------------------- //
+    //  Public API
+    // --------------------------------------------------------------------- //
+
+    /**
+     * Execute a Solr query and obtain the raw JSON response.
+     * @param {QueryOptions} opts Query parameters & flags.
+     * @returns {jqXHR} jQuery AJAX promise.
+     */
+    static query(opts = {}) {
+      const {
+        q = "*:*",
+        filterQueries = [],
+        fields = [],
+        sort = "dateUploaded desc",
+        rows = 25,
+        start = 0,
+        facets = [],
+        facetQueries = [],
+        statsFields = [],
+        facetLimit = -1,
+        facetMinCount = 1,
+        usePost,
+        useAuth = true,
+      } = opts;
+
+      const endpoint = QueryService.queryServiceUrl();
+      const urlBase = endpoint.replace(/\?$/, "");
+      const queryParams = QueryService.buildQueryObject({
+        q,
+        filterQueries,
+        fields,
+        sort,
+        rows,
+        start,
+        facets,
+        facetQueries,
+        statsFields,
+        facetLimit,
+        facetMinCount,
+      });
+
+      const shouldPost = QueryService.decidePost({
+        explicit: usePost,
+        queryParams,
+        urlBase,
+      });
+
+      let ajaxSettings = shouldPost
+        ? QueryService.buildPostSettings(urlBase, queryParams)
+        : QueryService.buildGetSettings(urlBase, queryParams);
+
+      if (useAuth) {
+        ajaxSettings = QueryService.mergeAuth(ajaxSettings);
+      }
+
+      return $.ajax(ajaxSettings);
+    }
+
+    /**
+     * Build query parameters as a plain object (useful for tests or logging).
+     * @param {QueryOptions} opts Query options.
+     * @returns {object} Query parameters object.
+     */
+    static buildQueryParams(opts = {}) {
+      return QueryService.buildQueryObject(opts);
+    }
+
+    // --------------------------------------------------------------------- //
+    //  Private helpers
+    // --------------------------------------------------------------------- //
+
+    /**
+     * Get the configured query service URL from MetacatUI's appModel. Throws an
+     * error if not configured.
+     * @returns {string} The query service URL.
+     * @throws {Error} If queryServiceUrl is not configured.
+     */
+    static queryServiceUrl() {
+      if (!MetacatUI?.appModel?.get("queryServiceUrl")) {
+        throw new Error(
+          "QueryService.queryServiceUrl(): queryServiceUrl is not configured.",
+        );
+      }
+      return MetacatUI.appModel.get("queryServiceUrl");
+    }
+
+    /**
+     * Construct a query object for Solr. Formats the parameters according to
+     * Solr's expectations, including facets, filter queries, and stats fields.
+     * Applies defaults for missing parameters.
+     * @param {QueryOptions} opts Query options.
+     * @returns {object} Query parameters object.
+     */
+    static buildQueryObject({
+      q,
+      filterQueries,
+      fields,
+      sort,
+      rows,
+      start,
+      facets,
+      facetQueries,
+      statsFields,
+      facetLimit,
+      facetMinCount,
+    }) {
+      const params = {
+        q,
+        rows,
+        start,
+        wt: "json",
+      };
+
+      // fq
+      const fqArray = [].concat(filterQueries).flat().filter(Boolean);
+      fqArray.forEach((fq) => {
+        params.fq = params.fq || [];
+        params.fq.push(fq);
+      });
+
+      // fl
+      if (fields) {
+        const fieldsArray = [].concat(fields).flat().filter(Boolean);
+        if (fieldsArray.length) {
+          params.fl = fieldsArray.join(",");
+        }
+      }
+
+      // sort
+      if (sort) params.sort = sort.replace(/\+/g, " ");
+
+      // facets
+      const facetsArray = [].concat(facets).flat().filter(Boolean);
+      if (facetsArray.length) {
+        params.facet = "true";
+        facetsArray.forEach((field) => {
+          params["facet.field"] = params["facet.field"] || [];
+          params["facet.field"].push(field);
+        });
+        params["facet.mincount"] = facetMinCount;
+        params["facet.limit"] = facetLimit;
+        params["facet.sort"] = "index";
+      }
+
+      // facet queries
+      const facetQueriesArray = [].concat(facetQueries).flat().filter(Boolean);
+      if (facetQueriesArray.length) {
+        params.facet = "true";
+        facetQueriesArray.forEach((fq) => {
+          params["facet.query"] = params["facet.query"] || [];
+          params["facet.query"].push(fq);
+        });
+      }
+
+      // stats
+      const statsFieldsArray = [].concat(statsFields).flat().filter(Boolean);
+      if (statsFieldsArray.length) {
+        params.stats = "true";
+        statsFieldsArray.forEach((field) => {
+          params["stats.field"] = params["stats.field"] || [];
+          params["stats.field"].push(field);
+        });
+      }
+
+      return params;
+    }
+
+    /**
+     * Decide whether to use POST or GET for the query. If `explicit` is
+     * provided, it overrides the auto-decision. If `disableQueryPOSTs` is set,
+     * always use GET. If the query string length exceeds `maxQueryLength`, use
+     * POST.
+     * @param {object} options The options to decide POST/GET.
+     * @param {boolean} [options.explicit] Explicitly force POST or GET.
+     * @param {object} options.queryParams The query parameters to evaluate.
+     * @param {string} options.urlBase The base URL for the query service.
+     * @returns {boolean} `true` for POST, `false` for GET.
+     */
+    static decidePost({ explicit, queryParams, urlBase }) {
+      if (typeof explicit === "boolean") return explicit;
+
+      // Safely read disableQueryPOSTs; default to false
+      const disablePost = !!MetacatUI?.appModel?.get("disableQueryPOSTs");
+      if (disablePost) return false;
+
+      // Use default when maxQueryLength isn’t configured
+      const maxLen =
+        MetacatUI?.appModel?.get("maxQueryLength") ?? DEFAULT_MAX_QUERY_LEN;
+
+      const qs = QueryService.toQueryString(queryParams);
+      return urlBase.length + 1 + qs.length > maxLen;
+    }
+
+    /**
+     * Convert an object to a URL query string. Handles arrays by appending each
+     * item with the same key.
+     * @param {object} obj The object to convert.
+     * @returns {string} The URL-encoded query string.
+     */
+    static toQueryString(obj) {
+      const usp = new URLSearchParams();
+      Object.entries(obj).forEach(([k, v]) => {
+        if (Array.isArray(v)) {
+          v.forEach((item) => usp.append(k, item));
+        } else {
+          usp.append(k, v);
+        }
+      });
+      return usp.toString();
+    }
+
+    /**
+     * Build GET ajax settings for a query.
+     * @param {string} urlBase The base URL for the query service.
+     * @param {object} queryParams The query parameters to include.
+     * @returns {object} jQuery AJAX settings object.
+     */
+    static buildGetSettings(urlBase, queryParams) {
+      const qs = QueryService.toQueryString(queryParams);
+      const url = urlBase + (urlBase.includes("?") ? "" : "?") + qs;
+      return {
+        url,
+        type: "GET",
+        dataType: "json",
+      };
+    }
+
+    /**
+     * Build POST ajax settings for a query.
+     * @param {string} urlBase The base URL for the query service.
+     * @param {object} queryParams The query parameters to include.
+     * @returns {object} jQuery AJAX settings object.
+     */
+    static buildPostSettings(urlBase, queryParams) {
+      const fd = new FormData();
+      Object.entries(queryParams).forEach(([k, v]) => {
+        if (Array.isArray(v)) {
+          v.forEach((item) => fd.append(k, item));
+        } else {
+          fd.append(k, v);
+        }
+      });
+      return {
+        url: urlBase,
+        type: "POST",
+        data: fd,
+        contentType: false,
+        processData: false,
+        dataType: "json",
+      };
+    }
+
+    /**
+     * Merge authentication settings into AJAX options. If `appUserModel` is not
+     * available, returns the original options.
+     * @param {object} ajaxOpts The AJAX options to merge with auth.
+     * @returns {object} Merged AJAX options with authentication headers.
+     */
+    static mergeAuth(ajaxOpts) {
+      if (!MetacatUI.appUserModel?.createAjaxSettings) return ajaxOpts;
+      const auth = MetacatUI.appUserModel.createAjaxSettings();
+      return { ...ajaxOpts, ...auth };
+    }
+  }
+
+  return QueryService;
+});

--- a/src/js/models/SolrResult.js
+++ b/src/js/models/SolrResult.js
@@ -3,11 +3,15 @@ define(["jquery", "underscore", "backbone"], ($, _, Backbone) => {
    * @class SolrResult
    * @classdesc A single result from the Solr search service
    * @classcategory Models
-   * @extends Backbone.Model
+   * @augments Backbone.Model
    */
   const SolrResult = Backbone.Model.extend(
     /** @lends SolrResult.prototype */ {
-      // This model contains all of the attributes found in the SOLR 'docs' field inside of the SOLR response element
+      /**
+       * @property {object} defaults - The default attributes for this model
+       * This model contains all of the attributes found in the SOLR 'docs'
+       * field inside of the SOLR response element
+       */
       defaults: {
         abstract: null,
         entityName: null,
@@ -24,7 +28,6 @@ define(["jquery", "underscore", "backbone"], ($, _, Backbone) => {
         attributeName: "",
         beginDate: "",
         endDate: "",
-        pubDate: "",
         id: "",
         seriesId: null,
         resourceMap: null,
@@ -52,11 +55,11 @@ define(["jquery", "underscore", "backbone"], ($, _, Backbone) => {
         serviceOutput: null,
         notFound: false,
         newestVersion: null,
-        //@type {string} - The system metadata XML as a string
+        // @type {string} - The system metadata XML as a string
         systemMetadata: null,
         provSources: [],
         provDerivations: [],
-        //Provenance index fields
+        // Provenance index fields
         prov_generated: null,
         prov_generatedByDataONEDN: null,
         prov_generatedByExecution: null,
@@ -81,30 +84,34 @@ define(["jquery", "underscore", "backbone"], ($, _, Backbone) => {
         prov_wasInformedBy: null,
       },
 
-      initialize: function () {
+      /** @inheritdoc */
+      initialize() {
         this.setURL();
         this.on("change:id", this.setURL);
 
         this.set("type", this.getType());
-        this.on("change:read_count_i", function () {
+        this.on("change:read_count_i", function setReads() {
           this.set("reads", this.get("read_count_i"));
         });
       },
 
+      /** @type {string} The type of this model */
       type: "SolrResult",
 
-      // Toggle the `selected` state of the result
-      toggle: function () {
+      /** Toggle the `selected` state of the result */
+      toggle() {
         this.selected = !this.get("selected");
       },
 
       /**
-       * Returns a plain-english version of the general format - either image, program, metadata, PDF, annotation or data
-       * @return {string}
+       * Returns a plain-english version of the general format - either image,
+       * program, metadata, PDF, annotation or data
+       * @returns {string} The type of this object, such as "image", "program",
+       * "metadata", "PDF", "annotation" or "data"
        */
-      getType: function () {
-        //The list of formatIds that are images
-        var imageIds = [
+      getType() {
+        // The list of formatIds that are images
+        const imageIds = [
           "image/gif",
           "image/jp2",
           "image/jpeg",
@@ -113,48 +120,51 @@ define(["jquery", "underscore", "backbone"], ($, _, Backbone) => {
           "image/svg+xml",
           "image/bmp",
         ];
-        //The list of formatIds that are images
-        var pdfIds = ["application/pdf"];
-        var annotationIds = [
+        // The list of formatIds that are images
+        const pdfIds = ["application/pdf"];
+        const annotationIds = [
           "http://docs.annotatorjs.org/en/v1.2.x/annotation-format.html",
         ];
-        var collectionIds = [
+        const collectionIds = [
           "https://purl.dataone.org/collections-1.0.0",
           "https://purl.dataone.org/collections-1.1.0",
         ];
-        var portalIds = [
+        const portalIds = [
           "https://purl.dataone.org/portals-1.0.0",
           "https://purl.dataone.org/portals-1.1.0",
         ];
 
-        //Determine the type via provONE
-        var instanceOfClass = this.get("prov_instanceOfClass");
+        // Determine the type via provONE
+        const instanceOfClass = this.get("prov_instanceOfClass");
         if (typeof instanceOfClass !== "undefined") {
-          var programClass = _.filter(instanceOfClass, function (className) {
-            return className.indexOf("#Program") > -1;
-          });
+          const programClass = _.filter(
+            instanceOfClass,
+            (className) => className.indexOf("#Program") > -1,
+          );
           if (typeof programClass !== "undefined" && programClass.length)
             return "program";
-        } else {
-          if (this.get("prov_generated") || this.get("prov_used"))
-            return "program";
-        }
+        } else if (this.get("prov_generated") || this.get("prov_used"))
+          return "program";
 
-        //Determine the type via file format
+        // Determine the type via file format
         if (_.contains(collectionIds, this.get("formatId")))
           return "collection";
         if (_.contains(portalIds, this.get("formatId"))) return "portal";
-        if (this.get("formatType") == "METADATA") return "metadata";
+        if (this.get("formatType") === "METADATA") return "metadata";
         if (_.contains(imageIds, this.get("formatId"))) return "image";
         if (_.contains(pdfIds, this.get("formatId"))) return "PDF";
         if (_.contains(annotationIds, this.get("formatId")))
           return "annotation";
-        else return "data";
+        return "data";
       },
 
-      //Returns a plain-english version of the specific format ID (for selected ids)
-      getFormat: function () {
-        var formatMap = {
+      /**
+       * Get a plain-english version of the specific format ID (for selected
+       * ids)
+       * @returns {string} The specific format of this object
+       */
+      getFormat() {
+        const formatMap = {
           "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet":
             "Microsoft Excel OpenXML",
           "application/vnd.openxmlformats-officedocument.wordprocessingml.document":
@@ -212,7 +222,10 @@ define(["jquery", "underscore", "backbone"], ($, _, Backbone) => {
         return formatMap[this.get("formatId")] || this.get("formatId");
       },
 
-      setURL: function () {
+      /**
+       * Sets the URL for this object based on the id and seriesId
+       */
+      setURL() {
         if (MetacatUI.appModel.get("objectServiceUrl"))
           this.set(
             "url",
@@ -229,11 +242,11 @@ define(["jquery", "underscore", "backbone"], ($, _, Backbone) => {
 
       /**
        * Checks if the pid or sid or given string is a DOI
-       *
-       * @param {string} customString - Optional. An identifier string to check instead of the id and seriesId attributes on the model
+       * @param {string} customString - Optional. An identifier string to check
+       * instead of the id and seriesId attributes on the model
        * @returns {boolean} True if it is a DOI
        */
-      isDOI: function (customString) {
+      isDOI(customString) {
         return (
           MetacatUI.appModel.isDOI(customString) ||
           MetacatUI.appModel.isDOI(this.get("id")) ||
@@ -241,32 +254,33 @@ define(["jquery", "underscore", "backbone"], ($, _, Backbone) => {
         );
       },
 
-      /*
+      /**
        * Checks if the currently-logged-in user is authorized to change
        * permissions (or other action if set as parameter) on this doc
-       * @param {string} [action=changePermission] - The action (read, write, or changePermission) to check
-       * if the current user has authorization to perform. By default checks for the highest level of permission.
+       * @param {string} [action] - The action (read, write, or
+       * changePermission) to check if the current user has authorization to
+       * perform. By default checks for the highest level of permission.
+       * @returns {boolean|null} True if the user is authorized, false if not,
+       * or null if the authServiceUrl is not set
        */
-      checkAuthority: function (action = "changePermission") {
-        var authServiceUrl = MetacatUI.appModel.get("authServiceUrl");
+      checkAuthority(action = "changePermission") {
+        const authServiceUrl = MetacatUI.appModel.get("authServiceUrl");
         if (!authServiceUrl) return false;
 
-        var model = this;
+        const model = this;
 
-        var requestSettings = {
-          url:
-            authServiceUrl +
-            encodeURIComponent(this.get("id")) +
-            "?action=" +
-            action,
+        const requestSettings = {
+          url: `${
+            authServiceUrl + encodeURIComponent(this.get("id"))
+          }?action=${action}`,
           type: "GET",
-          success: function (data, textStatus, xhr) {
-            model.set("isAuthorized_" + action, true);
+          success(_data, _textStatus, _xhr) {
+            model.set(`isAuthorized_${action}`, true);
             model.set("isAuthorized", true);
             model.trigger("change:isAuthorized");
           },
-          error: function (xhr, textStatus, errorThrown) {
-            model.set("isAuthorized_" + action, false);
+          error(_xhr, _textStatus, _errorThrown) {
+            model.set(`isAuthorized_${action}`, false);
             model.set("isAuthorized", false);
           },
         };
@@ -276,6 +290,7 @@ define(["jquery", "underscore", "backbone"], ($, _, Backbone) => {
             MetacatUI.appUserModel.createAjaxSettings(),
           ),
         );
+        return null;
       },
 
       /**
@@ -400,101 +415,117 @@ define(["jquery", "underscore", "backbone"], ($, _, Backbone) => {
         );
       },
 
-      getInfo: function (fields) {
-        var model = this;
+      /**
+       * Get the information for this object from the Solr index
+       * @param {string} [queryFields] - Optional. A string of fields to
+       * retrieve from the Solr index. If not specified, a default set of fields
+       * will be used.
+       */
+      getInfo(queryFields) {
+        const model = this;
 
-        if (!fields)
-          var fields =
-            "abstract,id,seriesId,fileName,resourceMap,formatType,formatId,obsoletedBy,isDocumentedBy,documents,title,origin,keywords,attributeName,pubDate,eastBoundCoord,westBoundCoord,northBoundCoord,southBoundCoord,beginDate,endDate,dateUploaded,archived,datasource,replicaMN,isAuthorized,isPublic,size,read_count_i,isService,serviceTitle,serviceEndpoint,serviceOutput,serviceDescription,serviceType,project,dateModified";
+        const fields =
+          queryFields ||
+          "abstract,id,seriesId,fileName,resourceMap,formatType,formatId," +
+            "obsoletedBy,isDocumentedBy,documents,title,origin,keywords," +
+            "attributeName,pubDate,eastBoundCoord,westBoundCoord," +
+            "northBoundCoord,southBoundCoord,beginDate,endDate,dateUploaded," +
+            "archived,datasource,replicaMN,isAuthorized,isPublic,size," +
+            "read_count_i,isService,serviceTitle,serviceEndpoint," +
+            "serviceOutput,serviceDescription,serviceType,project,dateModified";
 
-        var escapeSpecialChar = MetacatUI.appSearchModel.escapeSpecialChar;
+        const { escapeSpecialChar } = MetacatUI.appSearchModel;
 
-        var query = "q=";
+        let query = "q=";
 
-        //If there is no seriesId set, then search for pid or sid
+        // If there is no seriesId set, then search for pid or sid
         if (!this.get("seriesId"))
-          query +=
-            '(id:"' +
-            escapeSpecialChar(encodeURIComponent(this.get("id"))) +
-            '" OR seriesId:"' +
-            escapeSpecialChar(encodeURIComponent(this.get("id"))) +
-            '")';
-        //If a seriesId is specified, then search for that
+          query += `(id:"${escapeSpecialChar(
+            encodeURIComponent(this.get("id")),
+          )}" OR seriesId:"${escapeSpecialChar(
+            encodeURIComponent(this.get("id")),
+          )}")`;
+        // If a seriesId is specified, then search for that
         else if (this.get("seriesId") && this.get("id").length > 0)
-          query +=
-            '(seriesId:"' +
-            escapeSpecialChar(encodeURIComponent(this.get("seriesId"))) +
-            '" AND id:"' +
-            escapeSpecialChar(encodeURIComponent(this.get("id"))) +
-            '")';
-        //If only a seriesId is specified, then just search for the most recent version
+          query += `(seriesId:"${escapeSpecialChar(
+            encodeURIComponent(this.get("seriesId")),
+          )}" AND id:"${escapeSpecialChar(
+            encodeURIComponent(this.get("id")),
+          )}")`;
+        // If only a seriesId is specified, then just search for the most recent
+        // version
         else if (this.get("seriesId") && !this.get("id"))
-          query +=
-            'seriesId:"' +
-            escapeSpecialChar(encodeURIComponent(this.get("id"))) +
-            '" -obsoletedBy:*';
+          query += `seriesId:"${escapeSpecialChar(
+            encodeURIComponent(this.get("id")),
+          )}" -obsoletedBy:*`;
 
         query +=
-          "&fl=" +
-          fields + //Specify the fields to return
-          "&wt=json&rows=1000" + //Get the results in JSON format and get 1000 rows
-          "&archived=archived:*"; //Get archived or unarchived content
+          `&fl=${
+            fields // Specify the fields to return
+          }&wt=json&rows=1000` + // Get the results in JSON format and get 1000 rows
+          `&archived=archived:*`; // Get archived or unarchived content
 
-        var requestSettings = {
+        const requestSettings = {
           url: MetacatUI.appModel.get("queryServiceUrl") + query,
           type: "GET",
-          success: function (data, response, xhr) {
-            //If the Solr response was not as expected, trigger and error and exit
-            if (!data || typeof data.response == "undefined") {
+          success(data, _response, _xhr) {
+            // If the Solr response was not as expected, trigger and error and
+            // exit
+            if (!data || typeof data.response === "undefined") {
               model.set("indexed", false);
               model.trigger("getInfoError");
               return;
             }
 
-            var docs = data.response.docs;
+            const { docs } = data.response;
 
-            if (docs.length == 1) {
+            if (docs.length === 1) {
               docs[0].resourceMap = model.parseResourceMapField(docs[0]);
               model.set(docs[0]);
               model.trigger("sync");
             }
-            //If we searched by seriesId, then let's find the most recent version in the series
+            // If we searched by seriesId, then let's find the most recent
+            // version in the series
             else if (docs.length > 1) {
-              //Filter out docs that are obsoleted
-              var mostRecent = _.reject(docs, function (doc) {
-                return typeof doc.obsoletedBy !== "undefined";
-              });
+              // Filter out docs that are obsoleted
+              const mostRecent = _.reject(
+                docs,
+                (doc) => typeof doc.obsoletedBy !== "undefined",
+              );
 
-              //If there is only one doc that is not obsoleted (the most recent), then
-              // set this doc's values on this model
-              if (mostRecent.length == 1) {
+              // If there is only one doc that is not obsoleted (the most
+              // recent), then set this doc's values on this model
+              if (mostRecent.length === 1) {
                 mostRecent[0].resourceMap = model.parseResourceMapField(
                   mostRecent[0],
                 );
                 model.set(mostRecent[0]);
                 model.trigger("sync");
               } else {
-                //If there are multiple docs without an obsoletedBy statement, then
-                // retreive the head of the series via the system metadata
-                var sysMetaRequestSettings = {
+                // If there are multiple docs without an obsoletedBy statement,
+                // then retreive the head of the series via the system metadata
+                const sysMetaRequestSettings = {
                   url:
                     MetacatUI.appModel.get("metaServiceUrl") +
                     encodeURIComponent(docs[0].seriesId),
                   type: "GET",
-                  success: function (sysMetaData) {
-                    //Get the identifier node from the system metadata
-                    var seriesHeadID = $(sysMetaData).find("identifier").text();
-                    //Get the doc from the Solr results with that identifier
-                    var seriesHead = _.findWhere(docs, { id: seriesHeadID });
+                  success(sysMetaData) {
+                    // Get the identifier node from the system metadata
+                    const seriesHeadID = $(sysMetaData)
+                      .find("identifier")
+                      .text();
+                    // Get the doc from the Solr results with that identifier
+                    const seriesHead = _.findWhere(docs, { id: seriesHeadID });
 
-                    //If there is a doc in the Solr results list that matches the series head id
+                    // If there is a doc in the Solr results list that matches
+                    // the series head id
                     if (seriesHead) {
                       seriesHead.resourceMap =
                         model.parseResourceMapField(seriesHead);
-                      //Set those values on this model
+                      // Set those values on this model
                       model.set(seriesHead);
                     }
-                    //Otherwise, just fall back on the first doc in the list
+                    // Otherwise, just fall back on the first doc in the list
                     else if (mostRecent.length) {
                       mostRecent[0].resourceMap = model.parseResourceMapField(
                         mostRecent[0],
@@ -509,7 +540,7 @@ define(["jquery", "underscore", "backbone"], ($, _, Backbone) => {
 
                     model.trigger("sync");
                   },
-                  error: function (xhr, textStatus, errorThrown) {
+                  error(__xhr, _textStatus, _errorThrown) {
                     // Fall back on the first doc in the list
                     if (mostRecent.length) {
                       model.set(mostRecent[0]);
@@ -530,11 +561,11 @@ define(["jquery", "underscore", "backbone"], ($, _, Backbone) => {
               }
             } else {
               model.set("indexed", false);
-              //Try getting the system metadata as a backup
+              // Try getting the system metadata as a backup
               model.getSysMeta();
             }
           },
-          error: function (xhr, textStatus, errorThrown) {
+          error(_xhr, _textStatus, _errorThrown) {
             model.set("indexed", false);
             model.trigger("getInfoError");
           },
@@ -548,43 +579,41 @@ define(["jquery", "underscore", "backbone"], ($, _, Backbone) => {
         );
       },
 
-      getCitationInfo: function () {
+      /** Get the citation information for this object from the Solr index */
+      getCitationInfo() {
         this.getInfo(
           "id,seriesId,origin,pubDate,dateUploaded,title,datasource,project",
         );
       },
 
-      /*
-       * Get the system metadata for this object
-       */
-      getSysMeta: function () {
-        var url =
-            MetacatUI.appModel.get("metaServiceUrl") +
-            encodeURIComponent(this.get("id")),
-          model = this;
+      /** Get the system metadata for this object */
+      getSysMeta() {
+        const url =
+          MetacatUI.appModel.get("metaServiceUrl") +
+          encodeURIComponent(this.get("id"));
+        const model = this;
 
-        var requestSettings = {
-          url: url,
+        const requestSettings = {
+          url,
           type: "GET",
           dataType: "text",
-          success: function (data, response, xhr) {
+          success(data, _response, _xhr) {
             if (data && data.length) {
               model.set("systemMetadata", data);
             }
 
-            //Check if this is archvied
-            var archived = $(data).find("archived").text() == "true";
+            // Check if this is archvied
+            const archived = $(data).find("archived").text() === "true";
             model.set("archived", archived);
 
-            //Get the file size
+            // Get the file size
             model.set("size", $(data).find("size").text() || "");
 
-            //Get the entity name
+            // Get the entity name
             model.set("fileName", $(data).find("filename").text() || "");
 
-            //Check if this is a metadata doc
-            var formatId = $(data).find("formatid").text() || "",
-              formatType;
+            // Check if this is a metadata doc
+            const formatId = $(data).find("formatid").text() || "";
             model.set("formatId", formatId);
             if (
               formatId.indexOf("ecoinformatics.org") > -1 ||
@@ -606,21 +635,22 @@ define(["jquery", "underscore", "backbone"], ($, _, Backbone) => {
             )
               model.set("formatType", "METADATA");
 
-            //Trigger the sync event so the app knows we found the model info
+            // Trigger the sync event so the app knows we found the model info
             model.trigger("sync");
           },
-          error: function (response) {
-            //When the user is unauthorized to access this object, trigger a 401 error
-            if (response.status == 401) {
+          error(response) {
+            // When the user is unauthorized to access this object, trigger a
+            // 401 error
+            if (response.status === 401) {
               model.set("notFound", true);
               model.trigger("401");
             }
-            //When the object doesn't exist, trigger a 404 error
-            else if (response.status == 404) {
+            // When the object doesn't exist, trigger a 404 error
+            else if (response.status === 404) {
               model.set("notFound", true);
               model.trigger("404");
             }
-            //Other error codes trigger a generic error
+            // Other error codes trigger a generic error
             else {
               model.trigger("error");
             }
@@ -635,49 +665,59 @@ define(["jquery", "underscore", "backbone"], ($, _, Backbone) => {
         );
       },
 
-      //Transgresses the obsolence chain until it finds the newest version that this user is authorized to read
-      findLatestVersion: function (newestVersion, possiblyNewer) {
+      /**
+       * Transgresses the obsolence chain until it finds the newest version that
+       * this user is authorized to read
+       * @param {string} [newest] - The id of the newest version to start with.
+       * If not supplied, this model's id will be used.
+       * @param {string} [newer] - The id of a possibly newer version.
+       */
+      findLatestVersion(newest, newer) {
         // Make sure we have the /meta service configured
         if (!MetacatUI.appModel.get("metaServiceUrl")) return;
 
-        //If no pid was supplied, use this model's id
+        let newestVersion = newest;
+        let possiblyNewer = newer;
+
+        // If no pid was supplied, use this model's id
         if (!newestVersion) {
-          var newestVersion = this.get("id");
-          var possiblyNewer = this.get("obsoletedBy");
+          newestVersion = this.get("id");
+          possiblyNewer = this.get("obsoletedBy");
         }
 
-        //If this isn't obsoleted by anything, then there is no newer version
+        // If this isn't obsoleted by anything, then there is no newer version
         if (!possiblyNewer) {
           this.set("newestVersion", newestVersion);
           return;
         }
 
-        var model = this;
+        const model = this;
 
-        //Get the system metadata for the possibly newer version
-        var requestSettings = {
+        // Get the system metadata for the possibly newer version
+        const requestSettings = {
           url:
             MetacatUI.appModel.get("metaServiceUrl") +
             encodeURIComponent(possiblyNewer),
           type: "GET",
-          success: function (data) {
+          success(data) {
             // the response may have an obsoletedBy element
-            var obsoletedBy = $(data).find("obsoletedBy").text();
+            const obsoletedBy = $(data).find("obsoletedBy").text();
 
-            //If there is an even newer version, then get it and rerun this function
+            // If there is an even newer version, then get it and rerun this
+            // function
             if (obsoletedBy)
               model.findLatestVersion(possiblyNewer, obsoletedBy);
-            //If there isn't a newer version, then this is it
+            // If there isn't a newer version, then this is it
             else model.set("newestVersion", possiblyNewer);
           },
-          error: function (xhr) {
-            //If this newer version isn't found or accessible, then save the last
-            // accessible id as the newest version
+          error(xhr) {
+            // If this newer version isn't found or accessible, then save the
+            // last accessible id as the newest version
             if (
-              xhr.status == 401 ||
-              xhr.status == 404 ||
-              xhr.status == "401" ||
-              xhr.status == "404"
+              xhr.status === 401 ||
+              xhr.status === 404 ||
+              xhr.status === "401" ||
+              xhr.status === "404"
             ) {
               model.set("newestVersion", newestVersion);
             }
@@ -692,57 +732,69 @@ define(["jquery", "underscore", "backbone"], ($, _, Backbone) => {
         );
       },
 
-      /**** Provenance-related functions ****/
-      /*
-       * Returns true if this provenance field points to a source of this data or metadata object
+      // ================ Provenance-related functions ================/
+
+      /**
+       * Returns true if this provenance field points to a source of this data
+       * or metadata object
+       * @param {string} field - The provenance field to check
+       * @returns {boolean} True if this field is a source field, false
+       * otherwise
        */
-      isSourceField: function (field) {
-        if (typeof field == "undefined" || !field) return false;
+      isSourceField(field) {
+        if (typeof field === "undefined" || !field) return false;
         if (!_.contains(MetacatUI.appSearchModel.getProvFields(), field))
           return false;
 
         if (
-          field == "prov_generatedByExecution" ||
-          field == "prov_generatedByProgram" ||
-          field == "prov_used" ||
-          field == "prov_wasDerivedFrom" ||
-          field == "prov_wasInformedBy"
+          field === "prov_generatedByExecution" ||
+          field === "prov_generatedByProgram" ||
+          field === "prov_used" ||
+          field === "prov_wasDerivedFrom" ||
+          field === "prov_wasInformedBy"
         )
           return true;
-        else return false;
+        return false;
       },
 
-      /*
-       * Returns true if this provenance field points to a derivation of this data or metadata object
+      /**
+       * Returns true if this provenance field points to a derivation of this
+       * data or metadata object
+       * @param {string} field - The provenance field to check
+       * @returns {boolean} True if this field is a derivation field, false
+       * otherwise
        */
-      isDerivationField: function (field) {
-        if (typeof field == "undefined" || !field) return false;
+      isDerivationField(field) {
+        if (typeof field === "undefined" || !field) return false;
         if (!_.contains(MetacatUI.appSearchModel.getProvFields(), field))
           return false;
 
         if (
-          field == "prov_usedByExecution" ||
-          field == "prov_usedByProgram" ||
-          field == "prov_hasDerivations" ||
-          field == "prov_generated"
+          field === "prov_usedByExecution" ||
+          field === "prov_usedByProgram" ||
+          field === "prov_hasDerivations" ||
+          field === "prov_generated"
         )
           return true;
-        else return false;
+        return false;
       },
 
-      /*
-       * Returns true if this SolrResult has a provenance trace (i.e. has either sources or derivations)
+      /**
+       * Returns true if this SolrResult has a provenance trace (i.e. has either
+       * sources or derivations)
+       * @returns {boolean} True if this object has a provenance trace, false
+       * otherwise
        */
-      hasProvTrace: function () {
-        if (this.get("formatType") == "METADATA") {
+      hasProvTrace() {
+        if (this.get("formatType") === "METADATA") {
           if (this.get("prov_hasSources") || this.get("prov_hasDerivations"))
             return true;
         }
 
-        var fieldNames = MetacatUI.appSearchModel.getProvFields(),
-          currentField = "";
+        const fieldNames = MetacatUI.appSearchModel.getProvFields();
+        let currentField = "";
 
-        for (var i = 0; i < fieldNames.length; i++) {
+        for (let i = 0; i < fieldNames.length; i += 1) {
           currentField = fieldNames[i];
           if (this.has(currentField)) return true;
         }
@@ -750,21 +802,22 @@ define(["jquery", "underscore", "backbone"], ($, _, Backbone) => {
         return false;
       },
 
-      /*
-       * Returns an array of all the IDs of objects that are sources of this object
+      /**
+       * Returns an array of all the IDs of objects that are sources of this
+       * object
+       * @returns {string[]} An array of source IDs
        */
-      getSources: function () {
-        var sources = new Array(),
-          model = this,
-          //Get the prov fields but leave out references to executions which are not used in the UI yet
-          fields = _.reject(
-            MetacatUI.appSearchModel.getProvFields(),
-            function (f) {
-              return f.indexOf("xecution") > -1;
-            },
-          ); //Leave out the first e in execution so we don't have to worry about case sensitivity
+      getSources() {
+        const sources = [];
+        const model = this;
+        // Get the prov fields but leave out references to executions which are
+        // not used in the UI yet
+        const fields = _.reject(
+          MetacatUI.appSearchModel.getProvFields(),
+          (f) => f.indexOf("xecution") > -1,
+        ); // Leave out the first e in execution so we don't have to worry about case sensitivity
 
-        _.each(fields, function (provField, i) {
+        _.each(fields, (provField, _i) => {
           if (model.isSourceField(provField) && model.has(provField))
             sources.push(model.get(provField));
         });
@@ -772,21 +825,22 @@ define(["jquery", "underscore", "backbone"], ($, _, Backbone) => {
         return _.uniq(_.flatten(sources));
       },
 
-      /*
-       * Returns an array of all the IDs of objects that are derivations of this object
+      /**
+       * Returns an array of all the IDs of objects that are derivations of this
+       * object
+       * @returns {string[]} An array of derivation IDs
        */
-      getDerivations: function () {
-        var derivations = new Array(),
-          model = this,
-          //Get the prov fields but leave out references to executions which are not used in the UI yet
-          fields = _.reject(
-            MetacatUI.appSearchModel.getProvFields(),
-            function (f) {
-              return f.indexOf("xecution") > -1;
-            },
-          ); //Leave out the first e in execution so we don't have to worry about case sensitivity
+      getDerivations() {
+        const derivations = [];
+        const model = this;
+        // Get the prov fields but leave out references to executions which are
+        // not used in the UI yet
+        const fields = _.reject(
+          MetacatUI.appSearchModel.getProvFields(),
+          (f) => f.indexOf("xecution") > -1,
+        ); // Leave out the first e in execution so we don't have to worry about case sensitivity
 
-        _.each(fields, function (provField, i) {
+        _.each(fields, (provField, _i) => {
           if (model.isDerivationField(provField) && model.has(provField))
             derivations.push(model.get(provField));
         });
@@ -794,92 +848,101 @@ define(["jquery", "underscore", "backbone"], ($, _, Backbone) => {
         return _.uniq(_.flatten(derivations));
       },
 
-      getInputs: function () {
+      /** @returns {string[]} IDs of all objs that are used by this obj */
+      getInputs() {
         return this.get("prov_used");
       },
 
-      getOutputs: function () {
+      /** @returns {string[]} IDs of all objs that are generated by this obj */
+      getOutputs() {
         return this.get("prov_generated");
       },
 
-      /*
-       * Uses the app configuration to check if this model's metrics should be hidden in the display
-       *
-       * @return {boolean}
+      /**
+       * Uses the app configuration to check if this model's metrics should be
+       * hidden in the display
+       * @returns {boolean} True if the metrics should be hidden, false
+       * otherwise
        */
-      hideMetrics: function () {
-        //If the AppModel is configured with cases of where to hide metrics,
+      hideMetrics() {
+        // If the AppModel is configured with cases of where to hide metrics,
         if (
-          typeof MetacatUI.appModel.get("hideMetricsWhen") == "object" &&
+          typeof MetacatUI.appModel.get("hideMetricsWhen") === "object" &&
           MetacatUI.appModel.get("hideMetricsWhen")
         ) {
-          //Check for at least one match
+          // Check for at least one match
           return _.some(
             MetacatUI.appModel.get("hideMetricsWhen"),
-            function (value, modelProperty) {
-              //Get the value of this property from this model
-              var modelValue = this.get(modelProperty);
+            function hideWhen(value, modelProperty) {
+              // Get the value of this property from this model
+              const modelValue = this.get(modelProperty);
 
-              //Check for the presence of this model's value in the AppModel value
-              if (Array.isArray(value) && typeof modelValue == "string") {
+              // Check for the presence of this model's value in the AppModel
+              // value
+              if (Array.isArray(value) && typeof modelValue === "string") {
                 return _.contains(value, modelValue);
               }
-              //Check for the presence of the AppModel's value in this model's value
-              else if (typeof value == "string" && Array.isArray(modelValue)) {
+              // Check for the presence of the AppModel's value in this model's
+              // value
+              if (typeof value === "string" && Array.isArray(modelValue)) {
                 return _.contains(modelValue, value);
               }
-              //Check for overlap of two arrays
-              else if (Array.isArray(value) && Array.isArray(modelValue)) {
+              // Check for overlap of two arrays
+              if (Array.isArray(value) && Array.isArray(modelValue)) {
                 return _.intersection(value, modelValue).length > 0;
               }
-              //If the AppModel value is a function, execute it
-              else if (typeof value == "function") {
+              // If the AppModel value is a function, execute it
+              if (typeof value === "function") {
                 return value(modelValue);
               }
-              //Otherwise, just check for equality
-              else {
-                return value === modelValue;
-              }
+              // Otherwise, just check for equality
+
+              return value === modelValue;
             },
             this,
           );
-        } else {
-          return false;
         }
+        return false;
       },
 
       /**
        * Creates a URL for viewing more information about this metadata
-       * @return {string}
+       * @returns {string} The URL to view this metadata
        */
-      createViewURL: function () {
-        return this.getType() == "portal" || this.getType() == "collection"
-          ? MetacatUI.root +
-              "/" +
-              MetacatUI.appModel.get("portalTermPlural") +
-              "/" +
-              encodeURIComponent(
-                this.get("label") || this.get("seriesId") || this.get("id"),
-              )
-          : MetacatUI.root +
-              "/view/" +
-              encodeURIComponent(this.get("seriesId") || this.get("id"));
+      createViewURL() {
+        return this.getType() === "portal" || this.getType() === "collection"
+          ? `${MetacatUI.root}/${MetacatUI.appModel.get(
+              "portalTermPlural",
+            )}/${encodeURIComponent(
+              this.get("label") || this.get("seriesId") || this.get("id"),
+            )}`
+          : `${MetacatUI.root}/view/${encodeURIComponent(
+              this.get("seriesId") || this.get("id"),
+            )}`;
       },
 
-      parseResourceMapField: function (json) {
-        if (typeof json.resourceMap == "string") {
+      /**
+       * Parses the resourceMap field from the Solr response JSON.
+       * @param {object} json - The JSON object from the Solr response
+       * @returns {string|string[]} The resourceMap parsed. If it is a string,
+       * it returns the trimmed string. If it is an array, it returns an array
+       * of trimmed strings. If it is neither, it returns an empty array.
+       */
+      parseResourceMapField(json) {
+        if (typeof json.resourceMap === "string") {
           return json.resourceMap.trim();
-        } else if (Array.isArray(json.resourceMap)) {
-          let newResourceMapIds = [];
-          _.each(json.resourceMap, function (rMapId) {
-            if (typeof rMapId == "string") {
+        }
+        if (Array.isArray(json.resourceMap)) {
+          const newResourceMapIds = [];
+          _.each(json.resourceMap, (rMapId) => {
+            if (typeof rMapId === "string") {
               newResourceMapIds.push(rMapId.trim());
             }
           });
           return newResourceMapIds;
         }
 
-        //If nothing works so far, return an empty array
+        // If nothing works so far, return an empty array
         return [];
       },
     },

--- a/test/config/tests.json
+++ b/test/config/tests.json
@@ -70,6 +70,7 @@
     "./js/specs/unit/common/IconUtilities.spec.js",
     "./js/specs/unit/common/SearchParams.spec.js",
     "./js/specs/unit/common/EventLog.spec.js",
+    "./js/specs/unit/common/QueryService.spec.js",
     "./js/specs/unit/models/maps/AssetCategory.spec.js",
     "./js/specs/unit/collections/maps/AssetCategories.spec.js",
     "./js/specs/unit/models/maps/Map.spec.js",

--- a/test/js/specs/unit/common/QueryService.spec.js
+++ b/test/js/specs/unit/common/QueryService.spec.js
@@ -1,0 +1,390 @@
+define([
+  "/test/js/specs/shared/clean-state.js",
+  "common/QueryService",
+  "jquery",
+], (cleanState, QueryService, $) => {
+  const should = chai.should();
+  const expect = chai.expect;
+
+  describe("QueryService Test Suite", () => {
+    // Clean up Sinon sandbox and any globals after each test
+    const state = cleanState(
+      () => {
+        const sandbox = sinon.createSandbox();
+        return { sandbox };
+      },
+      beforeEach,
+      afterEach,
+    );
+
+    afterEach(() => {
+      state.sandbox.restore();
+    });
+
+    describe("Instantiation", () => {
+      it("creates an instance with defaults", () => {
+        const qs = new QueryService();
+        qs.should.be.instanceof(QueryService);
+        // QueryService is a collection of static methods, but instantiating
+        // it should not throw or attach unexpected instance props.
+        Object.keys(qs).length.should.equal(0);
+      });
+    });
+
+    describe("queryServiceUrl()", () => {
+      it("throws an error when queryServiceUrl is not configured", () => {
+        const { sandbox } = state;
+        // Remove MetacatUI or stub to return undefined
+        sandbox.stub(window, "MetacatUI").value(undefined);
+        expect(() => QueryService.queryServiceUrl()).to.throw(
+          Error,
+          "queryServiceUrl is not configured",
+        );
+      });
+
+      it("returns the configured query service URL", () => {
+        const currentUrl = MetacatUI.appModel.get("queryServiceUrl");
+        const url = QueryService.queryServiceUrl();
+        url.should.equal(currentUrl);
+      });
+    });
+
+    describe("buildQueryObject()", () => {
+      it("applies defaults and basic options", () => {
+        const opts = {
+          q: "title:hello",
+          filterQueries: "rights:public",
+          fields: ["id", "title"],
+          sort: "dateUploaded+asc",
+          rows: 50,
+          start: 5,
+        };
+        const params = QueryService.buildQueryObject(opts);
+        params.should.deep.include({
+          q: "title:hello",
+          rows: 50,
+          start: 5,
+          wt: "json",
+        });
+        params.sort.should.equal("dateUploaded asc");
+        // filterQueries becomes an array of fq parameters
+        params.fq.should.deep.equal(["rights:public"]);
+        // fields (fl) joined by comma
+        params.fl.should.equal("id,title");
+      });
+
+      it("handles multiple filterQueries and nested arrays", () => {
+        const opts = {
+          q: "*:*",
+          filterQueries: ["type:data", ["rights:public", "format:csv"]],
+        };
+        const params = QueryService.buildQueryObject(opts);
+        params.fq.should.deep.equal([
+          "type:data",
+          "rights:public",
+          "format:csv",
+        ]);
+      });
+
+      it("handles facet fields and sets facet params", () => {
+        const opts = {
+          facets: ["creator", ["format"]],
+          facetLimit: 10,
+          facetMinCount: 2,
+        };
+        const params = QueryService.buildQueryObject(opts);
+        params.facet.should.equal("true");
+        params["facet.field"].should.deep.equal(["creator", "format"]);
+        params["facet.limit"].should.equal(10);
+        params["facet.mincount"].should.equal(2);
+        params["facet.sort"].should.equal("index");
+      });
+
+      it("handles facet queries without facet fields", () => {
+        const opts = {
+          facetQueries: ["size:[100 TO *]", "size:[* TO 100]"],
+          facetLimit: -1,
+          facetMinCount: 1,
+        };
+        const params = QueryService.buildQueryObject(opts);
+        params.facet.should.equal("true");
+        params["facet.query"].should.deep.equal([
+          "size:[100 TO *]",
+          "size:[* TO 100]",
+        ]);
+        // facet.limit and facet.mincount are not set when only facet queries are provided
+        should.equal(params["facet.limit"], undefined);
+        should.equal(params["facet.mincount"], undefined);
+      });
+
+      it("handles stats fields", () => {
+        const opts = {
+          statsFields: ["size", ["views"]],
+        };
+        const params = QueryService.buildQueryObject(opts);
+        params.stats.should.equal("true");
+        params["stats.field"].should.deep.equal(["size", "views"]);
+      });
+
+      it("ignores empty or falsey fields and filterQueries", () => {
+        const opts = {
+          fields: [],
+          filterQueries: [null, ""],
+        };
+        const params = QueryService.buildQueryObject(opts);
+        should.equal(params.fl, undefined);
+        should.equal(params.fq, undefined);
+      });
+    });
+
+    describe("buildQueryParams()", () => {
+      it("forwards to buildQueryObject()", () => {
+        const { sandbox } = state;
+        const spy = sandbox.spy(QueryService, "buildQueryObject");
+        const opts = { q: "x" };
+        const result = QueryService.buildQueryParams(opts);
+        spy.calledOnceWithExactly(opts).should.be.true;
+        result.should.deep.equal(QueryService.buildQueryObject(opts));
+      });
+    });
+
+    describe("toQueryString()", () => {
+      it("serializes simple and array values into repeated keys", () => {
+        const obj = {
+          q: "*:*",
+          fq: ["rights:public", "type:data"],
+          rows: 5,
+        };
+        const qs = QueryService.toQueryString(obj);
+        // Order is not strictly guaranteed, but all key-value pairs must appear
+        qs.should.include("q=*%3A*");
+        qs.should.include("rows=5");
+        // fq appears twice
+        const fqCount = qs.split("fq=").length - 1;
+        fqCount.should.equal(2);
+      });
+    });
+
+    describe("buildGetSettings()", () => {
+      it("constructs a GET request with query string appended", () => {
+        const params = { q: "*:*", rows: 1 };
+        const settings = QueryService.buildGetSettings(
+          "https://example.com/solr",
+          params,
+        );
+        settings.should.deep.include({
+          type: "GET",
+          dataType: "json",
+        });
+        settings.url.should.include("?q=*%3A*");
+        settings.url.should.include("&rows=1");
+      });
+
+      it("does not add a second '?' if urlBase already contains one", () => {
+        const params = { q: "test" };
+        const settings = QueryService.buildGetSettings(
+          "https://example.com/search?",
+          params,
+        );
+        settings.url.startsWith("https://example.com/search?q=").should.be.true;
+      });
+    });
+
+    describe("buildPostSettings()", () => {
+      it("constructs a POST request with FormData", () => {
+        const { sandbox } = state;
+        // Replace global FormData with a simple collector
+        class MockFormData {
+          constructor() {
+            this.fields = [];
+          }
+          append(k, v) {
+            this.fields.push({ key: k, value: v });
+          }
+        }
+        sandbox.stub(window, "FormData").callsFake(() => new MockFormData());
+        const params = { q: "x", fq: ["a", "b"], rows: 5 };
+        const settings = QueryService.buildPostSettings(
+          "https://example.com/api",
+          params,
+        );
+        settings.should.deep.include({
+          url: "https://example.com/api",
+          type: "POST",
+          contentType: false,
+          processData: false,
+          dataType: "json",
+        });
+        // Data should be our mock form data instance
+        settings.data.should.be.instanceOf(MockFormData);
+        // Keys should have been appended: fq twice, q once, rows once
+        settings.data.fields
+          .filter((f) => f.key === "fq")
+          .length.should.equal(2);
+        settings.data.fields
+          .filter((f) => f.key === "q")
+          .length.should.equal(1);
+        settings.data.fields
+          .filter((f) => f.key === "rows")
+          .length.should.equal(1);
+      });
+    });
+
+    describe("mergeAuth()", () => {
+      it("returns original options when appUserModel is undefined", () => {
+        const { sandbox } = state;
+        sandbox.stub(window, "MetacatUI").value({});
+        const opts = { url: "x", type: "GET" };
+        const merged = QueryService.mergeAuth(opts);
+        merged.should.deep.equal(opts);
+      });
+
+      it("merges authentication settings into ajax options", () => {
+        const { sandbox } = state;
+        const ajaxOpts = { url: "x", type: "GET" };
+        const auth = { headers: { Authorization: "Bearer 1" }, timeout: 1000 };
+        const mockGetAuth = sandbox.stub().returns(auth);
+        sandbox.stub(window, "MetacatUI").value({
+          appUserModel: { createAjaxSettings: mockGetAuth },
+        });
+        const result = QueryService.mergeAuth(ajaxOpts);
+        // Should combine both objects, auth values override when keys conflict
+        result.should.deep.equal({ ...ajaxOpts, ...auth });
+        mockGetAuth.calledOnce.should.be.true;
+      });
+    });
+
+    describe("decidePost()", () => {
+      it("respects explicit boolean override", () => {
+        const opts = { explicit: true, queryParams: {}, urlBase: "x" };
+        QueryService.decidePost(opts).should.be.true;
+        QueryService.decidePost({ ...opts, explicit: false }).should.be.false;
+      });
+
+      it("returns false when disableQueryPOSTs is enabled", () => {
+        const { sandbox } = state;
+        sandbox.stub(window, "MetacatUI").value({
+          appModel: {
+            get: sandbox.stub().withArgs("disableQueryPOSTs").returns(true),
+          },
+        });
+        const res = QueryService.decidePost({
+          queryParams: { q: "x" },
+          urlBase: "http://",
+        });
+        res.should.be.false;
+      });
+
+      it("returns true when query string length exceeds configured max", () => {
+        const { sandbox } = state;
+        // max length set to 10 for easier test
+        const getStub = sandbox.stub().callsFake((key) => {
+          if (key === "maxQueryLength") return 10;
+          return false;
+        });
+        sandbox.stub(window, "MetacatUI").value({
+          appModel: { get: getStub },
+        });
+        const longParams = { q: "a".repeat(20) };
+        // URL base length is 5, plus '?', plus query length (20) -> 26 > 10
+        const res = QueryService.decidePost({
+          queryParams: longParams,
+          urlBase: "12345",
+        });
+        res.should.be.true;
+        getStub.calledWithExactly("maxQueryLength").should.be.true;
+      });
+
+      it("uses DEFAULT_MAX_QUERY_LEN when configuration is missing", () => {
+        const { sandbox } = state;
+        sandbox
+          .stub(window, "MetacatUI")
+          .value({ appModel: { get: () => undefined } });
+        // Create small query so result is false when default length is large
+        const res = QueryService.decidePost({
+          queryParams: { q: "abc" },
+          urlBase: "",
+        });
+        res.should.be.false;
+      });
+
+      it("does not throw when MetacatUI is undefined", () => {
+        const { sandbox } = state;
+        sandbox.stub(window, "MetacatUI").value(undefined);
+        const res = QueryService.decidePost({
+          queryParams: { q: "a" },
+          urlBase: "",
+        });
+        // Using default max length (2000), this should be false
+        res.should.be.false;
+      });
+    });
+
+    describe("query()", () => {
+      it("invokes GET settings and merges auth for default options", () => {
+        const { sandbox } = state;
+        // stub jQuery ajax
+        const ajaxStub = sandbox.stub($, "ajax").resolves("response");
+        // stub internal helpers
+        sandbox
+          .stub(QueryService, "queryServiceUrl")
+          .returns("https://example.com/api");
+        sandbox.stub(QueryService, "buildQueryObject").returns({ q: "*:*" });
+        sandbox.stub(QueryService, "decidePost").returns(false);
+        const getSettings = {
+          url: "https://example.com/api?q=*%3A*",
+          type: "GET",
+          dataType: "json",
+        };
+        sandbox.stub(QueryService, "buildGetSettings").returns(getSettings);
+        const mergedSettings = { ...getSettings, headers: { Auth: "123" } };
+        sandbox.stub(QueryService, "mergeAuth").returns(mergedSettings);
+        return QueryService.query().then((result) => {
+          result.should.equal("response");
+          QueryService.buildQueryObject.calledOnce.should.be.true;
+          QueryService.decidePost.calledOnce.should.be.true;
+          QueryService.buildGetSettings.calledOnce.should.be.true;
+          QueryService.mergeAuth.calledOnce.should.be.true;
+          ajaxStub.calledOnceWithExactly(mergedSettings).should.be.true;
+        });
+      });
+
+      it("invokes POST settings when decidePost() returns true", () => {
+        const { sandbox } = state;
+        const ajaxStub = sandbox.stub($, "ajax").resolves("ok");
+        sandbox
+          .stub(QueryService, "queryServiceUrl")
+          .returns("https://api.test");
+        sandbox.stub(QueryService, "buildQueryObject").returns({ q: "x" });
+        sandbox.stub(QueryService, "decidePost").returns(true);
+        const postSettings = {
+          url: "https://api.test",
+          type: "POST",
+          data: new FormData(),
+          dataType: "json",
+        };
+        sandbox.stub(QueryService, "buildPostSettings").returns(postSettings);
+        sandbox.stub(QueryService, "mergeAuth").returns(postSettings);
+        return QueryService.query().then(() => {
+          QueryService.buildPostSettings.calledOnce.should.be.true;
+          ajaxStub.calledOnceWithExactly(postSettings).should.be.true;
+        });
+      });
+
+      it("skips mergeAuth when useAuth is false", () => {
+        const { sandbox } = state;
+        const ajaxStub = sandbox.stub($, "ajax").resolves("noauth");
+        sandbox.stub(QueryService, "queryServiceUrl").returns("u");
+        sandbox.stub(QueryService, "buildQueryObject").returns({ q: "x" });
+        sandbox.stub(QueryService, "decidePost").returns(false);
+        const getSettings = { url: "u?q=x", type: "GET", dataType: "json" };
+        sandbox.stub(QueryService, "buildGetSettings").returns(getSettings);
+        const mergeAuthSpy = sandbox.spy(QueryService, "mergeAuth");
+        return QueryService.query({ useAuth: false }).then(() => {
+          mergeAuthSpy.called.should.be.false;
+          ajaxStub.calledOnceWithExactly(getSettings).should.be.true;
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
- Centralize Solr query construction into a new class
  - Make the `QueryService` class, including unit tests
  - Use this class everywhere MetacatUI constructs a query
- Design this class to use `POST` by default unless explicitly blocked by the `disableQueryPOSTs` app setting
- Add warning to `disableQueryPOSTs` that it will be deprecated in a future release

Other:
- Fix linting issues & add JSdocs to SolrResult


Fixes #1998