### PR TITLE
Use BEM CSS for DownloadPanelView and LayerDownloadView

### DIFF
--- a/src/css/map-view.css
+++ b/src/css/map-view.css
@@ -1650,7 +1650,7 @@ other class: .ui-slider-range */
   padding-top: 0;
   color: var(--portal-col-neutral-7);
   overflow-y: auto; /* Enable vertical scrolling */
-  max-height: 150px; /* Fixed height for the list */
+  max-height: 200px; /* Fixed height for the list */
   /* Styling the scrollbar */
   scrollbar-width: thin; /* For Firefox */
   scrollbar-color: var(--portal-col-neutral-4, #888)

--- a/src/css/map-view.css
+++ b/src/css/map-view.css
@@ -1575,18 +1575,16 @@ other class: .ui-slider-range */
   margin-bottom: 3px;
 }
 
-/* Two-class specificity (0,2,0) is needed to beat portal-theme rules like
-   `.portal-view h3` (0,1,1) that would otherwise force the h3 to white. */
-.download-panel__title-group .download-panel__title {
-  color: var(--portal-col-primary-6, var(--map-col-text__deprecate));
-}
-
-.icon-download-alt {
-  font-size: 20px; /* Adjust icon size */
-  vertical-align: bottom; /* Ensures inline alignment */
+/* !important is required to override portal-theme rules such as `.portal-view h3`
+   (specificity 0,1,1) which would otherwise force the colour to white regardless
+   of the BEM modifier. No structural selector relationship is implied. */
+.download-panel__title {
+  color: var(--portal-col-primary-6, var(--map-col-text__deprecate)) !important;
 }
 
 .download-panel__icon {
+  font-size: 20px;
+  vertical-align: bottom;
   color: var(--portal-col-primary-6, var(--map-col-text__deprecate));
 }
 
@@ -1716,7 +1714,7 @@ other class: .ui-slider-range */
   display: none;
 }
 
-.layer-download.show-content .layer-download__content {
+.layer-download__content--visible {
   display: block;
 }
 
@@ -1736,7 +1734,7 @@ other class: .ui-slider-range */
   height: 100%; /* Ensure the container has height to align */
 }
 
