### PR TITLE
Fix bug with namespaces in attribute serialization

### DIFF
--- a/src/js/collections/metadata/eml/EMLAttributes.js
+++ b/src/js/collections/metadata/eml/EMLAttributes.js
@@ -5,7 +5,8 @@ define([
   "backbone",
   "models/metadata/eml211/EMLAttribute",
   "models/DataONEObject",
-], ($, Backbone, EMLAttribute, DataONEObject) => {
+  "common/EMLUtilities",
+], ($, Backbone, EMLAttribute, DataONEObject, EMLUtilities) => {
   /**
    * @class EMLAttributes
    * @classdesc A collection of EMLAttributes.
@@ -204,8 +205,7 @@ define([
        */
       serialize() {
         const newDOM = this.updateDOM();
-        const serializer = new XMLSerializer();
-        return serializer.serializeToString(newDOM);
+        return EMLUtilities.serializeDOM(newDOM);
       },
     },
   );

--- a/src/js/common/EMLUtilities.js
+++ b/src/js/common/EMLUtilities.js
@@ -27,6 +27,27 @@ define([], () => {
 
       return emlModel && emlModel.type === "EML" ? emlModel : false;
     },
+
+    /**
+     * Serialize a DOM element to a string, removing the XML declaration and any
+     * namespace declarations. Namespaces are added to the elements because the
+     * codebase currently combines older ways of handling XML (using jQuery's
+     * parseHTML and document.createElement) with newer ways (using DOMParser).
+     * While we transition to using modern methods, this function can be used to
+     * clean up the serialized XML.
+     * @param {Element} dom - The DOM element to serialize
+     * @returns {string} The serialized XML string
+     * @since 0.0.0
+     */
+    serializeDOM(dom) {
+      const serializer = new XMLSerializer();
+      let str = serializer.serializeToString(dom);
+      // Remove the XML declaration if it exists
+      str = str.replace(/<\?xml.*?\?>/g, "");
+      // Remove any namespace declarations
+      str = str.replace(/xmlns(:\w+)?="[^"]*"/g, "");
+      return str;
+    },
   };
 
   return EMLUtilities;

--- a/src/js/models/metadata/eml211/EMLAttributeList.js
+++ b/src/js/models/metadata/eml211/EMLAttributeList.js
@@ -236,8 +236,7 @@ define([
         if (!dom) return null;
 
         // Convert the DOM element to a string
-        const serializer = new XMLSerializer();
-        let xmlString = serializer.serializeToString(dom);
+        let xmlString = EMLUtilities.serializeDOM(dom);
 
         // Remove the XML declaration
         xmlString = xmlString.replace(/<\?xml.*?\?>/, "");


### PR DESCRIPTION
This PR fixes a bug with XML serialization of EML <attribute> elements. Most of the codebase still uses HTML-oriented parsing methods like jQuery’s parseHTML, while I've been writing newer code using modern XML APIs. The mix creates a namespace mismatch: elements parsed with parseHTML end up in the HTML namespace, and when these are inserted into an XML DOM and serialized, extra namespace declarations are added. The result is invalid EML output.

To resolve this, a new utility method was introduced to serialize DOM elements to strings while stripping out unwanted namespace attributes. This utility replaces direct calls to XMLSerializer in the two places where <attribute> elements are serialized: the EMLAttributes collection and the EMLAttributeList model.

Closes #2728