### PR TITLE
Temporary fix to #2782

### DIFF
--- a/src/js/views/ImageUploaderView.js
+++ b/src/js/views/ImageUploaderView.js
@@ -220,7 +220,7 @@ define([
           // Add upload & drag and drop functionality to the dropzone div.
           // For config details, see: https://www.dropzonejs.com/#configuration
           var $dropZone = view.$(".dropzone").dropzone({
-            url: view.model.get("imageURL") || view.model.url() || MetacatUI.appModel.getActiveAltRepo().objectServiceUrl,
+            url: view.model.get("imageURL") || view.model.url() || MetacatUI.appModel.getActiveAltRepo()?.objectServiceUrl,
             acceptedFiles: "image/*",
             addRemoveLinks: false,
             maxFiles: 1,

--- a/src/js/views/ImageUploaderView.js
+++ b/src/js/views/ImageUploaderView.js
@@ -220,7 +220,7 @@ define([
           // Add upload & drag and drop functionality to the dropzone div.
           // For config details, see: https://www.dropzonejs.com/#configuration
           var $dropZone = view.$(".dropzone").dropzone({
-            url: view.model.get("imageURL") || view.model.url(),
+            url: view.model.get("imageURL") || view.model.url() || MetacatUI.appModel.getActiveAltRepo().objectServiceUrl,
             acceptedFiles: "image/*",
             addRemoveLinks: false,
             maxFiles: 1,


### PR DESCRIPTION
Resolves the issues of portal image dropzone URL being null without setting the
```
  objectServiceUrl: "https://mn-ucsb-1.dataone.org/knb/d1/mn/v2/object/"
```
in the `dataone` theme `config.js` which is an imprecise solution and affects the workingness of other things in DataONE. Should resolve #2782 until a more permanent solution can be implemented.