### PR TITLE
Show skipped MDQ checks in Assessment page

### DIFF
--- a/src/css/mdq.css
+++ b/src/css/mdq.css
@@ -14,10 +14,12 @@
 }
 
 .mdq-results {
+  --col-bkg-grey: #ededed;
   --col-bkg-red: #fbd6d6;
   --col-bkg-green: #dff0d8;
   --col-bkg-blue: #d9edf7;
   --col-bkg-orange: #fcf8e3;
+  --col-text-grey: #535353;
   --col-text-red: #811010;
   --col-text-green: #0a7035;
   --col-text-blue: #0f5f95;
@@ -120,5 +122,11 @@
   .content.mdq-results__item--orange {
     --item-bkg-color: var(--col-bkg-orange);
     --item-text-color: var(--col-text-orange);
+  }
+
+  .title.mdq-results__item--grey,
+  .content.mdq-results__item--grey {
+    --item-bkg-color: var(--col-bkg-grey);
+    --item-text-color: var(--col-text-grey);
   }
 }

--- a/src/css/metacatui-common.css
+++ b/src/css/metacatui-common.css
@@ -1483,14 +1483,6 @@ svg.icon {
   fill: #b94a48;
 }
 
-#mdqResult .donut.data > g:nth-child(4) .donut-arc {
-  fill: #91d7fb;
-}
-#mdqResult .donut.data > g:nth-child(4) .donut-arc-label,
-#mdqResult .donut.data > g:nth-child(4) .donut-arc.active {
-  fill: #3a87ad;
-}
-
 #mdqResult .donut-labels {
   opacity: 0;
 }

