### PR TITLE
Update Legend swatches to indicate whether layer is visible or not

### DIFF
--- a/src/js/models/maps/MapInteraction.js
+++ b/src/js/models/maps/MapInteraction.js
@@ -171,7 +171,6 @@ define([
        * All except LEFT_CLICK are ignored.
        */
       handleClick: function (m, action) {
-        // updated by Shirly - testing
         if (action !== "LEFT_CLICK" && action !== "LEFT_DOUBLE_CLICK") return;
         // Clone the models in hovered features and set them as clicked features
         const hoveredFeatures = this.get("hoveredFeatures").models;
@@ -196,7 +195,7 @@ define([
         } else if (clickAction === "zoom") {
           this.set("zoomTarget", hoveredFeatures[0]);
         }
-        // Added by Shirly --  Custom behavior for double-click
+        // Custom behavior for double-click
         else if (action === "LEFT_DOUBLE_CLICK") {
           this.set("previousAction", "LEFT_DOUBLE_CLICK");
         }

--- a/src/js/views/maps/legend/CategoricalSwatchView.js
+++ b/src/js/views/maps/legend/CategoricalSwatchView.js
@@ -52,6 +52,12 @@ define([
           "background-color",
           this.model.getCss(),
         );
+
+        // When filterActive is true, opacity = 0.25 (transparent).
+        // When filterActive is false, opacity = 1 (fully visible).
+        const opacity = this.model.get("filterActive") ? 1 : 0.25;
+        this.$(`.${CLASS_NAMES.swatch}`).css("opacity", opacity);
+        this.$(".categorical-swatch__value").css("opacity", opacity);
       },
     },
   );

--- a/src/js/views/maps/legend/LegendContainerView.js
+++ b/src/js/views/maps/legend/LegendContainerView.js
@@ -61,6 +61,29 @@ define([
         this.model.get("allLayers")?.forEach((layer) => {
           this.stopListening(layer, "change:visible");
           this.listenTo(layer, "change:visible", this.updateLegend);
+
+          // Updates the legend when the Filter model is updated (through the Filter by Property feature).
+          this.filters = layer?.get("filters"); // Retrieve filters attribute
+          this.filterModel = this.filters?.at(0); // Get the first filter model
+          if (this.filterModel) {
+            this.stopListening(this.filterModel, "change:values");
+            this.listenTo(this.filterModel, "change:values", this.updateLegend);
+          }
+        });
+      },
+
+      /**
+       * Sets the active state of the filter based values (for categorical
+       * filters) in the Color Palette model.
+       */
+      updateColorPalette(layer, colorPaletteModel) {
+        const layerValues = layer.get("filters")?.at(0)?.get("values");
+        colorPaletteModel.get("colors").forEach((color) => {
+          if (layerValues.includes(color.get("value"))) {
+            color.set("filterActive", true);
+          } else {
+            color.set("filterActive", false);
+          }
         });
       },
 
@@ -84,6 +107,8 @@ define([
           ) {
             return;
           }
+          let colorPaletteModel = layer.get("colorPalette");
+          colorPaletteModel = this.updateColorPalette(layer, colorPaletteModel);
           const layerLegendView = new LayerLegendView({
             model: layer.get("colorPalette"),
             layerName: layer.get("label"),


### PR DESCRIPTION
**See issue #2713 **

**Description:** Adjust the look of labels in the legend, based on whether the feature layer is visible on the map or not. This adjustment is a change in label transparency. 

**Status:** This UI adjustment is a first iteration of testing whether this is an ideal way to go about showing layer visibility status.

**Context:** This feature is an improvement to the "Filter by Property" feature (see issue https://github.com/NCEAS/metacatui/issues/1770). 

**Code changes:**

- Added a listener to the `render()` in `LayerContainerView` that updates the Legend View whenever a user interacts with the Filter by Property feature.
- Added the function `updateColorPalette()` in LayerContainerView` that updates the ColorPalette model to track all values that are selected or unselected in the Filter model. 
- Updated the `render()` of `CategoricalSwatchView`, which already builds the swatch and applies CSS, by adding an if condition to set opacity dynamically based on filter status set on values in the ColorPalette model. 
- Some other minimal code clean-up.