### PR TITLE
Feature 2663 use Backbone events() in DownloadPanelView and LayerDownloadView

### DIFF
--- a/src/js/views/maps/DownloadPanelView.js
+++ b/src/js/views/maps/DownloadPanelView.js
@@ -142,6 +142,8 @@ define([
         const events = {};
         const CN = CLASS_NAMES;
         events[`click .${CN.button}`] = "handleButtonClick";
+        events[`click .${CN.closeButton}`] = "close";
+        events[`click .${CN.copyIcon}`] = "handleCopyIconClick";
         return events;
       },
 
@@ -468,6 +470,35 @@ define([
       },
 
       /**
+       * Handles a click on the copy icon in the WMTS info box. Copies the WMTS
+       * URL text to the clipboard and briefly shows a confirmation message.
+       * Because this handler is registered via the delegated events hash, it
+       * replaces the previous `.onclick` assignment and never stacks.
+       * @param {Event} event - The click event.
+       */
+      handleCopyIconClick(event) {
+        const infoBox = event.currentTarget.closest(`.${CLASS_NAMES.wmtsCopy}`);
+        if (!infoBox) return;
+        const wmtsText = infoBox.querySelector(`.${CLASS_NAMES.wmtsText}`);
+        if (!wmtsText) return;
+        const text = wmtsText.textContent;
+        navigator.clipboard
+          .writeText(text)
+          .then(() => {
+            wmtsText.textContent = "Copied to clipboard!";
+            setTimeout(() => {
+              wmtsText.textContent = text;
+            }, 2000);
+          })
+          .catch(() => {
+            wmtsText.textContent = "Copy failed!";
+            setTimeout(() => {
+              wmtsText.textContent = text;
+            }, 2000);
+          });
+      },
+
+      /**
        * Toggles the draw tool on and off.
        * @param {boolean} [draw] - If true, the draw tool will be turned on. If
        * false, it will be turned off. If not provided, the draw tool will
@@ -672,12 +703,6 @@ define([
         });
 
         view.generatePreviewPanel();
-        const closeDownloadPanelButton = this.el.querySelector(
-          `.${CLASS_NAMES.closeButton}`,
-        );
-        closeDownloadPanelButton.addEventListener("click", () => {
-          view.close();
-        });
       },
 
       /**
@@ -954,50 +979,17 @@ define([
         if (!fileSizeInfoBox) return;
         fileSizeInfoBox.classList.remove(CLASS_NAMES.error);
         fileSizeInfoBox.classList.remove(CLASS_NAMES.wmtsCopy);
-        const view = this;
         if (fileType === "wmts") {
           fileSizeInfoBox.innerHTML = `
             <span class="${CLASS_NAMES.wmtsText}">${fileSizeDetails}</span>
             <i class="${CLASS_NAMES.copyIcon} icon-copy" title="Copy to Clipboard"></i>
           `;
           fileSizeInfoBox.classList.add(CLASS_NAMES.wmtsCopy);
-
-          // Keep direct references so closures below are scoped to this exact
-          // render — not to fileSizeInfoBox.innerHTML which may be replaced.
-          const wmtsText = fileSizeInfoBox.querySelector(
-            `.${CLASS_NAMES.wmtsText}`,
-          );
-          const copyIcon = fileSizeInfoBox.querySelector(
-            `.${CLASS_NAMES.copyIcon}`,
-          );
-
-          if (!wmtsText || !copyIcon) return;
-
-          // Use .onclick (not addEventListener) so re-calling updateTextbox for
-          // the same box replaces rather than stacks the handler.
-          copyIcon.onclick = () => {
-            navigator.clipboard
-              .writeText(wmtsText.textContent)
-              .then(() => {
-                const original = wmtsText.textContent;
-                wmtsText.textContent = "Copied to clipboard!";
-                setTimeout(() => {
-                  wmtsText.textContent = original;
-                }, 2000);
-              })
-              .catch(() => {
-                const original = wmtsText.textContent;
-                wmtsText.textContent = "Copy failed!";
-                setTimeout(() => {
-                  wmtsText.textContent = original;
-                }, 2000);
-              });
-          };
         } else {
           const optionalComment =
             "Use WMTS for accessing large data volume or re-draw AOI.";
-          const maxSize = Utilities.bytesToSize(view.downloadSizeLimit, 2);
-          if (fileSizeDetails > view.downloadSizeLimit) {
+          const maxSize = Utilities.bytesToSize(this.downloadSizeLimit, 2);
+          if (fileSizeDetails > this.downloadSizeLimit) {
             fileSizeInfoBox.textContent = `Download size is too big ( > ${maxSize}). ${optionalComment}.`;
             fileSizeInfoBox.classList.add(CLASS_NAMES.error);
           } else {
@@ -1008,8 +1000,8 @@ define([
         // Instead of disabling the Download button for large file sizes simply
         // remove the layer from the the download list variable (i.e.,
         // dataDownloadLinks)
-        if (view.dataDownloadLinks[layerID].fileSize > view.downloadSizeLimit) {
-          delete view.dataDownloadLinks[layerID];
+        if (this.dataDownloadLinks[layerID].fileSize > this.downloadSizeLimit) {
+          delete this.dataDownloadLinks[layerID];
         }
       },
 

--- a/src/js/views/maps/LayerDownloadView.js
+++ b/src/js/views/maps/LayerDownloadView.js
@@ -50,6 +50,16 @@ define(["underscore", "backbone"], (_, Backbone) => {
        */
       className: BASE_CLASS,
 
+      /** @inheritdoc */
+      events() {
+        const CN = CLASS_NAMES;
+        return {
+          [`change .${CN.checkbox}`]: "handleCheckboxChange",
+          [`change .${CN.resolutionDropdown}`]: "handleResolutionChange",
+          [`change .${CN.fileTypeDropdown}`]: "handleFileTypeChange",
+        };
+      },
+
       /**
        * Initialise the view.
        * @param {object} options - Options for the view.
@@ -114,13 +124,82 @@ define(["underscore", "backbone"], (_, Backbone) => {
       },
 
       /**
+       * Handles changes to the layer checkbox. If checked, selects the layer
+       * and expands the content; if unchecked, deselects, collapses, and resets
+       * the dropdowns.
+       */
+      handleCheckboxChange() {
+        if (this.checkbox.checked) {
+          this.isSelected = true;
+          this.expand();
+        } else {
+          this.isSelected = false;
+          this.collapse();
+          this.resetDropdowns();
+        }
+        this.downloadPanelView.layerSelection();
+      },
+
+      /**
+       * Handles changes to the resolution dropdown. Enables the file-type
+       * dropdown, clears the file-type selection, removes stale download links,
+       * and updates the info box and save-button state.
+       */
+      handleResolutionChange() {
+        this.selectedResolution = this.resolutionDropdown.value;
+        this.fileTypeDropdown.disabled = false;
+        this.fileTypeDropdown.value =
+          this.downloadPanelView.dropdownOptions.fileType.defaultValue;
+        this.selectedFileType = "";
+        delete this.downloadPanelView.dataDownloadLinks[this.item.layerID];
+        this.fileSizeInfoBox.textContent = "Select file format to download...";
+        this.fileSizeInfoBox.classList.add(CLASS_NAMES.informationBoxWarning);
+        this.fileSizeInfoBox.classList.remove(
+          CLASS_NAMES.error,
+          CLASS_NAMES.informationBoxWmts,
+        );
+        this.downloadPanelView.layerSelection();
+      },
+
+      /**
+       * Handles changes to the file-type dropdown. Calculates the estimated
+       * file size and updates the info box and save-button state.
+       */
+      handleFileTypeChange() {
+        const { item, downloadPanelView } = this;
+        this.selectedFileType = this.fileTypeDropdown.value;
+        this.fileSizeInfoBox.classList.remove(
+          CLASS_NAMES.informationBoxWarning,
+        );
+        downloadPanelView.fileTypeSelection(item.layerID);
+        const fileSize = downloadPanelView.getRawFileSize(
+          this.resolutionDropdown.value,
+          this.fileTypeDropdown.value,
+          item.layerID,
+          item.fullDownloadLink,
+          item.pngDownloadLink,
+          item.gpkgDownloadLink,
+          item.ID,
+          item.layerName,
+          item.wmtsDownloadLink,
+          item.metadataPid,
+          item.tiffDownloadLink,
+        );
+        downloadPanelView.updateTextbox(
+          this.fileSizeInfoBox,
+          fileSize,
+          this.fileTypeDropdown.value,
+          item.layerID,
+        );
+      },
+
+      /**
        * Render the complete panel: a header row with [checkbox] [title] [caret]
        * and a collapsible content section with the download controls.
        * @returns {LayerDownloadView} this
        */
       render() {
         this.$el.empty();
-        const view = this;
         const { item, downloadPanelView } = this;
 
         // ── Header row ────────────────────────────────────────────────────────
@@ -255,67 +334,6 @@ define(["underscore", "backbone"], (_, Backbone) => {
         this.contentEl = content;
         this.el.appendChild(header);
         this.el.appendChild(content);
-
-        // ── Event listeners ───────────────────────────────────────────────────
-
-        // Checking the checkbox selects the layer and expands the content;
-        // unchecking deselects, collapses, and resets the dropdowns.
-        checkbox.addEventListener("change", () => {
-          if (checkbox.checked) {
-            view.isSelected = true;
-            view.expand();
-          } else {
-            view.isSelected = false;
-            view.collapse();
-            view.resetDropdowns();
-          }
-          downloadPanelView.layerSelection();
-        });
-
-        // Resolution change: enable file-type dropdown, clear its value,
-        // delete stale download links, update hint, recalculate button state
-        resolutionDropdown.addEventListener("change", () => {
-          view.selectedResolution = resolutionDropdown.value;
-          fileTypeDropdown.disabled = false;
-          fileTypeDropdown.value = defaultFileTypeOption.value;
-          view.selectedFileType = "";
-
-          delete downloadPanelView.dataDownloadLinks[item.layerID];
-
-          fileSizeInfoBox.textContent = "Select file format to download...";
-          fileSizeInfoBox.classList.add(CLASS_NAMES.informationBoxWarning);
-          fileSizeInfoBox.classList.remove(
-            CLASS_NAMES.error,
-            CLASS_NAMES.informationBoxWmts,
-          );
-          downloadPanelView.layerSelection();
-        });
-
-        // File-type change: recalculate file size and notify parent
-        fileTypeDropdown.addEventListener("change", () => {
-          view.selectedFileType = fileTypeDropdown.value;
-          fileSizeInfoBox.classList.remove(CLASS_NAMES.informationBoxWarning);
-          downloadPanelView.fileTypeSelection(item.layerID);
-          const fileSize = downloadPanelView.getRawFileSize(
-            resolutionDropdown.value,
-            fileTypeDropdown.value,
-            item.layerID,
-            item.fullDownloadLink,
-            item.pngDownloadLink,
-            item.gpkgDownloadLink,
-            item.ID,
-            item.layerName,
-            item.wmtsDownloadLink,
-            item.metadataPid,
-            item.tiffDownloadLink,
-          );
-          downloadPanelView.updateTextbox(
-            fileSizeInfoBox,
-            fileSize,
-            fileTypeDropdown.value,
-            item.layerID,
-          );
-        });
 
         return this;
       },


### PR DESCRIPTION
## Notice: ☝️
**This feature branches from work proposed in #2818. Please review and merge those changes prior to evaluating this one, or point the PR at the feature-2662-DownloadPanelView-BEM branch to see the meaningful diff before merging to develop.** 

## What:
The DownloadPanelView and LayerDownloaView used to use addEventListener directly in several places to bind DOM events. While this worked, it’s not the best practice in Backbone apps. Instead, this PR updates them to use [Backbone's built-in event handling events() property](https://backbonejs.org/#View-events) thereby closing #2663.

## Why:
Backbone's delegated events hash (or at minimum this.listenTo) is the idiomatic approach. Manual addEventListener calls are not cleaned up when undelegateEvents() or remove() is called, causing memory/listener leaks if the view is re-rendered.

## How (brought to you by Claude sonnet 4.6):

**DownloadPanelView**

- events() — added two new entries: 
  1. click .download-panel__close-button → "close" 
  2. click .layer-download__copy-icon → "handleCopyIconClick".
- handleCopyIconClick(event) — new method. Uses event.currentTarget.closest(...) to find the WMTS info box and its text node, then writes to the clipboard. Replaces the old per-render .onclick assignment entirely.
- renderToolbar() — removed the querySelector + addEventListener("click", ...) block for the close button. The delegated events() entry handles it now.
- updateTextbox() — removed the post-render DOM queries (wmtsText, copyIcon), the guard if (!wmtsText || !copyIcon) return, and the entire copyIcon.onclick = ... closure. Also removed the now-unused const view = this alias and replaced remaining view. references with this..

**LayerDownloadView**

- events() — new method returning three delegated change entries: 
  1. checkbox → handleCheckboxChange
  2. resolution dropdown → handleResolutionChange
  3. file-type dropdown → handleFileTypeChange.
- extracted three new named handler methods from the old addEventListener closures (handleCheckboxChange(), handleResolutionChange(), handleFileTypeChange()) now using this.* instead of captured local variables.
- render() — removed const view = this, removed the entire // ── Event listeners section and its three addEventListener blocks.

## Testing and Documentation:
All 1303 tests completed and passed and new handlers have comments describing them above.