### PR TITLE
Prevent editing groups before they are completely loaded

### DIFF
--- a/src/js/collections/UserGroup.js
+++ b/src/js/collections/UserGroup.js
@@ -63,6 +63,8 @@ define(["jquery", "underscore", "backbone", "models/UserModel"], function (
           }
         }
 
+        this.fullyLoaded = Boolean(options && options.rawData);
+
         //Add all our models to this collection
         this.add(models);
       },
@@ -75,7 +77,9 @@ define(["jquery", "underscore", "backbone", "models/UserModel"], function (
           this.groupId = "CN=" + this.name + ",DC=dataone,DC=org";
         }
 
-        this.fetch(options);
+        this.fetch(options).done(() => {
+          this.fullyLoaded = true;
+        });
 
         return this;
       },
@@ -177,6 +181,7 @@ define(["jquery", "underscore", "backbone", "models/UserModel"], function (
        */
       save: function (onSuccess, onError) {
         if (this.pending && this.nameAvailable == false) return false;
+        if (!this.pending && !this.fullyLoaded) return false;
 
         var memberXML = "",
           ownerXML = "",

--- a/src/js/views/UserGroupView.js
+++ b/src/js/views/UserGroupView.js
@@ -6,6 +6,7 @@ define([
   "views/GroupListView",
   "text!templates/userGroup.html",
   "text!templates/alert.html",
+  "text!templates/loading.html",
 ], function (
   $,
   _,
@@ -14,6 +15,7 @@ define([
   GroupListView,
   Template,
   AlertTemplate,
+  LoadingTemplate,
 ) {
   "use strict";
 
@@ -38,6 +40,7 @@ define([
 
       template: _.template(Template),
       alertTemplate: _.template(AlertTemplate),
+      loadingTemplate: _.template(LoadingTemplate),
 
       initialize: function (options) {
         if (typeof options == "undefined") var options = {};
@@ -94,16 +97,30 @@ define([
        */
       getGroups: function () {
         var view = this,
-          groups = [],
           model = this.model;
         //Create a group Collection for each group this user is a member of
         _.each(_.sortBy(model.get("isMemberOf"), "name"), function (group) {
-          var userGroup = new UserGroup([model], group);
-          groups.push(userGroup);
+          const userGroup = new UserGroup([model], group);
+          const loading = $(
+            view.loadingTemplate({ msg: "Loading group information..." }),
+          );
+          view.$("#group-list-container").append(loading);
 
-          view.listenTo(userGroup, "sync", function () {
-            var list = this.createGroupList(userGroup);
-            this.$("#group-list-container").append(list);
+          view.listenToOnce(userGroup, "sync", () => {
+            loading.remove();
+            view
+              .$("#group-list-container")
+              .prepend(view.createGroupList(userGroup));
+          });
+          view.listenToOnce(userGroup, "error", () => {
+            loading
+              .removeClass("loading")
+              .addClass("error")
+              .html(
+                $(document.createElement("p")).text(
+                  "Group information could not be loaded. Refresh the page to try again.",
+                ),
+              );
           });
           userGroup.getGroup();
         });

--- a/test/config/tests.json
+++ b/test/config/tests.json
@@ -23,6 +23,7 @@
     "./js/specs/unit/models/notifications/ObjectNotification.spec.js",
     "./js/specs/unit/models/CrossRefModel.spec.js",
     "./js/specs/unit/collections/ProjectList.spec.js",
+    "./js/specs/unit/collections/UserGroup.spec.js",
     "./js/specs/unit/collections/DataPackage.spec.js",
     "./js/specs/unit/collections/DataONEObjects.spec.js",
     "./js/specs/unit/models/project/Project.spec.js",

--- a/test/config/tests.json
+++ b/test/config/tests.json
@@ -118,6 +118,7 @@
     "./js/specs/unit/models/accordion/Accordion.spec.js",
     "./js/specs/unit/models/accordion/AccordionItem.spec.js",
     "./js/specs/unit/views/DataItemView.spec.js",
+    "./js/specs/unit/views/UserGroupView.spec.js",
     "./js/specs/unit/views/uiElements/ToggleView.spec.js",
     "./js/specs/unit/views/notifications/NotificationModalView.spec.js",
     "./js/specs/unit/views/metadata/EML211EditorView.spec.js",

--- a/test/js/specs/unit/collections/UserGroup.spec.js
+++ b/test/js/specs/unit/collections/UserGroup.spec.js
@@ -1,0 +1,87 @@
+define([
+  "jquery",
+  "backbone",
+  "collections/UserGroup",
+  "models/UserModel",
+  "/test/js/specs/shared/clean-state.js",
+], ($, Backbone, UserGroup, UserModel, cleanState) => {
+  "use strict";
+
+  const expect = chai.expect;
+
+  describe("UserGroup", () => {
+    const state = cleanState(() => {
+      const sandbox = sinon.createSandbox();
+      const fetchDeferred = $.Deferred();
+      const fetchRequests = [];
+
+      sandbox
+        .stub(Backbone, "sync")
+        .callsFake((method, _collection, options) => {
+          expect(method).to.equal("read");
+          fetchRequests.push(options);
+          return fetchDeferred.promise();
+        });
+
+      const saveRequests = [];
+      sandbox.stub($, "ajax").callsFake((options) => {
+        saveRequests.push(options);
+        return $.Deferred().promise();
+      });
+
+      return {
+        fetchDeferred,
+        fetchRequests,
+        sandbox,
+        saveRequests,
+      };
+    }, beforeEach);
+
+    afterEach(() => {
+      state.sandbox.restore();
+    });
+
+    it("prevents a partial update until the group finishes loading", async () => {
+      const groupId = "CN=large-group,DC=dataone,DC=org";
+      const group = new UserGroup([new UserModel({ username: "member-000" })], {
+        groupId,
+        name: "Large Group",
+      });
+
+      group.getGroup();
+      group.add(new UserModel({ username: "new-member" }));
+
+      expect(group.save()).to.be.false;
+      expect(state.saveRequests).to.be.empty;
+
+      const memberNodes = Array.from({ length: 263 }, (_, index) => {
+        const username = `member-${String(index).padStart(3, "0")}`;
+        return (
+          `<person><subject>${username}</subject>` +
+          `<givenName>Member</givenName><familyName>${index}</familyName>` +
+          `<isMemberOf>${groupId}</isMemberOf></person>`
+        );
+      }).join("");
+      const response = $.parseXML(
+        `<accounts>${memberNodes}<group><subject>${groupId}</subject>` +
+          "<groupName>Large Group</groupName></group></accounts>",
+      );
+
+      state.fetchRequests[0].success(response);
+      state.fetchDeferred.resolve(response);
+
+      expect(group.save()).to.be.true;
+      expect(state.saveRequests).to.have.length(1);
+      const savedGroupBlob = state.saveRequests[0].data.get("group");
+      const savedGroupXML = await savedGroupBlob.text();
+      const savedMembers = Array.from(
+        $.parseXML(savedGroupXML).querySelectorAll("hasMember"),
+        (member) => member.textContent,
+      );
+
+      expect(savedMembers).to.have.length(264);
+      expect(savedMembers).to.include("member-262");
+      expect(savedMembers).to.include("new-member");
+    });
+  });
+});

--- a/test/js/specs/unit/views/UserGroupView.spec.js
+++ b/test/js/specs/unit/views/UserGroupView.spec.js
@@ -1,0 +1,75 @@
+define([
+  "backbone",
+  "collections/UserGroup",
+  "views/UserGroupView",
+  "/test/js/specs/shared/clean-state.js",
+], (Backbone, UserGroup, UserGroupView, cleanState) => {
+  "use strict";
+
+  const expect = chai.expect;
+
+  describe("UserGroupView", () => {
+    const state = cleanState(() => {
+      const sandbox = sinon.createSandbox();
+      const model = new Backbone.Model({
+        username: "owner",
+        usernameReadable: "owner",
+        isOwnerOf: [],
+        isMemberOf: [{ groupId: "large-group", name: "Large Group" }],
+      });
+      const view = new UserGroupView({ model });
+      view.$el.html('<div id="group-list-container"></div>');
+      const getGroup = sandbox
+        .stub(UserGroup.prototype, "getGroup")
+        .returnsThis();
+
+      return { getGroup, sandbox, view };
+    }, beforeEach);
+
+    afterEach(() => {
+      state.view.remove();
+      state.sandbox.restore();
+    });
+
+    it("shows that group information is loading without edit controls", () => {
+      state.view.getGroups();
+
+      expect(state.view.$("#group-list-container").text()).to.contain(
+        "Loading group information...",
+      );
+      expect(state.view.$("#group-list-container .add-member")).to.have.length(
+        0,
+      );
+      expect(state.view.$("#group-list-container .member-list")).to.have.length(
+        0,
+      );
+    });
+
+    it("replaces the loading message with the group list after loading", () => {
+      state.view.getGroups();
+      state.getGroup.firstCall.thisValue.trigger("sync");
+
+      expect(
+        state.view.$("#group-list-container .notification.loading"),
+      ).to.have.length(0);
+      expect(state.view.$("#group-list-container .member-list")).to.have.length(
+        1,
+      );
+    });
+
+    it("replaces the loading message with a refresh instruction on error", () => {
+      state.view.getGroups();
+      state.getGroup.firstCall.thisValue.trigger("error");
+
+      expect(state.view.$("#group-list-container").text()).to.contain(
+        "Group information could not be loaded. Refresh the page to try again.",
+      );
+      expect(state.view.$("#group-list-container .add-member")).to.have.length(
+        0,
+      );
+      expect(
+        state.view.$("#group-list-container .notification.error"),
+      ).to.have.length(1);
+    });
+  });
+});


### PR DESCRIPTION
The PR makes it so that the GroupView doesn't load until the complete associated group information has synced. This is to prevent users from editing and submitting changes before all group members have loaded, leading to the bug described in #2131. There are now also loading and error messages to indicate that a group is still loading or if there was a problem with the request.