-.layer-download__dropdown-wrapper label {
+.layer-download__dropdown-label {
   font-size: 12px;
   white-space: nowrap;
   margin-bottom: 0;
@@ -1752,7 +1750,7 @@ other class: .ui-slider-range */
   height: 18px;
   background-color: var(--portal-col-neutral-00, #faf9f6);
   color: var(--portal-col-neutral-7);
-  border: 1px solid var(--portal-col-neutral-2, #ccc); /* Light border for the dropdown */
+  border: 1px solid var(--portal-col-neutral-4, #ccc); /* Light border for the dropdown */
   border-radius: 4px; /* Rounded corners */
   margin-left: 5px;
 }

--- a/src/css/map-view.css
+++ b/src/css/map-view.css
@@ -1431,17 +1431,6 @@ other class: .ui-slider-range */
   display: flex;
   justify-content: center;
   align-items: center;
-
-  .icon {
-    color: var(--portal-col-primary-6, var(--map-col-text__deprecate));
-  }
-
-  .draw-tool__button--disable .icon {
-    color: var(
-      --portal-col-neutral-4,
-      var(--portal-col-text-subtle__deprecate, #6b7280)
-    );
-  }
 }
 
 .draw-tool__button {
@@ -1477,10 +1466,6 @@ other class: .ui-slider-range */
     var(--portal-col-text-subtle__deprecate, #6b7280)
   );
   cursor: not-allowed;
-
-  .draw-tool__button-icon-wrap {
-    opacity: 0.75;
-  }
 }
 
 .draw-tool__button-icon-wrap {
@@ -1496,6 +1481,14 @@ other class: .ui-slider-range */
   font-size: 20px;
   border: 1px solid
     var(--portal-col-primary-2, var(--map-col-bkg-lightest__deprecate));
+}
+
+.draw-tool__button-icon-wrap--disabled {
+  opacity: 0.75;
+  color: var(
+    --portal-col-neutral-4,
+    var(--portal-col-text-subtle__deprecate, #6b7280)
+  );
 }
 
 .draw-tool__button-label {

--- a/src/css/map-view.css
+++ b/src/css/map-view.css
@@ -1427,7 +1427,10 @@ other class: .ui-slider-range */
   }
 
   .draw-tool__button--disable .icon {
-    color: var(--portal-col-neutral-4, var(--map-col-text__deprecate));
+    color: var(
+      --portal-col-neutral-4,
+      var(--portal-col-text-subtle__deprecate)
+    );
   }
 }
 
@@ -1459,7 +1462,7 @@ other class: .ui-slider-range */
 }
 
 .draw-tool__button--disable {
-  color: var(--portal-col-neutral-4);
+  color: var(--portal-col-neutral-4, var(--portal-col-text-subtle__deprecate));
   cursor: not-allowed;
   trash {
     color: var(--portal-col-primary-6, var(--map-col-text__deprecate));
@@ -1599,7 +1602,10 @@ other class: .ui-slider-range */
 
 .download-panel__progress-container {
   width: 100%;
-  background-color: var(--portal-col-neutral-2, rgba(200, 199, 199, 0.77));
+  background-color: var(
+    --portal-col-neutral-2,
+    var(--map-col-bkg-lightest__deprecate)
+  );
   border-radius: 5px;
   margin-top: 10px;
   overflow: hidden;
@@ -1608,9 +1614,12 @@ other class: .ui-slider-range */
 .download-panel__progress-bar {
   width: 0%;
   height: 18px;
-  background-color: var(--portal-col-primary-6, var(--map-col-text__deprecate));
+  background-color: var(
+    --portal-col-primary-6,
+    var(--map-col-highlight__deprecate)
+  );
   text-align: center;
-  color: var(--portal-col-neutral-00);
+  color: var(--portal-col-neutral-00, var(--map-col-text__deprecate));
   line-height: 18px;
   font-size: 10px;
   border-radius: 5px;
@@ -1620,7 +1629,7 @@ other class: .ui-slider-range */
   width: 0%;
   height: 18px;
   text-align: center;
-  color: var(--portal-col-neutral-8);
+  color: var(--portal-col-neutral-8, var(--map-col-bkg__deprecate));
   line-height: 18px;
   font-size: 10px;
   border-radius: 5px;

--- a/src/css/map-view.css
+++ b/src/css/map-view.css
@@ -1439,7 +1439,7 @@ other class: .ui-slider-range */
   .draw-tool__button--disable .icon {
     color: var(
       --portal-col-neutral-4,
-      var(--portal-col-text-subtle__deprecate)
+      var(--portal-col-text-subtle__deprecate, #6b7280)
     );
   }
 }
@@ -1472,8 +1472,15 @@ other class: .ui-slider-range */
 }
 
 .draw-tool__button--disable {
-  color: var(--portal-col-neutral-4, var(--portal-col-text-subtle__deprecate));
+  color: var(
+    --portal-col-neutral-4,
+    var(--portal-col-text-subtle__deprecate, #6b7280)
+  );
   cursor: not-allowed;
+
+  .draw-tool__button-icon-wrap {
+    opacity: 0.75;
+  }
   trash {
     color: var(--portal-col-primary-6, var(--map-col-text__deprecate));
   }
@@ -1795,11 +1802,11 @@ other class: .ui-slider-range */
 
 .layer-download__copy-icon {
   cursor: pointer;
-  color: var(--portal-col-neutral-7);
+  color: var(--portal-col-neutral-7, var(--map-col-text__deprecate));
 }
 
 .layer-download__copy-icon:hover {
-  color: var(--portal-col-primary-6, var(--map-col-text__deprecate));
+  color: var(--portal-col-primary-6, #0087b5);
 }
 
 /*****************************************************************************************

--- a/src/css/map-view.css
+++ b/src/css/map-view.css
@@ -1413,11 +1413,25 @@ other class: .ui-slider-range */
  *
  * Draw Tool
  *
- * Panel for drawing polygons in the map
+ * Panel for drawing polygons in the map (used in download panel)
  *
  */
 
-.draw__button {
+.draw-tool {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  .icon {
+    color: var(--portal-col-primary-6, var(--map-col-text__deprecate));
+  }
+
+  .draw-tool__button--disable .icon {
+    color: var(--portal-col-neutral-4, var(--map-col-text__deprecate));
+  }
+}
+
+.draw-tool__button {
   position: relative;
   font-family: inherit;
   font-size: 100%;
@@ -1436,21 +1450,7 @@ other class: .ui-slider-range */
   margin: 0 25px;
 }
 
-.draw-tool {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-
-  .icon {
-    color: var(--portal-col-primary-6, var(--map-col-text__deprecate));
-  }
-
-  .draw__button--disable .icon {
-    color: var(--portal-col-neutral-4, var(--map-col-text__deprecate));
-  }
-}
-
-.draw__button--active {
+.draw-tool__button--active {
   background-color: var(
     --portal-col-primary-6,
     var(--map-col-highlight__deprecate)
@@ -1458,7 +1458,19 @@ other class: .ui-slider-range */
   color: var(--portal-col-neutral-00);
 }
 
-.custom-circle {
+.draw-tool__button--disable {
+  /* background-color: gray; */
+  color: gray;
+  cursor: not-allowed;
+  trash {
+    color: var(
+      --portal-col-primary-6,
+      var(--map-col-text__deprecate)
+    ) !important;
+  }
+}
+
+.draw-tool__button-icon-wrap {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -1467,22 +1479,19 @@ other class: .ui-slider-range */
   border-radius: 50%;
   padding: 0.5rem;
   background-color: var(--portal-col-neutral-00, var(--map-col-bkg__deprecate));
-  border: 2px solid var(--portal-col-primary-3);
-  color: #333;
+  color: var(--portal-col-primary-6, var(--map-col-text__deprecate));
   font-size: 20px;
   border: 1px solid var(--portal-col-primary-2);
 }
 
-.draw-button-label {
+.draw-tool__button-label {
   display: none; /* Hide the label by default */
   position: absolute;
-  background-color: rgba(
-    0,
-    0,
-    0,
-    0.7
+  background-color: var(
+    --portal-col-neutral-7,
+    rgba(0, 0, 0, 0.7)
   ); /* Optional: Add a semi-transparent background */
-  color: #fff; /* Label text color */
+  color: var(--portal-col-neutral-00, #fff); /* Label text color */
   padding: 4px 8px;
   border-radius: 4px;
   font-size: 12px;
@@ -1494,9 +1503,21 @@ other class: .ui-slider-range */
   margin-top: 5px;
 }
 
-.draw__button:hover .draw-button-label {
+.draw-tool__button:hover .draw-tool__button-label {
   display: block;
 }
+
+/*****************************************************************************************
+ *
+ * Download Panel
+ *
+ * Panel for downloading data from the map. 
+ * Contains:
+ *   - a header
+ *   - instructions
+ *   - a list of downloadable data layers (download-data-list)
+ *   - the draw-tool for selecting a custom area to download
+ */
 
 .download-panel {
   display: flex;
@@ -1516,26 +1537,13 @@ other class: .ui-slider-range */
   background-color: var(--portal-col-primary-1, var(--map-col-bkg__deprecate));
 }
 
-.download-panel-close__button {
-  /* override default button styles */
-  font-family: inherit;
-  font-size: 100%;
-  line-height: 1.15;
-  margin: 0;
-  overflow: visible;
-  text-transform: none;
-  border: 0;
-  border-radius: var(--map-border-radius-big);
-  background: var(--portal-col-neutral-00, var(--map-col-buttons__deprecate));
-  color: var(--portal-col-primary-6, var(--map-col-text__deprecate));
-  white-space: nowrap;
-  text-decoration: none;
-  padding: 0.25rem 0.5rem;
-  cursor: pointer;
+/* The only style unique to the close button is its right margin; all other
+   styles come from .map-view__button which is added in the template. */
+.download-panel__close-button {
   margin-right: 30px;
 }
 
-.header-container {
+.download-panel__header {
   display: flex;
   justify-content: space-between; /* Push label and button apart */
   align-items: center;
@@ -1545,13 +1553,13 @@ other class: .ui-slider-range */
 }
 
 /* Group icon and label in a flex container */
-.label-container {
+.download-panel__title-group {
   display: flex;
   align-items: center; /* Ensures both icon & text align properly */
   gap: 8px; /* Adds spacing between icon and text */
 }
 
-.download__label {
+.download-panel__title {
   margin: 0;
   font-size: 20px;
   font-weight: 700;
@@ -1561,11 +1569,10 @@ other class: .ui-slider-range */
   margin-bottom: 3px;
 }
 
-.download-panel .label-container {
-  color: var(--portal-col-primary-6, var(--map-col-text__deprecate)) !important;
-  .download__label {
-    color: currentColor;
-  }
+/* Two-class specificity (0,2,0) is needed to beat portal-theme rules like
+   `.portal-view h3` (0,1,1) that would otherwise force the h3 to white. */
+.download-panel__title-group .download-panel__title {
+  color: var(--portal-col-primary-6, var(--map-col-text__deprecate));
 }
 
 .icon-download-alt {
@@ -1573,11 +1580,14 @@ other class: .ui-slider-range */
   vertical-align: bottom; /* Ensures inline alignment */
 }
 
-.download-data-list__panel {
+.download-panel__icon {
+  color: var(--portal-col-primary-6, var(--map-col-text__deprecate));
+}
+
+.download-panel__instructions {
   display: block; /* To display the panel below */
   width: calc(100% - 60px);
   padding-top: 0;
-  color: black;
   font-size: 0.825rem;
   font-weight: 400;
   margin: 0 0.5rem;
@@ -1587,17 +1597,57 @@ other class: .ui-slider-range */
   text-overflow: ellipsis;
 }
 
+.download-panel__progress-container {
+  width: 100%;
+  background-color: var(--portal-col-neutral-2, rgba(200, 199, 199, 0.77));
+  border-radius: 5px;
+  margin-top: 10px;
+  overflow: hidden;
+}
+
+.download-panel__progress-bar {
+  width: 0%;
+  height: 18px;
+  background-color: var(--portal-col-primary-6, var(--map-col-text__deprecate));
+  text-align: center;
+  color: white;
+  line-height: 18px;
+  font-size: 10px;
+  border-radius: 5px;
+  transition: width 0.4s;
+}
+.download-panel__progress-bar--no-data {
+  width: 0%;
+  height: 18px;
+  text-align: center;
+  color: rgb(3, 3, 3);
+  line-height: 18px;
+  font-size: 10px;
+  border-radius: 5px;
+  transition: width 0.4s;
+  background-color: rgba(255, 255, 0, 0.172);
+}
+
+/*****************************************************************************************
+ *
+ * Download Data List
+ *
+ * A list of data layers (layer-download blocks) that can be downloaded.
+ * 
+ */
+
 .download-data-list {
   display: block;
   width: calc(100% - 60px);
   margin: 5px 0 15px 0;
   padding-top: 0;
-  color: black;
+  color: var(--portal-col-neutral-7);
   overflow-y: auto; /* Enable vertical scrolling */
   max-height: 150px; /* Fixed height for the list */
   /* Styling the scrollbar */
   scrollbar-width: thin; /* For Firefox */
-  scrollbar-color: #888 #f0f0f0; /* For Firefox */
+  scrollbar-color: var(--portal-col-neutral-4, #888)
+    var(--portal-col-neutral-1, #f0f0f0); /* For Firefox */
 }
 
 /* For Chrome, Edge, and Safari */
@@ -1606,72 +1656,37 @@ other class: .ui-slider-range */
 }
 
 .download-data-list::-webkit-scrollbar-track {
-  background: #f0f0f0; /* Background of the scrollbar track */
+  background: var(
+    --portal-col-neutral-1,
+    #f0f0f0
+  ); /* Background of the scrollbar track */
 }
 
 .download-data-list::-webkit-scrollbar-thumb {
-  background-color: #888; /* Color of the scrollbar thumb */
+  background-color: var(
+    --portal-col-neutral-4,
+    #888
+  ); /* Color of the scrollbar thumb */
   border-radius: 6px; /* Rounded edges */
-  border: 2px solid #f0f0f0; /* Adds some space between thumb and track */
+  border: 2px solid var(--portal-col-neutral-1, #f0f0f0); /* Adds some space between thumb and track */
 }
 
 .download-data-list::-webkit-scrollbar-thumb:hover {
-  background-color: #555; /* Darker thumb when hovered */
+  background-color: var(
+    --portal-col-neutral-5,
+    #555
+  ); /* Darker thumb when hovered */
 }
 
-.checkbox-item {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
+/*****************************************************************************************
+ *
+ * Layer Download
+ *
+ * A LayerDownloadView block within the download data list.
+ * Shows information about a downloadable layer, and allows the user to select it for download, configure options, and see size details.
+ *
+ */
 
-.checkbox-item input {
-  margin-top: 3px;
-  cursor: pointer;
-  width: 14px;
-  height: 14px;
-  display: inline-block;
-  vertical-align: middle;
-  position: relative;
-}
-
-.checkbox-item label {
-  /* font-size: 14px; */
-  margin-top: 5px;
-  cursor: pointer;
-  font-size: 0.825rem;
-  font-weight: 400;
-  color: var(--portal-col-neutral-7);
-  text-overflow: ellipsis;
-  line-height: 16px; /* Matches checkbox height */
-  display: inline-block;
-}
-
-.download-submit-btn {
-  margin-top: 10px;
-  padding: 8px 12px;
-  background-color: var(--portal-col-primary-6, var(--map-col-bkg__deprecate));
-  color: white;
-  border: none;
-  border-radius: 4px;
-  cursor: pointer;
-  font-size: 14px;
-  text-align: center;
-  margin-bottom: 20px;
-  width: calc(100% - 60px);
-}
-
-.download-submit-btn:hover {
-  background-color: var(--portal-col-primary-3, var(--map-col-bkg__deprecate));
-}
-
-.download-submit-btn:disabled {
-  background-color: gray; /* Change color to indicate disabled state */
-  cursor: not-allowed;
-  opacity: 0.6; /* Reduce opacity to make it look disabled */
-}
-
-/* Layer download panel: header row and collapsible content */
 .layer-download__header {
   display: grid;
   grid-template-columns: min-content auto min-content;
@@ -1701,13 +1716,13 @@ other class: .ui-slider-range */
   display: block;
 }
 
-.downloads-dropdown-container {
+.layer-download__dropdown-container {
   padding-top: 5px;
   display: flex;
   gap: 20px; /* Space between dropdowns */
 }
 
-.downloads-dropdown-wrapper {
+.layer-download__dropdown-wrapper {
   color: var(--portal-col-primary-6, var(--map-col-highlight__deprecate));
   display: flex;
   align-items: center; /* Align label and dropdown vertically */
@@ -1716,33 +1731,33 @@ other class: .ui-slider-range */
   justify-content: flex-end; /* Align items at the bottom */
   height: 100%; /* Ensure the container has height to align */
 }
-.downloads-dropdown-wrapper label {
+.layer-download__dropdown-wrapper label {
   font-size: 12px;
   white-space: nowrap;
   margin-bottom: 0;
   color: var(--portal-col-neutral-7);
 }
 
-.downloads-dropdown {
+.layer-download__dropdown {
   margin-bottom: 0;
   padding: 0px 2px; /* Add padding for better appearance */
   font-size: 10px;
   width: 65%; /* Adjust based on container */
   max-width: 120px; /* Prevents it from getting too wide */
   height: 18px;
-  background-color: #faf9f6;
+  background-color: var(--portal-col-neutral-00, #faf9f6);
   color: var(--portal-col-neutral-7);
-  border: 1px solid #ccc; /* Light border for the dropdown */
+  border: 1px solid var(--portal-col-neutral-2, #ccc); /* Light border for the dropdown */
   border-radius: 4px; /* Rounded corners */
   margin-left: 5px;
 }
 
-.downloads-dropdown option {
+.layer-download__dropdown option {
   font-size: 12px; /* Adjust option font size */
   color: var(--portal-col-neutral-7);
 }
 
-.downloads-textbox {
+.layer-download__information {
   margin: 5px 6px 8px 16px;
   padding: 3px 5px;
   line-height: 1;
@@ -1751,15 +1766,15 @@ other class: .ui-slider-range */
   display: block;
 }
 
-.downloads-textbox--warning {
+.layer-download__information--warning {
   color: var(--portal-col-warning, #b45309);
 }
 
-.downloads-textbox--warning::before {
+.layer-download__information--warning::before {
   content: "\26A0\FE0F  "; /* ⚠ warning sign */
 }
 
-.wmts-copy {
+.layer-download__information--wmts {
   background: var(--portal-col-neutral-1, var(--map-col-text__deprecate));
   border-radius: 5px;
   border: 1px solid
@@ -1768,56 +1783,12 @@ other class: .ui-slider-range */
   justify-content: space-between;
 }
 
-.download-status-container {
-  width: 100%;
-  background-color: #c8c7c7c4;
-  border-radius: 5px;
-  margin-top: 10px;
-  overflow: hidden;
-}
-
-.progress-bar {
-  width: 0%;
-  height: 18px;
-  background-color: var(
-    --portal-col-primary-6,
-    var(--map-col-text__deprecate)
-  ) !important;
-  text-align: center;
-  color: white;
-  line-height: 18px;
-  font-size: 10px;
-  border-radius: 5px;
-  transition: width 0.4s;
-}
-.progress-bar-no-data {
-  width: 0%;
-  height: 18px;
-  text-align: center;
-  color: rgb(3, 3, 3);
-  line-height: 18px;
-  font-size: 10px;
-  border-radius: 5px;
-  transition: width 0.4s;
-  background-color: rgba(255, 255, 0, 0.172);
-}
-.draw__button--disable {
-  /* background-color: gray; */
-  color: gray;
-  cursor: not-allowed;
-  trash {
-    color: var(
-      --portal-col-primary-6,
-      var(--map-col-text__deprecate)
-    ) !important;
-  }
-}
-#copyWMTS {
+.layer-download__copy-icon {
   cursor: pointer;
   color: var(--portal-col-neutral-7);
 }
 
-#copyWMTS:hover {
+.layer-download__copy-icon:hover {
   color: var(--portal-col-primary-6, var(--map-col-text__deprecate)) !important;
 }
 

--- a/src/css/map-view.css
+++ b/src/css/map-view.css
@@ -1497,7 +1497,7 @@ other class: .ui-slider-range */
   background-color: var(
     --portal-col-neutral-7,
     var(--map-col-bkg-lightest__deprecate)
-  ); /* Optional: Add a semi-transparent background */
+  );
   color: var(
     --portal-col-neutral-00,
     var(--map-col-text__deprecate)
@@ -1513,6 +1513,8 @@ other class: .ui-slider-range */
   margin-top: 5px;
 }
 
+/* :hover triggering a descendant is the only pure-CSS way to implement a tooltip. */
+/* The JS alternative (toggling a --visible BEM modifier on mouseenter/mouseleave) adds unnecessary complexity */
 .draw-tool__button:hover .draw-tool__button-label {
   display: block;
 }
@@ -1738,26 +1740,50 @@ other class: .ui-slider-range */
   font-size: 12px;
   white-space: nowrap;
   margin-bottom: 0;
-  color: var(--portal-col-neutral-7);
+  color: var(--portal-col-neutral-7, var(--map-col-text__deprecate));
 }
 
 .layer-download__dropdown {
   margin-bottom: 0;
-  padding: 0px 2px; /* Add padding for better appearance */
+  padding: 0px 2px;
   font-size: 10px;
   width: 65%; /* Adjust based on container */
-  max-width: 120px; /* Prevents it from getting too wide */
+  max-width: 120px;
   height: 18px;
-  background-color: var(--portal-col-neutral-00, #faf9f6);
-  color: var(--portal-col-neutral-7);
-  border: 1px solid var(--portal-col-neutral-4, #ccc); /* Light border for the dropdown */
-  border-radius: 4px; /* Rounded corners */
+  background-color: var(
+    --portal-col-neutral-1,
+    var(--map-col-bkg-lightest__deprecate)
+  );
+  color: var(--portal-col-neutral-8, var(--map-col-text__deprecate));
+  border: 1px solid
+    var(--portal-col-neutral-4, var(--map-col-bkg-lightest__deprecate));
+  border-radius: 4px;
   margin-left: 5px;
 }
 
+/* It seems native <option> elements inside a <select> cannot be given BEM classes in most browsers */
 .layer-download__dropdown option {
-  font-size: 12px; /* Adjust option font size */
-  color: var(--portal-col-neutral-7);
+  font-size: 12px;
+  color: var(--portal-col-neutral-7, var(--map-col-text__deprecate));
+}
+
+/* Cancel browser-default opacity on disabled selects so we can set explicit
+   muted-but-legible colours ourselves on both light and dark themes. */
+.layer-download__dropdown:disabled {
+  opacity: 1;
+  cursor: not-allowed;
+  color: var(
+    --portal-col-neutral-5,
+    var(--portal-col-text-subtle__deprecate, #6b7280)
+  );
+  background-color: var(
+    --portal-col-neutral-2,
+    var(--map-col-bkg-lightest__deprecate)
+  );
+  border-color: var(
+    --portal-col-neutral-3,
+    var(--map-col-bkg-lightest__deprecate)
+  );
 }
 
 .layer-download__information {
@@ -1785,6 +1811,7 @@ other class: .ui-slider-range */
   border-radius: 5px;
   border: 1px solid
     var(--portal-col-primary-2, var(--map-col-bkg-lightest__deprecate));
+  color: var(--portal-col-neutral-8, var(--map-col-text__deprecate));
   display: flex;
   justify-content: space-between;
 }

--- a/src/css/map-view.css
+++ b/src/css/map-view.css
@@ -1481,9 +1481,6 @@ other class: .ui-slider-range */
   .draw-tool__button-icon-wrap {
     opacity: 0.75;
   }
-  trash {
-    color: var(--portal-col-primary-6, var(--map-col-text__deprecate));
-  }
 }
 
 .draw-tool__button-icon-wrap {

--- a/src/css/map-view.css
+++ b/src/css/map-view.css
@@ -517,7 +517,7 @@ represents 1 unit of the given distance measurement. */
 /* The download panel is in-flow at the bottom of the flex column. It should
    only take as much vertical space as its content needs — not stretch to fill
    the remaining height the way sibling toolbar__content panels do. */
-.toolbar__content:has(.download-panel) {
+.toolbar__content--download {
   flex: 0 0 auto;
   min-height: 0;
   overflow: visible;
@@ -1735,6 +1735,7 @@ other class: .ui-slider-range */
   justify-content: flex-end; /* Align items at the bottom */
   height: 100%; /* Ensure the container has height to align */
 }
+
 .layer-download__dropdown-wrapper label {
   font-size: 12px;
   white-space: nowrap;

--- a/src/css/map-view.css
+++ b/src/css/map-view.css
@@ -1515,7 +1515,7 @@ other class: .ui-slider-range */
  * Contains:
  *   - a header
  *   - instructions
- *   - a list of downloadable data layers (download-data-list)
+ *   - a list of downloadable data layers (download-panel__data-list)
  *   - the draw-tool for selecting a custom area to download
  */
 
@@ -1628,15 +1628,7 @@ other class: .ui-slider-range */
   background-color: rgba(255, 255, 0, 0.172);
 }
 
-/*****************************************************************************************
- *
- * Download Data List
- *
- * A list of data layers (layer-download blocks) that can be downloaded.
- * 
- */
-
-.download-data-list {
+.download-panel__data-list {
   display: block;
   width: calc(100% - 60px);
   margin: 5px 0 15px 0;
@@ -1651,18 +1643,18 @@ other class: .ui-slider-range */
 }
 
 /* For Chrome, Edge, and Safari */
-.download-data-list::-webkit-scrollbar {
+.download-panel__data-list::-webkit-scrollbar {
   width: 12px; /* Width of the scrollbar */
 }
 
-.download-data-list::-webkit-scrollbar-track {
+.download-panel__data-list::-webkit-scrollbar-track {
   background: var(
     --portal-col-neutral-1,
     #f0f0f0
   ); /* Background of the scrollbar track */
 }
 
-.download-data-list::-webkit-scrollbar-thumb {
+.download-panel__data-list::-webkit-scrollbar-thumb {
   background-color: var(
     --portal-col-neutral-4,
     #888
@@ -1671,7 +1663,7 @@ other class: .ui-slider-range */
   border: 2px solid var(--portal-col-neutral-1, #f0f0f0); /* Adds some space between thumb and track */
 }
 
-.download-data-list::-webkit-scrollbar-thumb:hover {
+.download-panel__data-list::-webkit-scrollbar-thumb:hover {
   background-color: var(
     --portal-col-neutral-5,
     #555

--- a/src/css/map-view.css
+++ b/src/css/map-view.css
@@ -492,7 +492,8 @@ represents 1 unit of the given distance measurement. */
 
 .toolbar__content {
   /* TODO: remove temp styles */
-  height: 100%;
+  flex: 1 1 0;
+  min-height: 0;
   width: 100%;
   justify-content: center;
   /* hide unless the content section is active */
@@ -511,6 +512,15 @@ represents 1 unit of the given distance measurement. */
 .toolbar__content--active {
   display: flex;
   position: relative;
+}
+
+/* The download panel is in-flow at the bottom of the flex column. It should
+   only take as much vertical space as its content needs — not stretch to fill
+   the remaining height the way sibling toolbar__content panels do. */
+.toolbar__content:has(.download-panel) {
+  flex: 0 0 auto;
+  min-height: 0;
+  overflow: visible;
 }
 
 .toolbar__link {
@@ -1524,16 +1534,12 @@ other class: .ui-slider-range */
 
 .download-panel {
   display: flex;
-  position: fixed;
-  width: var(--map-width-toolbar-wide);
-  left: 0;
+  width: 100%;
   flex-direction: column;
   padding-bottom: 1rem;
-  z-index: 2;
   align-items: center;
   justify-content: space-between; /* Pushes elements apart */
   gap: 0.1rem;
-  bottom: 0;
   border-width: 1px 0;
   border-top: 1px solid
     var(--portal-col-neutral-2, var(--map-col-bkg-lightest__deprecate));

--- a/src/css/map-view.css
+++ b/src/css/map-view.css
@@ -1455,18 +1455,14 @@ other class: .ui-slider-range */
     --portal-col-primary-6,
     var(--map-col-highlight__deprecate)
   );
-  color: var(--portal-col-neutral-00);
+  color: var(--portal-col-neutral-00, var(--map-col-text__deprecate));
 }
 
 .draw-tool__button--disable {
-  /* background-color: gray; */
-  color: gray;
+  color: var(--portal-col-neutral-4);
   cursor: not-allowed;
   trash {
-    color: var(
-      --portal-col-primary-6,
-      var(--map-col-text__deprecate)
-    ) !important;
+    color: var(--portal-col-primary-6, var(--map-col-text__deprecate));
   }
 }
 
@@ -1481,7 +1477,8 @@ other class: .ui-slider-range */
   background-color: var(--portal-col-neutral-00, var(--map-col-bkg__deprecate));
   color: var(--portal-col-primary-6, var(--map-col-text__deprecate));
   font-size: 20px;
-  border: 1px solid var(--portal-col-primary-2);
+  border: 1px solid
+    var(--portal-col-primary-2, var(--map-col-bkg-lightest__deprecate));
 }
 
 .draw-tool__button-label {
@@ -1489,9 +1486,12 @@ other class: .ui-slider-range */
   position: absolute;
   background-color: var(
     --portal-col-neutral-7,
-    rgba(0, 0, 0, 0.7)
+    var(--map-col-bkg-lightest__deprecate)
   ); /* Optional: Add a semi-transparent background */
-  color: var(--portal-col-neutral-00, #fff); /* Label text color */
+  color: var(
+    --portal-col-neutral-00,
+    var(--map-col-text__deprecate)
+  ); /* Label text color */
   padding: 4px 8px;
   border-radius: 4px;
   font-size: 12px;
@@ -1610,7 +1610,7 @@ other class: .ui-slider-range */
   height: 18px;
   background-color: var(--portal-col-primary-6, var(--map-col-text__deprecate));
   text-align: center;
-  color: white;
+  color: var(--portal-col-neutral-00);
   line-height: 18px;
   font-size: 10px;
   border-radius: 5px;
@@ -1620,12 +1620,12 @@ other class: .ui-slider-range */
   width: 0%;
   height: 18px;
   text-align: center;
-  color: rgb(3, 3, 3);
+  color: var(--portal-col-neutral-8);
   line-height: 18px;
   font-size: 10px;
   border-radius: 5px;
   transition: width 0.4s;
-  background-color: rgba(255, 255, 0, 0.172);
+  background-color: var(--portal-col-highlight-1, #fffcf4);
 }
 
 .download-panel__data-list {
@@ -1767,7 +1767,10 @@ other class: .ui-slider-range */
 }
 
 .layer-download__information--wmts {
-  background: var(--portal-col-neutral-1, var(--map-col-text__deprecate));
+  background: var(
+    --portal-col-neutral-1,
+    var(--map-col-bkg-lightest__deprecate)
+  );
   border-radius: 5px;
   border: 1px solid
     var(--portal-col-primary-2, var(--map-col-bkg-lightest__deprecate));
@@ -1781,7 +1784,7 @@ other class: .ui-slider-range */
 }
 
 .layer-download__copy-icon:hover {
-  color: var(--portal-col-primary-6, var(--map-col-text__deprecate)) !important;
+  color: var(--portal-col-primary-6, var(--map-col-text__deprecate));
 }
 
 /*****************************************************************************************

--- a/src/css/portal-themes/light.css
+++ b/src/css/portal-themes/light.css
@@ -27,6 +27,8 @@
   --portal-col-highlight-2: #ffddaa;
   --portal-col-highlight-3: #ca6c0b;
 
+  --portal-col-warning: #b45309;
+
   --portal-col-search-match-highlight: #fef4d6;
 
   --portal-col-bkg__deprecate: #111827;

--- a/src/js/templates/maps/download-panel.html
+++ b/src/js/templates/maps/download-panel.html
@@ -11,5 +11,5 @@
     Draw Area of Interest: Single-click to add vertices, double-click to
     complete.
 </div>
-<div class="download-data-list"></div>
+<div class="download-panel__data-list"></div>
 <div class="draw-tool"></div>

--- a/src/js/templates/maps/download-panel.html
+++ b/src/js/templates/maps/download-panel.html
@@ -1,14 +1,13 @@
-<div class="header-container">
-    <div class="label-container">
-    <i class="icon-download-alt"></i>
-    <h3 class="download__label">Partial Data Download</h3>
+<div class="download-panel__header">
+    <div class="download-panel__title-group">
+    <i class="icon-download-alt download-panel__icon"></i>
+    <h3 class="download-panel__title">Partial Data Download</h3>
     </div>
-    <!-- <button class="layer-details__toggle map-view__button"> -->
-    <button class="download-panel-close__button">
+    <button class="map-view__button download-panel__close-button" type="button">
     <i class="icon-remove"></i>
     </button>
 </div>
-<div class="download-data-list__panel">
+<div class="download-panel__instructions">
     Draw Area of Interest: Single-click to add vertices, double-click to
     complete.
 </div>

--- a/src/js/views/maps/DownloadPanelView.js
+++ b/src/js/views/maps/DownloadPanelView.js
@@ -968,6 +968,8 @@ define([
             `.${CLASS_NAMES.copyIcon}`,
           );
 
+          if (!wmtsText || !copyIcon) return;
+
           // Use .onclick (not addEventListener) so re-calling updateTextbox for
           // the same box replaces rather than stacks the handler.
           copyIcon.onclick = () => {

--- a/src/js/views/maps/DownloadPanelView.js
+++ b/src/js/views/maps/DownloadPanelView.js
@@ -23,6 +23,18 @@ define([
 ) => {
   // Classes used in the view
   const CLASS_NAMES = {
+    // Block
+    block: "download-panel",
+    // Header elements
+    header: "download-panel__header",
+    titleGroup: "download-panel__title-group",
+    title: "download-panel__title",
+    closeButton: "download-panel__close-button",
+    // Body elements
+    instructions: "download-panel__instructions",
+    dataList: "download-panel__data-list",
+    // Draw tool block
+    drawTool: "draw-tool",
     // Draw toolbar buttons
     button: "draw-tool__button",
     buttonFocus: "draw-tool__button--active",
@@ -31,15 +43,6 @@ define([
     buttonIconWrap: "draw-tool__button-icon-wrap",
     buttonIconWrapDisabled: "draw-tool__button-icon-wrap--disabled",
     buttonLabel: "draw-tool__button-label",
-    // Header elements
-    header: "download-panel__header",
-    titleGroup: "download-panel__title-group",
-    title: "download-panel__title",
-    closeButton: "download-panel__close-button",
-    // Data list elements (referenced by querySelector)
-    dataList: "download-panel__data-list",
-    instructions: "download-panel__instructions",
-    drawTool: "draw-tool",
     // Shared toolbar classes (used for coordinating with ToolbarView)
     toolbarLink: "toolbar__links",
     toolbarLinkActive: "toolbar__link--active",
@@ -81,7 +84,7 @@ define([
        * The HTML classes to use for this view's element
        * @type {string}
        */
-      className: "download-panel",
+      className: CLASS_NAMES.block,
 
       /**
        * The maximum size of the download in bytes. If download is estimated to exceed

--- a/src/js/views/maps/DownloadPanelView.js
+++ b/src/js/views/maps/DownloadPanelView.js
@@ -23,14 +23,35 @@ define([
 ) => {
   // Classes used in the view
   const CLASS_NAMES = {
-    button: "draw__button",
-    buttonFocus: "draw__button--active",
-    buttonDisable: "draw__button--disable",
-    dropdown: "downloads-dropdown",
-    resolutionDropdown: "resolution-dropdown",
-    fileTypeDropdown: "fileType-downloads-dropdown",
+    // Draw toolbar buttons
+    button: "draw-tool__button",
+    buttonFocus: "draw-tool__button--active",
+    buttonDisable: "draw-tool__button--disable",
+    // Header elements
+    header: "download-panel__header",
+    titleGroup: "download-panel__title-group",
+    title: "download-panel__title",
+    closeButton: "download-panel__close-button",
+    // Data list elements (referenced by querySelector)
+    dataList: "download-data-list",
+    instructions: "download-panel__instructions",
+    drawTool: "draw-tool",
+    // Shared toolbar classes (used for coordinating with ToolbarView)
+    toolbarLink: "toolbar__links",
+    toolbarLinkActive: "toolbar__link--active",
+    toolbarContentActive: "toolbar__content--active",
+    // Draw toolbar button internals
+    buttonIconWrap: "draw-tool__button-icon-wrap",
+    buttonLabel: "draw-tool__button-label",
+    // Info box states (used in updateTextbox)
     error: "error",
-    wmtsCopy: "wmts-copy",
+    wmtsCopy: "layer-download__information--wmts",
+    wmtsText: "layer-download__wmts-text",
+    copyIcon: "layer-download__copy-icon",
+    // Progress bar (created in initializeDownloadPanel)
+    progressContainer: "download-panel__progress-container",
+    progressBar: "download-panel__progress-bar",
+    progressBarNoData: "download-panel__progress-bar--no-data",
   };
 
   /**
@@ -60,30 +81,6 @@ define([
        * @type {string}
        */
       className: "download-panel",
-
-      /**
-       * Class to use for the buttons
-       * @type {string}
-       */
-      buttonClass: "draw__button ",
-
-      /**
-       * Class to use for the active button
-       * @type {string}
-       */
-      buttonClassActive: "draw__button--active",
-
-      /**
-       * Class to disable button
-       * @type {string}
-       */
-      buttonClassDisable: "draw__button--disable",
-
-      /**
-       * The HTML classes to use for this data panel element
-       * @type {string}
-       */
-      dataPanelClass: "download-panel",
 
       /**
        * The maximum size of the download in bytes. If download is estimated to exceed
@@ -224,9 +221,9 @@ define([
        * @type {object}
        */
       fileSizes: {
-        tif: 525312,  // ~513 KiB per tile
-        png: 2765,    // ~2.7 KiB per tile
-        wmts: 15360,  // ~15 KiB per tile
+        tif: 525312, // ~513 KiB per tile
+        png: 2765, // ~2.7 KiB per tile
+        wmts: 15360, // ~15 KiB per tile
         gpkg: 184320, // ~180 KiB per tile
       },
 
@@ -236,16 +233,6 @@ define([
        * @type {Array}
        */
       dataDownloadLinks: {},
-
-      /**
-       * The classes of the sub-elements that combined to create the download
-       * panel view.
-       */
-      classes: {
-        toolbarLink: ".toolbar__links",
-        toolbarLinkActive: "toolbar__link--active",
-        toolbarContentActive: "toolbar__content--active",
-      },
 
       /**
        * The z levels available for download along with their approximate pixel
@@ -399,10 +386,10 @@ define([
         this.clearPoints();
         this.removeClickListeners();
 
-        document.querySelector(".download-data-list__panel").textContent =
+        this.el.querySelector(`.${CLASS_NAMES.instructions}`).textContent =
           "Draw Area of Interest: Single-click to add vertices, double-click to complete.";
 
-        document.querySelector(".download-data-list").innerHTML = "";
+        this.el.querySelector(`.${CLASS_NAMES.dataList}`).innerHTML = "";
         this.setButtonStatuses({
           draw: "enabled",
           clear: "deactivated",
@@ -646,19 +633,18 @@ define([
        * Create and insert the buttons for drawing and clearing the polygon.
        */
       renderToolbar() {
-        // alert("Rendering draw toolbar");
         const view = this;
-        const drawContainer = this.el.querySelector(".draw-tool");
+        const drawContainer = this.el.querySelector(`.${CLASS_NAMES.drawTool}`);
         if (!drawContainer) return;
         // Create the buttons
         view.buttons.forEach((options) => {
           const button = document.createElement("button");
-          button.className = this.buttonClass;
+          button.className = CLASS_NAMES.button;
           button.innerHTML = `
-              <span class="custom-circle">
+              <span class="${CLASS_NAMES.buttonIconWrap}">
                 <i class="icon icon-${options.icon}"></i>
               </span> 
-              <span class="draw-button-label">${options.label}</span> `;
+              <span class="${CLASS_NAMES.buttonLabel}">${options.label}</span> `;
           button.dataset.name = options.name;
           if (!view.buttonEls) view.buttonEls = {};
           view.buttonEls[`${options.name}Button`] = button;
@@ -674,7 +660,7 @@ define([
 
         view.generatePreviewPanel();
         const closeDownloadPanelButton = this.el.querySelector(
-          ".download-panel-close__button",
+          `.${CLASS_NAMES.closeButton}`,
         );
         closeDownloadPanelButton.addEventListener("click", () => {
           view.close();
@@ -796,7 +782,9 @@ define([
             index === self.findIndex((l) => l.layerID === layer.layerID),
         );
         // Create download tool panel
-        const downloadDataPanel = document.querySelector(".download-data-list");
+        const downloadDataPanel = this.el.querySelector(
+          `.${CLASS_NAMES.dataList}`,
+        );
 
         if (!downloadDataPanel) return;
 
@@ -818,7 +806,7 @@ define([
 
         if (!selectedLayersList.length) {
           // Update the text of download-data-list__panel
-          document.querySelector(".download-data-list__panel").textContent =
+          this.el.querySelector(`.${CLASS_NAMES.instructions}`).textContent =
             "No layers are available for download. Click on layers in the list above to make them visible on the Map and available for download. Only select layers have data products available for download.";
           view.setButtonStatuses({
             save: "deactivated",
@@ -840,21 +828,21 @@ define([
             view.layerDownloadViews.push(layerDownloadView);
           });
           // Update the text of download-data-list__panel
-          document.querySelector(".download-data-list__panel").textContent =
+          this.el.querySelector(`.${CLASS_NAMES.instructions}`).textContent =
             "Select products below and click the download button. To download full datasets (including original shapefiles) please use the Layers panel above. ";
 
           // Progress Bar
-          const dataListPanel = document.querySelector(
-            ".download-data-list__panel",
+          const dataListPanel = this.el.querySelector(
+            `.${CLASS_NAMES.instructions}`,
           );
           // Create the download status bar container
           const downloadStatusContainer = document.createElement("div");
-          downloadStatusContainer.classList.add("download-status-container");
+          downloadStatusContainer.classList.add(CLASS_NAMES.progressContainer);
           downloadStatusContainer.style.display = "none"; // Hidden by default
 
           // Create the progress bar element
           const progressBar = document.createElement("div");
-          progressBar.classList.add("progress-bar");
+          progressBar.classList.add(CLASS_NAMES.progressBar);
           progressBar.style.width = "0%"; // Initial width
           progressBar.textContent = "0%"; // Initial text
 
@@ -956,33 +944,40 @@ define([
         const view = this;
         if (fileType === "wmts") {
           fileSizeInfoBox.innerHTML = `
-            <span id="fileSizeText">${fileSizeDetails}</span>
-            <i id="copyWMTS" class="icon-copy" title="Copy to Clipboard"></i>
+            <span class="${CLASS_NAMES.wmtsText}">${fileSizeDetails}</span>
+            <i class="${CLASS_NAMES.copyIcon} icon-copy" title="Copy to Clipboard"></i>
           `;
           fileSizeInfoBox.classList.add(CLASS_NAMES.wmtsCopy);
 
-          // Add event listener for copying
-          document.getElementById("copyWMTS").addEventListener("click", () => {
-            const textToCopy =
-              document.getElementById("fileSizeText").textContent;
+          // Keep direct references so closures below are scoped to this exact
+          // render — not to fileSizeInfoBox.innerHTML which may be replaced.
+          const wmtsText = fileSizeInfoBox.querySelector(
+            `.${CLASS_NAMES.wmtsText}`,
+          );
+          const copyIcon = fileSizeInfoBox.querySelector(
+            `.${CLASS_NAMES.copyIcon}`,
+          );
+
+          // Use .onclick (not addEventListener) so re-calling updateTextbox for
+          // the same box replaces rather than stacks the handler.
+          copyIcon.onclick = () => {
             navigator.clipboard
-              .writeText(textToCopy)
+              .writeText(wmtsText.textContent)
               .then(() => {
-                const currentContent = fileSizeInfoBox.innerHTML;
-                // alert("Copied to clipboard!");
-                fileSizeInfoBox.innerHTML = "Copied to clipboard!";
+                const original = wmtsText.textContent;
+                wmtsText.textContent = "Copied to clipboard!";
                 setTimeout(() => {
-                  fileSizeInfoBox.innerHTML = currentContent;
-                }, 2000); // Reset after 2 seconds
+                  wmtsText.textContent = original;
+                }, 2000);
               })
               .catch(() => {
-                const currentContent = fileSizeInfoBox.innerHTML;
-                fileSizeInfoBox.innerHTML = "Copy failed!";
+                const original = wmtsText.textContent;
+                wmtsText.textContent = "Copy failed!";
                 setTimeout(() => {
-                  fileSizeInfoBox.innerHTML = currentContent;
-                }, 2000); // Reset after 2 seconds
+                  wmtsText.textContent = original;
+                }, 2000);
               });
-          });
+          };
         } else {
           const optionalComment =
             "Use WMTS for accessing large data volume or re-draw AOI.";
@@ -1431,11 +1426,11 @@ define([
         }
 
         if (error) {
-          progressBar.classList.remove("progress-bar");
-          progressBar.classList.add("progress-bar-no-data");
+          progressBar.classList.remove(CLASS_NAMES.progressBar);
+          progressBar.classList.add(CLASS_NAMES.progressBarNoData);
         } else {
-          progressBar.classList.remove("progress-bar-no-data");
-          progressBar.classList.add("progress-bar");
+          progressBar.classList.remove(CLASS_NAMES.progressBarNoData);
+          progressBar.classList.add(CLASS_NAMES.progressBar);
         }
 
         if (typeof progress === "number") {
@@ -1445,8 +1440,8 @@ define([
           } else {
             progressBar.textContent = "";
           }
-          progressBar.classList.remove("progress-bar-no-data");
-          progressBar.classList.add("progress-bar");
+          progressBar.classList.remove(CLASS_NAMES.progressBarNoData);
+          progressBar.classList.add(CLASS_NAMES.progressBar);
         } else {
           progressBar.style.width = "100%";
         }

--- a/src/js/views/maps/DownloadPanelView.js
+++ b/src/js/views/maps/DownloadPanelView.js
@@ -27,6 +27,10 @@ define([
     button: "draw-tool__button",
     buttonFocus: "draw-tool__button--active",
     buttonDisable: "draw-tool__button--disable",
+    // Draw toolbar button internals
+    buttonIconWrap: "draw-tool__button-icon-wrap",
+    buttonIconWrapDisabled: "draw-tool__button-icon-wrap--disabled",
+    buttonLabel: "draw-tool__button-label",
     // Header elements
     header: "download-panel__header",
     titleGroup: "download-panel__title-group",
@@ -40,9 +44,6 @@ define([
     toolbarLink: "toolbar__links",
     toolbarLinkActive: "toolbar__link--active",
     toolbarContentActive: "toolbar__content--active",
-    // Draw toolbar button internals
-    buttonIconWrap: "draw-tool__button-icon-wrap",
-    buttonLabel: "draw-tool__button-label",
     // Info box states (used in updateTextbox)
     error: "error",
     wmtsCopy: "layer-download__information--wmts",
@@ -512,14 +513,23 @@ define([
       setButtonStatus(name, status) {
         const buttonEl = this.buttonEls[`${name}Button`];
         if (!buttonEl || buttonEl.dataset.status === status) return;
+        const iconWrapEl = buttonEl.querySelector(
+          `.${CLASS_NAMES.buttonIconWrap}`,
+        );
 
         // Reset all button styles - default to enabled
         buttonEl.classList.remove(CLASS_NAMES.buttonFocus);
         buttonEl.classList.remove(CLASS_NAMES.buttonDisable);
+        if (iconWrapEl) {
+          iconWrapEl.classList.remove(CLASS_NAMES.buttonIconWrapDisabled);
+        }
         buttonEl.dataset.status = status;
 
         if (status === "deactivated") {
           buttonEl.classList.add(CLASS_NAMES.buttonDisable);
+          if (iconWrapEl) {
+            iconWrapEl.classList.add(CLASS_NAMES.buttonIconWrapDisabled);
+          }
         } else if (status === "focused") {
           buttonEl.classList.add(CLASS_NAMES.buttonFocus);
         }

--- a/src/js/views/maps/DownloadPanelView.js
+++ b/src/js/views/maps/DownloadPanelView.js
@@ -33,7 +33,7 @@ define([
     title: "download-panel__title",
     closeButton: "download-panel__close-button",
     // Data list elements (referenced by querySelector)
-    dataList: "download-data-list",
+    dataList: "download-panel__data-list",
     instructions: "download-panel__instructions",
     drawTool: "draw-tool",
     // Shared toolbar classes (used for coordinating with ToolbarView)
@@ -805,7 +805,7 @@ define([
         });
 
         if (!selectedLayersList.length) {
-          // Update the text of download-data-list__panel
+          // Update the text of download-panel__instructions
           this.el.querySelector(`.${CLASS_NAMES.instructions}`).textContent =
             "No layers are available for download. Click on layers in the list above to make them visible on the Map and available for download. Only select layers have data products available for download.";
           view.setButtonStatuses({
@@ -827,7 +827,7 @@ define([
 
             view.layerDownloadViews.push(layerDownloadView);
           });
-          // Update the text of download-data-list__panel
+          // Update the text of download-panel__instructions
           this.el.querySelector(`.${CLASS_NAMES.instructions}`).textContent =
             "Select products below and click the download button. To download full datasets (including original shapefiles) please use the Layers panel above. ";
 

--- a/src/js/views/maps/LayerDownloadView.js
+++ b/src/js/views/maps/LayerDownloadView.js
@@ -9,13 +9,15 @@ define(["underscore", "backbone"], (_, Backbone) => {
     checkbox: `${BASE_CLASS}__checkbox`,
     title: `${BASE_CLASS}__title`,
     content: `${BASE_CLASS}__content`,
-
-    dropdown: "downloads-dropdown",
-    resolutionDropdown: "resolution-dropdown",
-    fileTypeDropdown: "fileType-downloads-dropdown",
-    dropdownWrapper: "downloads-dropdown-wrapper",
-    dropdownContainer: "downloads-dropdown-container",
-    fileSizeBox: "downloads-textbox",
+    dropdown: `${BASE_CLASS}__dropdown`,
+    resolutionDropdown: `${BASE_CLASS}__dropdown--resolution`,
+    fileTypeDropdown: `${BASE_CLASS}__dropdown--file-type`,
+    dropdownWrapper: `${BASE_CLASS}__dropdown-wrapper`,
+    dropdownContainer: `${BASE_CLASS}__dropdown-container`,
+    informationBox: `${BASE_CLASS}__information`,
+    informationBoxWarning: `${BASE_CLASS}__information--warning`,
+    informationBoxWmts: `${BASE_CLASS}__information--wmts`,
+    error: "error",
   };
 
   /**
@@ -98,8 +100,11 @@ define(["underscore", "backbone"], (_, Backbone) => {
         if (this.fileSizeInfoBox) {
           this.fileSizeInfoBox.textContent =
             "Select resolution and file format to download...";
-          this.fileSizeInfoBox.classList.remove("error", "wmts-copy");
-          this.fileSizeInfoBox.classList.add("downloads-textbox--warning");
+          this.fileSizeInfoBox.classList.remove(
+            CLASS_NAMES.error,
+            CLASS_NAMES.informationBoxWmts,
+          );
+          this.fileSizeInfoBox.classList.add(CLASS_NAMES.informationBoxWarning);
         }
       },
 
@@ -229,8 +234,8 @@ define(["underscore", "backbone"], (_, Backbone) => {
 
         const fileSizeInfoBox = document.createElement("span");
         fileSizeInfoBox.classList.add(
-          CLASS_NAMES.fileSizeBox,
-          "downloads-textbox--warning",
+          CLASS_NAMES.informationBox,
+          CLASS_NAMES.informationBoxWarning,
         );
         fileSizeInfoBox.textContent =
           "Select resolution and file format to download...";
@@ -270,15 +275,18 @@ define(["underscore", "backbone"], (_, Backbone) => {
           delete downloadPanelView.dataDownloadLinks[item.layerID];
 
           fileSizeInfoBox.textContent = "Select file format to download...";
-          fileSizeInfoBox.classList.add("downloads-textbox--warning");
-          fileSizeInfoBox.classList.remove("error", "wmts-copy");
+          fileSizeInfoBox.classList.add(CLASS_NAMES.informationBoxWarning);
+          fileSizeInfoBox.classList.remove(
+            CLASS_NAMES.error,
+            CLASS_NAMES.informationBoxWmts,
+          );
           downloadPanelView.layerSelection();
         });
 
         // File-type change: recalculate file size and notify parent
         fileTypeDropdown.addEventListener("change", () => {
           view.selectedFileType = fileTypeDropdown.value;
-          fileSizeInfoBox.classList.remove("downloads-textbox--warning");
+          fileSizeInfoBox.classList.remove(CLASS_NAMES.informationBoxWarning);
           downloadPanelView.fileTypeSelection(item.layerID);
           const fileSize = downloadPanelView.getRawFileSize(
             resolutionDropdown.value,

--- a/src/js/views/maps/LayerDownloadView.js
+++ b/src/js/views/maps/LayerDownloadView.js
@@ -9,10 +9,12 @@ define(["underscore", "backbone"], (_, Backbone) => {
     checkbox: `${BASE_CLASS}__checkbox`,
     title: `${BASE_CLASS}__title`,
     content: `${BASE_CLASS}__content`,
+    contentVisible: `${BASE_CLASS}__content--visible`,
     dropdown: `${BASE_CLASS}__dropdown`,
     resolutionDropdown: `${BASE_CLASS}__dropdown--resolution`,
     fileTypeDropdown: `${BASE_CLASS}__dropdown--file-type`,
     dropdownWrapper: `${BASE_CLASS}__dropdown-wrapper`,
+    dropdownLabel: `${BASE_CLASS}__dropdown-label`,
     dropdownContainer: `${BASE_CLASS}__dropdown-container`,
     informationBox: `${BASE_CLASS}__information`,
     informationBoxWarning: `${BASE_CLASS}__information--warning`,
@@ -68,17 +70,20 @@ define(["underscore", "backbone"], (_, Backbone) => {
 
       /** @returns {boolean} Whether the content section is currently visible. */
       isExpanded() {
-        return this.$el.hasClass("show-content");
+        return (
+          this.contentEl?.classList.contains(CLASS_NAMES.contentVisible) ??
+          false
+        );
       },
 
       /** Show the content section without changing the checkbox state. */
       expand() {
-        this.$el.addClass("show-content");
+        this.contentEl?.classList.add(CLASS_NAMES.contentVisible);
       },
 
       /** Hide the content section without changing the checkbox state. */
       collapse() {
-        this.$el.removeClass("show-content");
+        this.contentEl?.classList.remove(CLASS_NAMES.contentVisible);
       },
 
       /**
@@ -156,6 +161,7 @@ define(["underscore", "backbone"], (_, Backbone) => {
 
         const resolutionDropdownId = `resolution-dropdown-${item.layerID}`;
         const resolutionLabel = document.createElement("label");
+        resolutionLabel.classList.add(CLASS_NAMES.dropdownLabel);
         resolutionLabel.textContent =
           downloadPanelView.dropdownOptions.resolution.label;
         resolutionLabel.htmlFor = resolutionDropdownId;
@@ -195,6 +201,7 @@ define(["underscore", "backbone"], (_, Backbone) => {
 
         const fileTypeDropdownId = `fileType-dropdown-${item.layerID}`;
         const fileTypeLabel = document.createElement("label");
+        fileTypeLabel.classList.add(CLASS_NAMES.dropdownLabel);
         fileTypeLabel.textContent =
           downloadPanelView.dropdownOptions.fileType.label;
         fileTypeLabel.htmlFor = fileTypeDropdownId;
@@ -245,6 +252,7 @@ define(["underscore", "backbone"], (_, Backbone) => {
         content.appendChild(fileSizeInfoBox);
 
         // ── Assemble ──────────────────────────────────────────────────────────
+        this.contentEl = content;
         this.el.appendChild(header);
         this.el.appendChild(content);
 

--- a/src/js/views/maps/ToolbarView.js
+++ b/src/js/views/maps/ToolbarView.js
@@ -96,6 +96,7 @@ define([
         linkActive: "toolbar__link--active",
         content: "toolbar__content",
         contentActive: "toolbar__content--active",
+        contentDownload: "toolbar__content--download",
       },
 
       /**
@@ -469,6 +470,11 @@ define([
         const contentContainer = document.createElement("div");
         // Add the class that identifies a toolbar section's content
         contentContainer.classList.add(this.classes.content);
+        // If this section uses the DownloadPanelView, mark it so CSS can give it
+        // shrink-wrap flex sizing without relying on the :has() selector.
+        if (sectionOption.view === DownloadPanelView) {
+          contentContainer.classList.add(this.classes.contentDownload);
+        }
         // Render the toolbar section view
         // Merge the icon and label with the other section options
         const viewOptions = {


### PR DESCRIPTION
## What:
This PR aims to resolve #2662 by implementing BEM style css classes for all of the CSS used in DownloadPanelView and LayerDownloadView and reusing existing classes where possible.

## Why:
For clearer code, better maintainability, and integration with the portal theming styles.

## How:

- Removed the .classes attribute from DownloadPanelView and move all values into the CLASS_NAMES constant
- Searched for hardcoded selectors and classes in DownloadPanelView and LayerDownloadView and move them into CLASS_NAMES constants in each file
- Renamed DownloadPanelView and LayerDownloadView classes to fall under download-panel, layer-download, or draw-tool Blocks in BEM style
- Deleted or consolidated redundant styles 
- Used theme's --portal-col-* variables for border, background, and color properties, only using --map-col-*__deprecate as fallbacks where necessary
- Extended the light portal theme with a new --portal-col-warning variable used by warning-state styling.
- Updated color values so draw-tool buttons were discernibly disabled and dropdowns and progress bar were legible on the dark theme
- Added download-panel to the flex flow of the navbar so that it expanded and collapsed without blocking the layer dropdowns by adding a .toolbar__content--download class and updating ToolbarView.js to apply it to the DownloadPanelView
- Increased the max-height of the data-list by 50px so more LayerDownloadViews could be seen simultaneously without scrolling
- Added non variable color fallbacks for the copy icon and draw tool buttons and use opacity to disambiguate disabled buttons regardless of color


Here is a tabular representation (Claude 4.6 put toghether) of the BEM structure Blocks, Elements, and Modifiers I've created from the classes in both views (note there was a lot of renaming involved so this may be meaningless without looking at the diff if you're used to the old names):

---

### Block: `download-panel`
The shell rendered by `DownloadPanelView` and its template.

| Class | Role |
|---|---|
| `download-panel` | Block — the view's root `el` |
| `download-panel__header` | Element — top bar containing title and close button |
| `download-panel__title-group` | Element — icon + heading grouping inside the header |
| `download-panel__title` | Element — the `<h3>` heading |
| `download-panel__icon` | Element — the `<i>` icon in the title group (template only) |
| `download-panel__close-button` | Element — the × button |
| `download-panel__instructions` | Element — text area above the layer list |
| `download-panel__data-list` | Element — container that holds `layer-download` rows |
| `download-panel__progress-container` | Element — wrapper for the progress bar |
| `download-panel__progress-bar` | Element — the progress fill bar |
| `download-panel__progress-bar--no-data` | Modifier on `progress-bar` — error/no-data state |

---

### Block: `layer-download`
Each row rendered by `LayerDownloadView`. Some classes in this block are read/written by `DownloadPanelView` via `updateTextbox()`.

| Class | Role |
|---|---|
| `layer-download` | Block — the view's root `el` |
| `layer-download__header` | Element — checkbox + title row |
| `layer-download__checkbox` | Element — the `<input type="checkbox">` |
| `layer-download__title` | Element — layer name text |
| `layer-download__content` | Element — collapsible area with dropdowns |
| `layer-download__content--visible` | Modifier on `content` — expanded/visible state (toggled on `content` element directly, not on the block root) |
| `layer-download__dropdown-container` | Element — flex row holding both dropdown wrappers |
| `layer-download__dropdown-wrapper` | Element — label + select pairing (used twice) |
| `layer-download__dropdown-label` | Element — the `<label>` inside each dropdown wrapper |
| `layer-download__dropdown` | Element — base class on both `<select>` elements |
| `layer-download__dropdown--resolution` | Modifier — resolution select |
| `layer-download__dropdown--file-type` | Modifier — file-type select |
| `layer-download__information` | Element — the file-size/status info box |
| `layer-download__information--warning` | Modifier — incomplete selection state (orange text) |
| `layer-download__information--wmts` | Modifier — WMTS state (styled card with copy icon) |
| `layer-download__wmts-text` | Element — the text `<span>` inside the WMTS card |
| `layer-download__copy-icon` | Element — the clipboard copy `<i>` icon inside the WMTS card |

---

### Block: `draw-tool`
The toolbar rendered inside `download-panel` by `renderToolbar()`.

| Class | Role |
|---|---|
| `draw-tool` | Block — the toolbar container |
| `draw-tool__button` | Element — each toolbar button |
| `draw-tool__button--active` | Modifier — focused/active button state |
| `draw-tool__button--disable` | Modifier — deactivated button state |
| `draw-tool__button-icon-wrap` | Element — `<span>` wrapping the icon circle inside a button |
| `draw-tool__button-icon-wrap--disabled` | Modifier — dimmed/muted icon circle when button is deactivated (toggled in JS alongside `button--disable`) |
| `draw-tool__button-label` | Element — `<span>` wrapping the tooltip text label (shown on hover) |

---

### Utility / cross-cutting

| Class | Source | Notes |
|---|---|---|
| `map-view__button` | shared | Applied alongside `download-panel__close-button`; shared button styles live in a separate block |
| `error` | global utility | Applied to `layer-download__information` for the oversized-download state |
| `toolbar__links`, `toolbar__link--active`, `toolbar__content--active` | toolbar block | External coordination classes set by `ToolbarView` |
| `toolbar__content--download` | toolbar block | Applied by `ToolbarView.renderSectionContent()` to the `toolbar__content` wrapper that holds the download panel; gives it `flex: 0 0 auto` sizing without requiring `:has()` |


## Testing and Documentation
As far as I can tell, this is functioning in the same way as the previous styling implementation, and I added some sectional comments to `map-view.css` to indicate the Block level distinctions. 
I tested the Download Panel's functionality in the following portal configurations:

- [x] Light theme + panels layout (e.g. PDG)
- [x] Dark theme + panels layout
- [x] No theme + panels layout
- [x] Light theme + default layout (led to the documentation of #2820 as styling changes highlighted a preexisting issue with the default layout across light, dark, and null themes)
- [x] Dark theme + default layout (#2820)
- [x] No theme + default layout (#2820)
- [ ] All the above in different repositories, especially DataONE and KNB (Where can I actually see the download panel if I'm using theme: "knb" or theme: "dataone" in my config.js?)