### PR TITLE
Prevent downloading map layers until visible

### DIFF
--- a/src/js/models/maps/AssetCategory.js
+++ b/src/js/models/maps/AssetCategory.js
@@ -84,7 +84,6 @@ define([
           return {
             ...layer,
             configuredVisibility: layer.visible,
-            originalVisibility: visible,
             visible,
           };
         });

--- a/src/js/models/maps/assets/Cesium3DTileset.js
+++ b/src/js/models/maps/assets/Cesium3DTileset.js
@@ -87,7 +87,7 @@ define([
             this.set("filters", new VectorFilters(assetConfig.filters));
           }
 
-          this.createCesiumModel();
+          this.createCesiumModelWhenVisible();
         } catch (error) {
           console.log(
             "There was an error initializing a 3DTileset model" +

--- a/src/js/models/maps/assets/CesiumImagery.js
+++ b/src/js/models/maps/assets/CesiumImagery.js
@@ -92,7 +92,7 @@ define([
             this.initUSGSImageryTopo(assetConfig);
           }
 
-          this.createCesiumModel();
+          this.createCesiumModelWhenVisible();
 
           this.getThumbnail();
         } catch (e) {
@@ -287,6 +287,11 @@ define([
       setListeners: function () {
         try {
           var cesiumModel = this.get("cesiumModel");
+
+          if (!cesiumModel) {
+            this.listenToOnce(this, "change:cesiumModel", this.setListeners);
+            return;
+          }
 
           // Make sure the listeners are only set once!
           this.stopListening(this);

--- a/src/js/models/maps/assets/CesiumTerrain.js
+++ b/src/js/models/maps/assets/CesiumTerrain.js
@@ -71,7 +71,7 @@ define([
         try {
           MapAsset.prototype.initialize.call(this, attributes, options);
 
-          this.createCesiumModel();
+          this.createCesiumModelWhenVisible();
         } catch (error) {
           console.log(
             "There was an error initializing a CesiumTerrain model" +

--- a/src/js/models/maps/assets/CesiumVectorData.js
+++ b/src/js/models/maps/assets/CesiumVectorData.js
@@ -109,11 +109,13 @@ define([
         try {
           if (!assetConfig) assetConfig = {};
 
-          MapAsset.prototype.initialize.call(this, assetConfig);
-
           if (assetConfig.filters) {
-            this.set("filters", new VectorFilters(assetConfig.filters));
+            const filters = new VectorFilters(assetConfig.filters);
+            this.set("filters", filters);
+            assetConfig.filters = filters;
           }
+
+          MapAsset.prototype.initialize.call(this, assetConfig);
 
           // displayReady will be updated by the Cesium map within which the
           // asset is rendered. The map will set it to true when the data is
@@ -141,7 +143,7 @@ define([
             );
           }
 
-          this.createCesiumModel();
+          this.createCesiumModelWhenVisible();
         } catch (error) {
           console.log("Error initializing a CesiumVectorData model.", error);
         }
@@ -211,6 +213,9 @@ define([
           const data = JSON.parse(JSON.stringify(cesiumOptions.data));
           delete cesiumOptions.data;
 
+          // TODO: Could show a progress bar starting here ...
+          // does dataSource.load support progress events?
+
           dataSource
             .load(data, cesiumOptions)
             .then(function (loadedData) {
@@ -222,7 +227,10 @@ define([
               model.updateAppearance();
               model.setReady();
             })
-            .otherwise(model.setError.bind(model));
+            .otherwise((error) => {
+              console.log("Failed to load Cesium Vector Data.", error);
+              model.setError.bind(model, error.message || error);
+            });
         } catch (error) {
           console.log("Failed to create a VectorData Cesium Model.", error);
         }
@@ -233,19 +241,15 @@ define([
        * updated.
        */
       setListeners: function () {
-        try {
-          MapAsset.prototype.setListeners.call(this);
-          const appearEvents =
-            "change:visible change:opacity change:color change:outlineColor" +
-            " change:temporarilyHidden";
-          this.stopListening(this, appearEvents);
-          this.listenTo(this, appearEvents, this.updateAppearance);
-          const filters = this.get("filters");
-          this.stopListening(filters, "update");
-          this.listenTo(filters, "update", this.updateFeatureVisibility);
-        } catch (error) {
-          console.log("Failed to set CesiumVectorData listeners.", error);
-        }
+        MapAsset.prototype.setListeners.call(this);
+        const appearEvents =
+          "change:visible change:opacity change:color change:outlineColor" +
+          " change:temporarilyHidden";
+        this.stopListening(this, appearEvents);
+        this.listenTo(this, appearEvents, this.updateAppearance);
+        const filters = this.get("filters");
+        this.stopListening(filters, "update");
+        this.listenTo(filters, "update", this.updateFeatureVisibility);
       },
 
       /**

--- a/src/js/models/maps/assets/MapAsset.js
+++ b/src/js/models/maps/assets/MapAsset.js
@@ -79,9 +79,6 @@ define([
        * visibility value according to the portal configuration and ignoring any
        * search query parameters in the URL which can affect the layer's initial
        * visibility.
-       * @property {boolean} [originalVisibility = true] Tracks the original
-       * visibility value according to search query parameters and portal
-       * configuration.
        * @property {AssetColorPalette} [colorPalette] The color or colors mapped to
        * attributes of this asset. This applies to raster/imagery and vector assets. For
        * imagery, the colorPalette will be used to create a legend. For vector assets
@@ -126,7 +123,6 @@ define([
           saturation: 1,
           visible: true,
           configuredVisibility: true,
-          originalVisibility: true,
           colorPalette: null,
           customProperties: {},
           featureTemplate: {},
@@ -368,22 +364,30 @@ define([
           }
         }
 
-        this.on("change:visible", () => {
-          if (!this.get("mapModel")?.get("showShareUrl")) return;
-
-          this.get("mapModel")
-            .get("allLayers")
-            .forEach((layer) => {
-              const layerId = layer.get("layerId");
-              if (layerId && layer.get("visible")) {
-                SearchParams.addEnabledLayer(layerId);
-              } else {
-                SearchParams.removeEnabledLayer(layerId);
-              }
-            });
-        });
-
         this.setListeners();
+      },
+
+      /**
+       * Create the Cesium model for this asset, if it doesn't already exist and
+       * the asset is visible. If not visible, then wait until it becomes
+       * visible to create the model.
+       * @since 0.0.0
+       */
+      createCesiumModelWhenVisible() {
+        if (this.get("visible") && !this.get("cesiumModel")) {
+          this.createCesiumModel();
+        } else {
+          let visibilityListener = new Backbone.Model();
+          visibilityListener.listenToOnce(this, "change:visible", () => {
+            if (!this.get("cesiumModel")) {
+              this.createCesiumModel();
+              if (visibilityListener) {
+                visibilityListener.stopListening(this);
+                visibilityListener = null;
+              }
+            }
+          });
+        }
       },
 
       /**
@@ -423,8 +427,18 @@ define([
        * @since 2.27.0
        */
       handleError() {
-        this.set("visible", false);
+        const visibilityBeforeError = this.get("visible");
         this.stopListening(this, "change:visible");
+        this.set({ visible: false, visibilityBeforeError });
+        let errorListener = new Backbone.Model();
+        errorListener.listenTo(this, "change:status", () => {
+          if (this.get("status") !== "error") {
+            this.set("visible", this.get("visibilityBeforeError"));
+            this.setListeners();
+            errorListener.stopListening(this);
+            errorListener = null;
+          }
+        });
       },
 
       /**
@@ -432,21 +446,45 @@ define([
        * @since 2.27.0
        */
       setListeners() {
-        const status = this.get("status");
-        if (status === "error") {
-          this.handleError();
-          return;
-        }
+        const model = this;
 
-        const vis = this.get("originalVisibility");
-        if (typeof vis === "boolean") {
-          this.set("visible", vis);
-        }
-
-        // The map asset cannot be visible on the map if there was an error
-        // loading the asset
+        // Listen for changes to the status
         this.stopListening(this, "change:status");
-        this.listenTo(this, "change:status", this.setListeners);
+        this.listenTo(this, "change:status", () => {
+          const status = this.get("status");
+          if (status === "error") {
+            this.handleError();
+          }
+        });
+
+        if (this.get("status") === "error") return;
+
+        // Create a model for only listening to visibility changes, since we
+        // alter the main model's visibility listener in other cases.
+        let existingListener = this.get("visibilityListener");
+        if (existingListener) {
+          existingListener.stopListening(model);
+          this.set("visibilityListener", null);
+          existingListener = null;
+        }
+        const visibilityListener = new Backbone.Model();
+        this.set("visibilityListener", visibilityListener);
+        // When the visibility of the layer changes, update the search params
+        // (for URL sharing)
+        visibilityListener.listenTo(model, "change:visible", () => {
+          if (!model.get("mapModel")?.get("showShareUrl")) return;
+          model
+            .get("mapModel")
+            .get("allLayers")
+            .forEach((layer) => {
+              const layerId = layer.get("layerId");
+              if (layerId && layer.get("visible")) {
+                SearchParams.addEnabledLayer(layerId);
+              } else {
+                SearchParams.removeEnabledLayer(layerId);
+              }
+            });
+        });
 
         // Listen for changes to the cesiumOptions object
         this.stopListening(this, "change:cesiumOptions");

--- a/src/js/views/maps/CesiumWidgetView.js
+++ b/src/js/views/maps/CesiumWidgetView.js
@@ -1434,23 +1434,35 @@ define([
 
           // The asset should be visible and the cesium model should be ready
           // before starting to render the asset
-          const checkAndRenderAsset = function () {
-            let shouldRender =
-              mapAsset.get("visible") && mapAsset.get("status") === "ready";
-            if (shouldRender) {
-              renderFunction.call(view, mapAsset.get("cesiumModel"));
-              view.stopListening(mapAsset);
+          const checkAndRenderAsset = (mapAsset, listenModel) => {
+            const cesiumModel = mapAsset.get("cesiumModel");
+            const ready = mapAsset.get("status") === "ready";
+            const visible = mapAsset.get("visible");
+            const shouldRender = ready && visible && cesiumModel;
+            if (!shouldRender) return false;
+
+            renderFunction.call(view, cesiumModel);
+            if (listenModel) {
+              listenModel.stopListening(mapAsset);
+              listenModel.destroy();
             }
+
+            return true;
           };
 
-          checkAndRenderAsset();
-
-          if (!mapAsset.get("visible")) {
-            view.listenToOnce(mapAsset, "change:visible", checkAndRenderAsset);
-          }
-
-          if (mapAsset.get("status") !== "ready") {
-            view.listenTo(mapAsset, "change:status", checkAndRenderAsset);
+          const done = checkAndRenderAsset(mapAsset);
+          if (!done) {
+            // Make a model just to listen for when mapAsset is ready to render.
+            // This way we can stop listening once it's rendered, without
+            // stopping any other view listeners on the mapAsset.
+            const listenModel = new Backbone.Model();
+            listenModel.listenTo(
+              mapAsset,
+              "change:visible change:status",
+              () => {
+                checkAndRenderAsset(mapAsset, listenModel);
+              },
+            );
           }
         } catch (e) {
           console.error("Error rendering an asset", e, mapAsset);

--- a/src/js/views/portals/PortalView.js
+++ b/src/js/views/portals/PortalView.js
@@ -344,7 +344,7 @@ define([
               ))
           ) {
             //Get the name of the source member node
-            const sourceMNName = "original data repository",
+            let sourceMNName = "original data repository",
               mnURL = "";
             if (typeof sourceMN == "string") {
               const sourceMNObject = MetacatUI.nodeModel.getMember(sourceMN);


### PR DESCRIPTION
Fixes a bug where maps with lots of GeoJSON files didn't display layers because all of the data was being downloaded simultaneously. With this PR, Cesium models are only created, and thus data downloaded, when assets are visible.

- Added the `createCesiumModelWhenVisible` method to `MapAsset.js`, which listens for visibility changes and creates the Cesium model only when needed.
- Refactored `Cesium3DTileset`, `CesiumImagery`, `CesiumTerrain`, and `CesiumVectorData` to use `createCesiumModelWhenVisible` instead of immediately creating the Cesium model.
- Removed the `originalVisibility` property and its usage, as this was causing layers to be hidden when they weren't rendered immediately.

Fixes #2767 