--- a/src/js/collections/QualityReport.js
+++ b/src/js/collections/QualityReport.js
@@ -100,7 +100,7 @@ define([
             return color;
           }
           if (status === "SKIP") {
-            color = "BLUE";
+            color = "GREY";
             return color;
           }
           // always green for success
@@ -137,6 +137,9 @@ define([
         }
         if (!groupedResults.RED) {
           groupedResults.RED = [];
+        }
+        if (!groupedResults.GREY) {
+          groupedResults.GREY = [];
         }
 
         // if (groupedResults.BLUE) {

--- a/src/js/collections/QualityReport.js
+++ b/src/js/collections/QualityReport.js
@@ -94,7 +94,6 @@ define([
           const check = result.get("check");
           const status = result.get("status");
           // simple cases
-          // always blue for info and skip
           if (check.level === "INFO") {
             color = "BLUE";
             return color;

--- a/src/js/views/MdqRunView.js
+++ b/src/js/views/MdqRunView.js
@@ -89,7 +89,7 @@ define([
       status: "GREY",
       icon: "chevron-sign-right",
       buildTitle: ({ count }) =>
-        `Skipped ${count} ${PLURAL(count)}${count ? " that are not applicable." : "."}`,
+        `Skipped ${count} ${PLURAL(count)}${count ? ` that ${count === 1 ? "is" : "are"} not applicable.` : "."}`
     },
   ];
 

--- a/src/js/views/MdqRunView.js
+++ b/src/js/views/MdqRunView.js
@@ -89,7 +89,7 @@ define([
       status: "GREY",
       icon: "chevron-sign-right",
       buildTitle: ({ count }) =>
-        `Skipped ${count} ${PLURAL(count)}${count ? ` that ${count === 1 ? "is" : "are"} not applicable.` : "."}`
+        `Skipped ${count} ${PLURAL(count)}${count ? ` that ${count === 1 ? "is" : "are"} not applicable.` : "."}`,
     },
   ];
 
@@ -753,11 +753,21 @@ define([
        * @param {object} groupedResults - The results grouped by status
        */
       drawScoreChart(results, groupedResults) {
+        const chartContainer = this.$(".format-charts-data");
+        if (!chartContainer) return;
+
         const greenCount = groupedResults.GREEN.length;
         const yellowCount = groupedResults.ORANGE.length;
         const redCount = groupedResults.RED.length;
-
         const dataCount = greenCount + yellowCount + redCount;
+
+        if (dataCount === 0) {
+          chartContainer.html(
+            `<h2 class='data fallback'>No scored checks were run for this dataset.</h2>` +
+              `<p>Informational and skipped checks are not included in the overall assessment score.</p>`,
+          );
+          return;
+        }
 
         const data = [
           {
@@ -768,12 +778,12 @@ define([
           {
             label: "Warn",
             count: yellowCount,
-            perc: yellowCount / results.length,
+            perc: yellowCount / dataCount,
           },
           {
             label: "Fail",
             count: redCount,
-            perc: redCount / results.length,
+            perc: redCount / dataCount,
           },
         ];
 
@@ -781,10 +791,10 @@ define([
 
         // If d3 isn't supported in this browser or didn't load correctly, insert a text title instead
         if (!d3) {
-          this.$(".format-charts-data").html(
+          chartContainer.html(
             `<h2 class='${svgClass} fallback'>${MetacatUI.appView.commaSeparateNumber(
               dataCount,
-            )} data files</h2>`,
+            )} checks</h2>`,
           );
 
           return;
@@ -806,7 +816,7 @@ define([
             return name;
           },
         });
-        this.$(".format-charts-data").html(donut.render().el);
+        chartContainer.html(donut.render().el);
       },
 
       /**

--- a/src/js/views/MdqRunView.js
+++ b/src/js/views/MdqRunView.js
@@ -66,7 +66,7 @@ define([
       status: "GREEN",
       icon: "check-sign",
       buildTitle: ({ count, totalPassable }) =>
-        `Passed ${count} ${PLURAL(count)} out of ${totalPassable} (excluding informational checks).`,
+        `Passed ${count} ${PLURAL(count)} out of ${totalPassable} (excluding informational & skipped checks).`,
     },
     {
       status: "ORANGE",
@@ -84,6 +84,12 @@ define([
       status: "BLUE",
       icon: "info-sign",
       buildTitle: ({ count }) => `${count} informational ${PLURAL(count)}.`,
+    },
+    {
+      status: "GREY",
+      icon: "chevron-sign-right",
+      buildTitle: ({ count }) =>
+        `Skipped ${count} ${PLURAL(count)}${count ? " that are not applicable." : "."}`,
     },
   ];
 
@@ -368,8 +374,11 @@ define([
 
         // Generate text for each status (GREEN, ORANGE, RED, BLUE)
         const counts = qualityReport.getCountsPerGroup(groupedResults);
+        const informational = counts.blue || counts.BLUE || 0;
+        const skipped = counts.grey || counts.GREY || 0;
+        const excluded = informational + skipped;
 
-        let totalPassable = counts.total - (counts.blue || counts.BLUE || 0);
+        let totalPassable = counts.total - excluded;
         if (totalPassable < 0) totalPassable = 0;
 
         REPORT_CATEGORIES.forEach((category) => {
@@ -388,13 +397,14 @@ define([
 
       /**
        * Add a category item to the accordion, which represents a
-       * category of checks (GREEN, ORANGE, RED, BLUE).
+       * category of checks (GREEN, ORANGE, RED, BLUE, GREY).
        * @param {object} category - The category object containing status, title, and icon
        * @param {object} groupedResults - The results grouped by status
        * @since 2.34.0
        */
       async addCategoryItem(category, groupedResults) {
-        // Root items are the main categories of checks, such as GREEN, ORANGE, RED, BLUE
+        // Root items are the main categories of checks, such as GREEN, ORANGE,
+        // RED, BLUE, GREY
         const CN = CLASS_NAMES;
         const { status, title, icon } = category;
         const results = groupedResults[status] || [];
@@ -743,27 +753,27 @@ define([
        * @param {object} groupedResults - The results grouped by status
        */
       drawScoreChart(results, groupedResults) {
-        const dataCount = results.length;
+        const greenCount = groupedResults.GREEN.length;
+        const yellowCount = groupedResults.ORANGE.length;
+        const redCount = groupedResults.RED.length;
+
+        const dataCount = greenCount + yellowCount + redCount;
+
         const data = [
           {
             label: "Pass",
-            count: groupedResults.GREEN.length,
-            perc: groupedResults.GREEN.length / results.length,
+            count: greenCount,
+            perc: greenCount / dataCount,
           },
           {
             label: "Warn",
-            count: groupedResults.ORANGE.length,
-            perc: groupedResults.ORANGE.length / results.length,
+            count: yellowCount,
+            perc: yellowCount / results.length,
           },
           {
             label: "Fail",
-            count: groupedResults.RED.length,
-            perc: groupedResults.RED.length / results.length,
-          },
-          {
-            label: "Info",
-            count: groupedResults.BLUE.length,
-            perc: groupedResults.BLUE.length / results.length,
+            count: redCount,
+            perc: redCount / results.length,
           },
         ];
 


### PR DESCRIPTION
Hide skipped informational and skipped checks in the pie chart. Total checks in chart is PASS + WARN + FAIL only.

<img width="720" height="516" alt="image" src="https://github.com/user-attachments/assets/bcccbfdb-3d51-45ba-8ce2-402c86f5a047" />


Fixes #2765