### PR TITLE
Feature 2636 url encode active feature

### DIFF
--- a/src/js/common/SearchParams.js
+++ b/src/js/common/SearchParams.js
@@ -432,7 +432,7 @@ define(["common/UriTemplateUtilities"], (UriTemplateUtilities) => {
    * @param {object} action Viewfinder action object.
    * @param {string} action.id Stable action identifier.
    * @param {string} action.url RFC6570 URL template.
-   * @param {boolean} [showShareUrl=true] Whether to read namespaced browser
+   * @param {boolean} [showShareUrl] Whether to read namespaced browser
    *   state when resolving the template.
    * @returns {string|null} The resolved iframe URL or null when no URL exists.
    * @since 0.0.0

--- a/src/js/common/SearchParams.js
+++ b/src/js/common/SearchParams.js
@@ -178,7 +178,11 @@ define(["common/UriTemplateUtilities"], (UriTemplateUtilities) => {
         : 0;
 
     // Phase 1 fields imply schema 1 writing.
-    if (normalized.activeActionId || normalized.openPanel || normalized.activeFeatureIds.length) {
+    if (
+      normalized.activeActionId ||
+      normalized.openPanel ||
+      normalized.activeFeatureIds.length
+    ) {
       normalized.schemaVersion = Math.max(1, normalized.schemaVersion);
     }
 

--- a/src/js/common/SearchParams.js
+++ b/src/js/common/SearchParams.js
@@ -97,10 +97,23 @@ define(["common/UriTemplateUtilities"], (UriTemplateUtilities) => {
    * @returns {string|null} A normalized ID string, or null if invalid.
    * @since 0.0.0
    */
-  const normalizeId = (value) => {
+  function normalizeId(value) {
     if (typeof value !== "string") return null;
     const trimmed = value.trim();
     return trimmed.length ? trimmed : null;
+  }
+
+  /**
+   * Normalize a list of IDs from array input.
+   * @param {unknown} value Candidate IDs from URL or model state.
+   * @returns {string[]} Normalized non-empty IDs.
+   * @since 0.0.0
+   */
+  const normalizeIdList = (value) => {
+    if (!Array.isArray(value)) return [];
+    return value
+      .map((item) => normalizeId(item))
+      .filter((item) => item != null);
   };
 
   /**
@@ -164,11 +177,7 @@ define(["common/UriTemplateUtilities"], (UriTemplateUtilities) => {
       enabledLayerStateProvided: Boolean(state.enabledLayerStateProvided),
       activeActionId: normalizeId(state.activeActionId),
       openPanel: normalizeId(state.openPanel),
-      activeFeatureIds: parseCommaSeparated(
-        Array.isArray(state.activeFeatureIds)
-          ? state.activeFeatureIds.join(",")
-          : state.activeFeatureIds,
-      ),
+      activeFeatureIds: normalizeIdList(state.activeFeatureIds),
     };
 
     const requestedSchema = Number(state.schemaVersion);
@@ -229,8 +238,8 @@ define(["common/UriTemplateUtilities"], (UriTemplateUtilities) => {
     if (schemaVersion >= 1) {
       base.activeActionId = normalizeId(url.searchParams.get(ACTIVE_ACTION_ID));
       base.openPanel = normalizeId(url.searchParams.get(OPEN_PANEL_ID));
-      base.activeFeatureIds = parseCommaSeparated(
-        url.searchParams.get(ACTIVE_FEATURES_ID),
+      base.activeFeatureIds = normalizeIdList(
+        url.searchParams.getAll(ACTIVE_FEATURES_ID),
       );
     }
 
@@ -283,10 +292,9 @@ define(["common/UriTemplateUtilities"], (UriTemplateUtilities) => {
         url.searchParams.set(OPEN_PANEL_ID, normalized.openPanel);
       }
       if (normalized.activeFeatureIds.length) {
-        url.searchParams.set(
-          ACTIVE_FEATURES_ID,
-          normalized.activeFeatureIds.join(","),
-        );
+        normalized.activeFeatureIds.forEach((featureId) => {
+          url.searchParams.append(ACTIVE_FEATURES_ID, featureId);
+        });
       }
     }
 

--- a/src/js/common/SearchParams.js
+++ b/src/js/common/SearchParams.js
@@ -16,6 +16,7 @@ define(["common/UriTemplateUtilities"], (UriTemplateUtilities) => {
   const SCHEMA_VERSION_ID = "sv";
   const ACTIVE_ACTION_ID = "a";
   const OPEN_PANEL_ID = "op";
+  const ACTIVE_FEATURES_ID = "f";
 
   /** The search parameter ID for enabled layers in the save to URL feature. */
   const ENABLED_LAYERS_ID = "el";
@@ -42,6 +43,7 @@ define(["common/UriTemplateUtilities"], (UriTemplateUtilities) => {
     SCHEMA_VERSION_ID,
     ACTIVE_ACTION_ID,
     OPEN_PANEL_ID,
+    ACTIVE_FEATURES_ID,
     ENABLED_LAYERS_ID,
   ];
 
@@ -57,6 +59,7 @@ define(["common/UriTemplateUtilities"], (UriTemplateUtilities) => {
     enabledLayerStateProvided: false,
     activeActionId: null,
     openPanel: null,
+    activeFeatureIds: [],
   });
 
   /**
@@ -161,6 +164,11 @@ define(["common/UriTemplateUtilities"], (UriTemplateUtilities) => {
       enabledLayerStateProvided: Boolean(state.enabledLayerStateProvided),
       activeActionId: normalizeId(state.activeActionId),
       openPanel: normalizeId(state.openPanel),
+      activeFeatureIds: parseCommaSeparated(
+        Array.isArray(state.activeFeatureIds)
+          ? state.activeFeatureIds.join(",")
+          : state.activeFeatureIds,
+      ),
     };
 
     const requestedSchema = Number(state.schemaVersion);
@@ -170,7 +178,7 @@ define(["common/UriTemplateUtilities"], (UriTemplateUtilities) => {
         : 0;
 
     // Phase 1 fields imply schema 1 writing.
-    if (normalized.activeActionId || normalized.openPanel) {
+    if (normalized.activeActionId || normalized.openPanel || normalized.activeFeatureIds.length) {
       normalized.schemaVersion = Math.max(1, normalized.schemaVersion);
     }
 
@@ -211,11 +219,15 @@ define(["common/UriTemplateUtilities"], (UriTemplateUtilities) => {
       enabledLayerStateProvided: url.searchParams.has(ENABLED_LAYERS_ID),
       activeActionId: null,
       openPanel: null,
+      activeFeatureIds: [],
     };
 
     if (schemaVersion >= 1) {
       base.activeActionId = normalizeId(url.searchParams.get(ACTIVE_ACTION_ID));
       base.openPanel = normalizeId(url.searchParams.get(OPEN_PANEL_ID));
+      base.activeFeatureIds = parseCommaSeparated(
+        url.searchParams.get(ACTIVE_FEATURES_ID),
+      );
     }
 
     return normalizeState(base);
@@ -265,6 +277,12 @@ define(["common/UriTemplateUtilities"], (UriTemplateUtilities) => {
       }
       if (normalized.openPanel) {
         url.searchParams.set(OPEN_PANEL_ID, normalized.openPanel);
+      }
+      if (normalized.activeFeatureIds.length) {
+        url.searchParams.set(
+          ACTIVE_FEATURES_ID,
+          normalized.activeFeatureIds.join(","),
+        );
       }
     }
 
@@ -507,6 +525,15 @@ define(["common/UriTemplateUtilities"], (UriTemplateUtilities) => {
   };
 
   /**
+   * Set active feature ids in URL state.
+   * @param {string[]} activeFeatureIds The feature ids to write.
+   * @since 0.0.0
+   */
+  const updateActiveFeatureIds = (activeFeatureIds) => {
+    updateStateInUrl({ activeFeatureIds });
+  };
+
+  /**
    * @namespace SearchParams
    * @description Helpful functions for dealing with various search parameter
    * changes.
@@ -523,6 +550,7 @@ define(["common/UriTemplateUtilities"], (UriTemplateUtilities) => {
     resolveActionUrl,
     syncActionStateFromVisualizationUrl,
     updateActiveActionId,
+    updateActiveFeatureIds,
     updateOpenPanel,
     updateStateInUrl,
     writeActionStateToUrl,

--- a/src/js/common/SearchParams.js
+++ b/src/js/common/SearchParams.js
@@ -59,7 +59,7 @@ define(["common/UriTemplateUtilities"], (UriTemplateUtilities) => {
     enabledLayerStateProvided: false,
     activeActionId: null,
     openPanel: null,
-    activeFeatureIds: [],
+    activeFeatures: [],
   });
 
   /**
@@ -104,16 +104,78 @@ define(["common/UriTemplateUtilities"], (UriTemplateUtilities) => {
   }
 
   /**
-   * Normalize a list of IDs from array input.
-   * @param {unknown} value Candidate IDs from URL or model state.
-   * @returns {string[]} Normalized non-empty IDs.
+   * Normalize active feature entries into { featureId, layerId } pairs.
+   * @param {unknown} value Candidate active feature entries.
+   * @returns {{featureId: string, layerId: (string|null)}[]} Normalized entries.
    * @since 0.0.0
    */
-  const normalizeIdList = (value) => {
+  const normalizeActiveFeatures = (value) => {
     if (!Array.isArray(value)) return [];
-    return value
-      .map((item) => normalizeId(item))
-      .filter((item) => item != null);
+
+    const normalized = [];
+    const seen = new Set();
+
+    value.forEach((entry) => {
+      if (!entry || typeof entry !== "object") return;
+
+      const featureId = normalizeId(entry.featureId);
+      if (!featureId) return;
+
+      const layerId = normalizeId(entry.layerId);
+      const normalizedEntry = {
+        featureId,
+        layerId: layerId || null,
+      };
+      const dedupeKey = JSON.stringify(normalizedEntry);
+      if (seen.has(dedupeKey)) return;
+
+      seen.add(dedupeKey);
+      normalized.push(normalizedEntry);
+    });
+
+    return normalized;
+  };
+
+  /**
+   * Parse a single encoded active-feature token from the URL.
+   * Expects JSON object payloads containing feature/layer ids.
+   * @param {unknown} token Candidate f param value.
+   * @returns {{featureId: string, layerId: (string|null)}|null} Parsed entry.
+   * @since 0.0.0
+   */
+  const parseActiveFeatureToken = (token) => {
+    if (typeof token !== "string") return null;
+
+    try {
+      const parsed = JSON.parse(token);
+      if (!parsed || typeof parsed !== "object") return null;
+
+      const featureId = normalizeId(parsed.featureId);
+      if (!featureId) return null;
+
+      return {
+        featureId,
+        layerId: normalizeId(parsed.layerId) || null,
+      };
+    } catch (_error) {
+      return null;
+    }
+  };
+
+  /**
+   * Serialize one active-feature entry into a stable URL token.
+   * @param {{featureId: string, layerId: (string|null)}} feature Active feature entry.
+   * @returns {string|null} JSON-encoded token string.
+   * @since 0.0.0
+   */
+  const serializeActiveFeatureToken = (feature) => {
+    const [normalizedFeature] = normalizeActiveFeatures([feature]);
+    if (!normalizedFeature) return null;
+
+    return JSON.stringify({
+      featureId: normalizedFeature.featureId,
+      layerId: normalizedFeature.layerId,
+    });
   };
 
   /**
@@ -165,6 +227,10 @@ define(["common/UriTemplateUtilities"], (UriTemplateUtilities) => {
    */
   const normalizeState = (state = {}) => {
     const defaults = getDefaultState();
+    const normalizedActiveFeatures = normalizeActiveFeatures(
+      Array.isArray(state.activeFeatures) ? state.activeFeatures : [],
+    );
+
     const normalized = {
       ...defaults,
       ...state,
@@ -177,7 +243,7 @@ define(["common/UriTemplateUtilities"], (UriTemplateUtilities) => {
       enabledLayerStateProvided: Boolean(state.enabledLayerStateProvided),
       activeActionId: normalizeId(state.activeActionId),
       openPanel: normalizeId(state.openPanel),
-      activeFeatureIds: normalizeIdList(state.activeFeatureIds),
+      activeFeatures: normalizedActiveFeatures,
     };
 
     const requestedSchema = Number(state.schemaVersion);
@@ -186,11 +252,10 @@ define(["common/UriTemplateUtilities"], (UriTemplateUtilities) => {
         ? Math.floor(requestedSchema)
         : 0;
 
-    // Phase 1 fields imply schema 1 writing.
     if (
       normalized.activeActionId ||
       normalized.openPanel ||
-      normalized.activeFeatureIds.length
+      normalized.activeFeatures.length
     ) {
       normalized.schemaVersion = Math.max(1, normalized.schemaVersion);
     }
@@ -232,14 +297,17 @@ define(["common/UriTemplateUtilities"], (UriTemplateUtilities) => {
       enabledLayerStateProvided: url.searchParams.has(ENABLED_LAYERS_ID),
       activeActionId: null,
       openPanel: null,
-      activeFeatureIds: [],
+      activeFeatures: [],
     };
 
     if (schemaVersion >= 1) {
       base.activeActionId = normalizeId(url.searchParams.get(ACTIVE_ACTION_ID));
       base.openPanel = normalizeId(url.searchParams.get(OPEN_PANEL_ID));
-      base.activeFeatureIds = normalizeIdList(
-        url.searchParams.getAll(ACTIVE_FEATURES_ID),
+      base.activeFeatures = normalizeActiveFeatures(
+        url.searchParams
+          .getAll(ACTIVE_FEATURES_ID)
+          .map((token) => parseActiveFeatureToken(token))
+          .filter((entry) => entry != null),
       );
     }
 
@@ -291,9 +359,12 @@ define(["common/UriTemplateUtilities"], (UriTemplateUtilities) => {
       if (normalized.openPanel) {
         url.searchParams.set(OPEN_PANEL_ID, normalized.openPanel);
       }
-      if (normalized.activeFeatureIds.length) {
-        normalized.activeFeatureIds.forEach((featureId) => {
-          url.searchParams.append(ACTIVE_FEATURES_ID, featureId);
+      if (normalized.activeFeatures.length) {
+        normalized.activeFeatures.forEach(({ featureId, layerId }) => {
+          const token = serializeActiveFeatureToken({ featureId, layerId });
+          if (token) {
+            url.searchParams.append(ACTIVE_FEATURES_ID, token);
+          }
         });
       }
     }
@@ -537,12 +608,13 @@ define(["common/UriTemplateUtilities"], (UriTemplateUtilities) => {
   };
 
   /**
-   * Set active feature ids in URL state.
-   * @param {string[]} activeFeatureIds The feature ids to write.
+   * Set active features in URL state as feature/layer pairs.
+   * @param {{featureId: string, layerId: (string|null)}[]} activeFeatures
+   * The feature state entries to write.
    * @since 0.0.0
    */
-  const updateActiveFeatureIds = (activeFeatureIds) => {
-    updateStateInUrl({ activeFeatureIds });
+  const updateActiveFeatures = (activeFeatures) => {
+    updateStateInUrl({ activeFeatures });
   };
 
   /**
@@ -562,7 +634,7 @@ define(["common/UriTemplateUtilities"], (UriTemplateUtilities) => {
     resolveActionUrl,
     syncActionStateFromVisualizationUrl,
     updateActiveActionId,
-    updateActiveFeatureIds,
+    updateActiveFeatures,
     updateOpenPanel,
     updateStateInUrl,
     writeActionStateToUrl,

--- a/src/js/models/maps/ActiveFeatureRestoreController.js
+++ b/src/js/models/maps/ActiveFeatureRestoreController.js
@@ -2,6 +2,17 @@
 
 define(["backbone"], (Backbone) => {
   /**
+   * @param {unknown} value Candidate id.
+   * @returns {string|null} Trimmed id string or null.
+   * @since 0.0.0
+   */
+  function normalizeId(value) {
+    if (typeof value !== "string") return null;
+    const trimmed = value.trim();
+    return trimmed.length ? trimmed : null;
+  }
+
+  /**
    * Extract a feature id from either a Feature model or plain attrs object.
    * @param {Backbone.Model|object} feature Feature model or attrs object.
    * @returns {string|undefined} Stable feature id when present.
@@ -15,6 +26,135 @@ define(["backbone"], (Backbone) => {
   }
 
   /**
+   * Extract map layer id from either a Feature model or plain attrs object.
+   * @param {Backbone.Model|object} feature Feature model or attrs object.
+   * @returns {string|null} Layer id if available.
+   * @since 0.0.0
+   */
+  function getLayerId(feature) {
+    const mapAsset =
+      feature instanceof Backbone.Model ? feature.get("mapAsset") : feature?.mapAsset;
+    if (!mapAsset || typeof mapAsset.get !== "function") return null;
+    return normalizeId(mapAsset.get("layerId"));
+  }
+
+  /**
+   * Build a stable key for a feature selection entry.
+   * @param {{featureId: string, layerId: (string|null)}} featureState Entry.
+   * @returns {string} Stable serialization key.
+   * @since 0.0.0
+   */
+  function getFeatureStateKey(featureState) {
+    return JSON.stringify(featureState);
+  }
+
+  /**
+   * Normalize a single feature entry into feature/layer form.
+   * @param {unknown} entry Candidate feature state entry.
+   * @returns {{featureId: string, layerId: (string|null)}|null} Normalized entry.
+   * @since 0.0.0
+   */
+  function normalizeFeatureStateEntry(entry) {
+    if (typeof entry === "string") {
+      const featureId = normalizeId(entry);
+      if (!featureId) return null;
+      return { featureId, layerId: null };
+    }
+
+    if (!entry || typeof entry !== "object") return null;
+
+    const featureId = normalizeId(entry.featureId || entry.featureID);
+    if (!featureId) return null;
+
+    return {
+      featureId,
+      layerId: normalizeId(entry.layerId) || null,
+    };
+  }
+
+  /**
+   * Normalize and deduplicate feature state entries.
+   * @param {unknown[]} entries Candidate entries.
+   * @returns {{featureId: string, layerId: (string|null)}[]} Normalized entries.
+   * @since 0.0.0
+   */
+  function normalizeFeatureState(entries) {
+    if (!Array.isArray(entries)) return [];
+    const normalized = [];
+    const seen = new Set();
+
+    entries.forEach((entry) => {
+      const normalizedEntry = normalizeFeatureStateEntry(entry);
+      if (!normalizedEntry) return;
+
+      const key = getFeatureStateKey(normalizedEntry);
+      if (seen.has(key)) return;
+
+      seen.add(key);
+      normalized.push(normalizedEntry);
+    });
+
+    return normalized;
+  }
+
+  /**
+   * Create a feature state entry from a selected feature model/attrs object.
+   * @param {Backbone.Model|object} feature Selected feature entry.
+   * @returns {{featureId: string, layerId: (string|null)}|null} Feature state entry.
+   * @since 0.0.0
+   */
+  function getFeatureStateFromSelection(feature) {
+    const featureId = normalizeId(getFeatureId(feature));
+    if (!featureId) return null;
+
+    return {
+      featureId,
+      layerId: getLayerId(feature),
+    };
+  }
+
+  /**
+   * Convert selected features to normalized feature state entries.
+   * @param {Array<Backbone.Model|object>} features Selected features.
+   * @returns {{featureId: string, layerId: (string|null)}[]} Normalized entries.
+   * @since 0.0.0
+   */
+  function getFeatureStateFromSelections(features = []) {
+    return normalizeFeatureState(
+      features
+        .map((feature) => getFeatureStateFromSelection(feature))
+        .filter((featureState) => featureState != null),
+    );
+  }
+
+  /**
+   * Whether a resolved feature satisfies a requested feature state.
+   * @param {{featureId: string, layerId: (string|null)}} requestedFeature Requested entry.
+   * @param {{featureId: string, layerId: (string|null)}} resolvedFeature Resolved entry.
+   * @returns {boolean} True when resolved entry satisfies request.
+   * @since 0.0.0
+   */
+  function matchesRequestedFeature(requestedFeature, resolvedFeature) {
+    if (!requestedFeature || !resolvedFeature) return false;
+    if (requestedFeature.featureId !== resolvedFeature.featureId) return false;
+    if (!requestedFeature.layerId) return true;
+    return requestedFeature.layerId === resolvedFeature.layerId;
+  }
+
+  /**
+   * Check whether a requested feature is resolved by any resolved entry.
+   * @param {{featureId: string, layerId: (string|null)}} requestedFeature Requested entry.
+   * @param {{featureId: string, layerId: (string|null)}[]} resolvedFeatures Resolved entries.
+   * @returns {boolean} True when request is resolved.
+   * @since 0.0.0
+   */
+  function isFeatureResolved(requestedFeature, resolvedFeatures = []) {
+    return resolvedFeatures.some((resolvedFeature) =>
+      matchesRequestedFeature(requestedFeature, resolvedFeature),
+    );
+  }
+
+  /**
    * Merge current and newly found features without duplicating feature ids.
    * @param {Array<Backbone.Model|object>} currentFeatures Currently selected features.
    * @param {Array<Backbone.Model|object>} newFeatures Newly resolved features.
@@ -23,15 +163,16 @@ define(["backbone"], (Backbone) => {
    */
   function mergeFeatureSelections(currentFeatures = [], newFeatures = []) {
     const merged = [];
-    const seenIds = new Set();
+    const seenKeys = new Set();
 
     currentFeatures.concat(newFeatures).forEach((feature) => {
       if (!feature) return;
 
-      const featureId = getFeatureId(feature);
-      if (typeof featureId === "string" && featureId.length) {
-        if (seenIds.has(featureId)) return;
-        seenIds.add(featureId);
+      const featureState = getFeatureStateFromSelection(feature);
+      if (featureState) {
+        const featureKey = getFeatureStateKey(featureState);
+        if (seenKeys.has(featureKey)) return;
+        seenKeys.add(featureKey);
       }
 
       merged.push(feature);
@@ -73,21 +214,47 @@ define(["backbone"], (Backbone) => {
     },
 
     /**
-     * Merge selected ids with in-flight restore ids for URL sync.
-     * @param {string[]} selectedIds Currently selected feature ids.
-     * @returns {string[]} Feature ids to write to URL.
+     * Merge selected features with in-flight restore entries for URL sync.
+     * @param {{featureId: string, layerId: (string|null)}[]} selectedFeatures
+     * Currently selected feature state entries.
+     * @returns {{featureId: string, layerId: (string|null)}[]}
+     * Feature state entries to write to URL.
      * @since 0.0.0
      */
-    getRequestedIdsForUrlSync(selectedIds = []) {
-      const restoringIds = this.getSession()?.requestedIds;
-      if (!restoringIds?.length) return selectedIds;
+    getRequestedFeaturesForUrlSync(selectedFeatures = []) {
+      const normalizedSelected = normalizeFeatureState(selectedFeatures);
+      const restoringFeatures = normalizeFeatureState(
+        this.getSession()?.requestedFeatures,
+      );
+      if (!restoringFeatures.length) return normalizedSelected;
 
-      const mergedIds = restoringIds.slice();
-      selectedIds.forEach((id) => {
-        if (!mergedIds.includes(id)) mergedIds.push(id);
+      const merged = restoringFeatures.slice();
+      normalizedSelected.forEach((selectedFeature) => {
+        const selectedKey = getFeatureStateKey(selectedFeature);
+        if (
+          merged.some(
+            (featureState) => getFeatureStateKey(featureState) === selectedKey,
+          )
+        ) {
+          return;
+        }
+
+        const replaceIndex =
+          selectedFeature.layerId &&
+          merged.findIndex(
+            (featureState) =>
+              featureState.featureId === selectedFeature.featureId &&
+              featureState.layerId == null,
+          );
+
+        if (replaceIndex >= 0) {
+          merged[replaceIndex] = selectedFeature;
+        } else {
+          merged.push(selectedFeature);
+        }
       });
 
-      return mergedIds;
+      return normalizeFeatureState(merged);
     },
 
     /**
@@ -106,12 +273,14 @@ define(["backbone"], (Backbone) => {
 
     /**
      * Start a new feature restore session, canceling any previous one.
-     * @param {string[]} activeFeatureIds The ids being restored.
+     * @param {{featureId: string, layerId: (string|null)}[]} activeFeatures
+     * The features being restored.
      * @returns {object} The active restore session.
      * @since 0.0.0
      */
-    beginSession(activeFeatureIds) {
-      const sessionKey = activeFeatureIds.join(",");
+    beginSession(activeFeatures) {
+      const normalizedFeatures = normalizeFeatureState(activeFeatures);
+      const sessionKey = JSON.stringify(normalizedFeatures);
       if (this.getSession()?.key === sessionKey) {
         return this.getSession();
       }
@@ -120,7 +289,7 @@ define(["backbone"], (Backbone) => {
       return this.setSession({
         cancelers: [],
         key: sessionKey,
-        requestedIds: activeFeatureIds.slice(),
+        requestedFeatures: normalizedFeatures.slice(),
       });
     },
 
@@ -151,30 +320,35 @@ define(["backbone"], (Backbone) => {
     },
 
     /**
-     * Search all layers for features matching the given ids and return
+     * Search layers for features matching the given feature state and return
      * feature attribute objects ready to be passed to selectFeatures().
-     * @param {string[]} ids Feature ids to search for.
+     * @param {{featureId: string, layerId: (string|null)}[]} features
+     * Feature state entries to search for.
      * @returns {object[]} Matching feature attribute objects.
      * @since 0.0.0
      */
-    findFeatureAttributesByIds(ids) {
-      const allLayers = this.mapModel.getAllLayers();
+    findFeatureAttributes(features) {
+      const normalizedFeatures = normalizeFeatureState(features);
 
-      return ids.reduce((result, id) => {
-        const featureAttrs = allLayers.reduce((foundAttrs, layer) => {
-          if (foundAttrs || typeof layer.getFeatureById !== "function") {
-            return foundAttrs;
-          }
+      return normalizedFeatures.reduce((result, featureState) => {
+        const match = this.mapModel.findFeature(
+          featureState.featureId,
+          featureState.layerId,
+        );
 
-          const feature = layer.getFeatureById(id);
-          if (!feature) return foundAttrs;
-
-          return layer.getFeatureAttributes(feature) || foundAttrs;
-        }, null);
-
-        if (featureAttrs) result.push(featureAttrs);
+        if (match?.attributes) result.push(match.attributes);
         return result;
       }, []);
+    },
+
+    /**
+     * Read normalized feature state from restoreState.
+     * @returns {{featureId: string, layerId: (string|null)}[]} Restore entries.
+     * @since 0.0.0
+     */
+    getRestoreFeatures() {
+      const restoreState = this.mapModel.get("restoreState") || {};
+      return normalizeFeatureState(restoreState.activeFeatures);
     },
 
     /**
@@ -192,34 +366,35 @@ define(["backbone"], (Backbone) => {
         return;
       }
 
-      const restoreState = mapModel.get("restoreState") || {};
-      const { activeFeatureIds = [] } = restoreState;
-      if (!activeFeatureIds.length) {
+      const activeFeatures = this.getRestoreFeatures();
+      if (!activeFeatures.length) {
         this.clearSession();
         return;
       }
 
       const selectedFeatures = mapModel.getSelectedFeatures();
-      const selectedRequestedIds = (selectedFeatures?.models || [])
-        .map((feature) => getFeatureId(feature))
-        .filter((id) => activeFeatureIds.includes(id));
+      const selectedRequestedFeatures = getFeatureStateFromSelections(
+        selectedFeatures?.models || [],
+      ).filter((featureState) =>
+        activeFeatures.some((requestedFeature) =>
+          matchesRequestedFeature(requestedFeature, featureState),
+        ),
+      );
       const allSearchableLayers = mapModel.getAllLayers().filter(
         (layer) => typeof layer.getFeatureById === "function",
       );
-      const featureAttrs = this.findFeatureAttributesByIds(activeFeatureIds);
-      const resolvedIds = new Set(selectedRequestedIds);
+      const featureAttrs = this.findFeatureAttributes(activeFeatures);
+      const resolvedFeatures = selectedRequestedFeatures.slice();
 
       featureAttrs.forEach((feature) => {
-        const featureId = getFeatureId(feature);
-        if (typeof featureId === "string" && featureId.length) {
-          resolvedIds.add(featureId);
-        }
+        const featureState = getFeatureStateFromSelection(feature);
+        if (featureState) resolvedFeatures.push(featureState);
       });
 
-      const unresolvedIds = activeFeatureIds.filter(
-        (id) => !resolvedIds.has(id),
+      const unresolvedFeatures = activeFeatures.filter(
+        (featureState) => !isFeatureResolved(featureState, resolvedFeatures),
       );
-      const restoreKey = activeFeatureIds.join(",");
+      const restoreKey = JSON.stringify(activeFeatures);
       const canResolveAsynchronously = allSearchableLayers.some(
         (layer) =>
           layer.get("status") !== "ready" ||
@@ -229,11 +404,11 @@ define(["backbone"], (Backbone) => {
       let restoreSession = existingSession;
 
       if (
-        unresolvedIds.length &&
+        unresolvedFeatures.length &&
         canResolveAsynchronously &&
         existingSession?.key !== restoreKey
       ) {
-        restoreSession = this.beginSession(activeFeatureIds);
+        restoreSession = this.beginSession(activeFeatures);
       }
 
       if (featureAttrs.length) {
@@ -242,7 +417,7 @@ define(["backbone"], (Backbone) => {
         );
       }
 
-      if (!unresolvedIds.length) {
+      if (!unresolvedFeatures.length) {
         this.clearSession();
         return;
       }
@@ -260,16 +435,19 @@ define(["backbone"], (Backbone) => {
       const selectIfFound = () => {
         if (!this.isActiveSession(restoreSession)) return;
 
-        const selectedIds = (mapModel.getSelectedFeatures()?.models || [])
-          .map((feature) => getFeatureId(feature))
-          .filter((id) => activeFeatureIds.includes(id));
-        const selectedIdSet = new Set(selectedIds);
-        if (activeFeatureIds.every((id) => selectedIdSet.has(id))) {
+        const selectedFeatureStates = getFeatureStateFromSelections(
+          mapModel.getSelectedFeatures()?.models || [],
+        );
+        if (
+          activeFeatures.every((featureState) =>
+            isFeatureResolved(featureState, selectedFeatureStates),
+          )
+        ) {
           this.clearSession();
           return;
         }
 
-        const attrs = this.findFeatureAttributesByIds(activeFeatureIds);
+        const attrs = this.findFeatureAttributes(activeFeatures);
         if (attrs.length) {
           mapModel.selectFeatures(
             mergeFeatureSelections(
@@ -279,12 +457,14 @@ define(["backbone"], (Backbone) => {
           );
         }
 
-        const resolvedAfterRetry = new Set(
-          (mapModel.getSelectedFeatures()?.models || [])
-            .map((feature) => getFeatureId(feature))
-            .filter((id) => activeFeatureIds.includes(id)),
+        const resolvedAfterRetry = getFeatureStateFromSelections(
+          mapModel.getSelectedFeatures()?.models || [],
         );
-        if (activeFeatureIds.every((id) => resolvedAfterRetry.has(id))) {
+        if (
+          activeFeatures.every((featureState) =>
+            isFeatureResolved(featureState, resolvedAfterRetry),
+          )
+        ) {
           this.clearSession();
         }
       };
@@ -293,15 +473,21 @@ define(["backbone"], (Backbone) => {
         if (!this.isActiveSession(restoreSession)) return;
         if (typeof layer.waitForFeatureById !== "function") return;
 
-        const selectedIds = (mapModel.getSelectedFeatures()?.models || []).map(
-          (feature) => getFeatureId(feature),
+        const layerId = normalizeId(layer.get("layerId"));
+        const selectedFeatureStates = getFeatureStateFromSelections(
+          mapModel.getSelectedFeatures()?.models || [],
         );
-        const missingIds = activeFeatureIds.filter(
-          (id) => !selectedIds.includes(id),
-        );
+        const missingFeatures = activeFeatures.filter((featureState) => {
+          if (featureState.layerId && featureState.layerId !== layerId) {
+            return false;
+          }
+          return !isFeatureResolved(featureState, selectedFeatureStates);
+        });
 
-        missingIds.forEach((id) => {
-          const cancel = layer.waitForFeatureById(id, () => selectIfFound());
+        missingFeatures.forEach((featureState) => {
+          const cancel = layer.waitForFeatureById(featureState.featureId, () =>
+            selectIfFound(),
+          );
           this.addWaiter(cancel, restoreSession);
         });
       };
@@ -309,6 +495,13 @@ define(["backbone"], (Backbone) => {
       if (!allSearchableLayers.length) return;
 
       allSearchableLayers.forEach((layer) => {
+        const layerId = normalizeId(layer.get("layerId"));
+        const isRelevantLayer = unresolvedFeatures.some(
+          (featureState) =>
+            !featureState.layerId || featureState.layerId === layerId,
+        );
+        if (!isRelevantLayer) return;
+
         if (layer.get("status") !== "ready") {
           const statusListener = () => {
             if (!this.isActiveSession(restoreSession)) {

--- a/src/js/models/maps/ActiveFeatureRestoreController.js
+++ b/src/js/models/maps/ActiveFeatureRestoreController.js
@@ -33,7 +33,9 @@ define(["backbone"], (Backbone) => {
    */
   function getLayerId(feature) {
     const mapAsset =
-      feature instanceof Backbone.Model ? feature.get("mapAsset") : feature?.mapAsset;
+      feature instanceof Backbone.Model
+        ? feature.get("mapAsset")
+        : feature?.mapAsset;
     if (!mapAsset || typeof mapAsset.get !== "function") return null;
     return normalizeId(mapAsset.get("layerId"));
   }
@@ -380,9 +382,9 @@ define(["backbone"], (Backbone) => {
           matchesRequestedFeature(requestedFeature, featureState),
         ),
       );
-      const allSearchableLayers = mapModel.getAllLayers().filter(
-        (layer) => typeof layer.getFeatureById === "function",
-      );
+      const allSearchableLayers = mapModel
+        .getAllLayers()
+        .filter((layer) => typeof layer.getFeatureById === "function");
       const featureAttrs = this.findFeatureAttributes(activeFeatures);
       const resolvedFeatures = selectedRequestedFeatures.slice();
 
@@ -428,7 +430,10 @@ define(["backbone"], (Backbone) => {
         return;
       }
 
-      if (this.getSession()?.key === restoreKey && existingSession?.key === restoreKey) {
+      if (
+        this.getSession()?.key === restoreKey &&
+        existingSession?.key === restoreKey
+      ) {
         return;
       }
 

--- a/src/js/models/maps/ActiveFeatureRestoreController.js
+++ b/src/js/models/maps/ActiveFeatureRestoreController.js
@@ -1,0 +1,337 @@
+"use strict";
+
+define(["backbone"], (Backbone) => {
+  /**
+   * Extract a feature id from either a Feature model or plain attrs object.
+   * @param {Backbone.Model|object} feature Feature model or attrs object.
+   * @returns {string|undefined} Stable feature id when present.
+   * @since 0.0.0
+   */
+  function getFeatureId(feature) {
+    if (feature instanceof Backbone.Model) {
+      return feature.get("featureID");
+    }
+    return feature?.featureID;
+  }
+
+  /**
+   * Merge current and newly found features without duplicating feature ids.
+   * @param {Array<Backbone.Model|object>} currentFeatures Currently selected features.
+   * @param {Array<Backbone.Model|object>} newFeatures Newly resolved features.
+   * @returns {Array<Backbone.Model|object>} Merged feature list.
+   * @since 0.0.0
+   */
+  function mergeFeatureSelections(currentFeatures = [], newFeatures = []) {
+    const merged = [];
+    const seenIds = new Set();
+
+    currentFeatures.concat(newFeatures).forEach((feature) => {
+      if (!feature) return;
+
+      const featureId = getFeatureId(feature);
+      if (typeof featureId === "string" && featureId.length) {
+        if (seenIds.has(featureId)) return;
+        seenIds.add(featureId);
+      }
+
+      merged.push(feature);
+    });
+
+    return merged;
+  }
+
+  /**
+   * Manage asynchronous feature restore state for a map model.
+   * @param {object} options Controller options.
+   * @param {MapModel} options.mapModel Owning map model.
+   * @class MapFeatureRestoreController
+   * @since 0.0.0
+   */
+  function MapFeatureRestoreController({ mapModel }) {
+    this.mapModel = mapModel;
+  }
+
+  MapFeatureRestoreController.prototype = {
+    /**
+     * Get the current restore session from the owning map.
+     * @returns {object|null} Current restore session.
+     * @since 0.0.0
+     */
+    getSession() {
+      return this.mapModel.featureRestoreSession || null;
+    },
+
+    /**
+     * Set the current restore session on the owning map.
+     * @param {object|null} session Restore session.
+     * @returns {object|null} The assigned session.
+     * @since 0.0.0
+     */
+    setSession(session) {
+      this.mapModel.featureRestoreSession = session;
+      return session;
+    },
+
+    /**
+     * Merge selected ids with in-flight restore ids for URL sync.
+     * @param {string[]} selectedIds Currently selected feature ids.
+     * @returns {string[]} Feature ids to write to URL.
+     * @since 0.0.0
+     */
+    getRequestedIdsForUrlSync(selectedIds = []) {
+      const restoringIds = this.getSession()?.requestedIds;
+      if (!restoringIds?.length) return selectedIds;
+
+      const mergedIds = restoringIds.slice();
+      selectedIds.forEach((id) => {
+        if (!mergedIds.includes(id)) mergedIds.push(id);
+      });
+
+      return mergedIds;
+    },
+
+    /**
+     * Cancel and clear any in-flight asynchronous feature restore waiters.
+     * @since 0.0.0
+     */
+    clearSession() {
+      const session = this.getSession();
+      if (!session) return;
+
+      this.setSession(null);
+      session.cancelers.forEach((cancel) => {
+        if (typeof cancel === "function") cancel();
+      });
+    },
+
+    /**
+     * Start a new feature restore session, canceling any previous one.
+     * @param {string[]} activeFeatureIds The ids being restored.
+     * @returns {object} The active restore session.
+     * @since 0.0.0
+     */
+    beginSession(activeFeatureIds) {
+      const sessionKey = activeFeatureIds.join(",");
+      if (this.getSession()?.key === sessionKey) {
+        return this.getSession();
+      }
+
+      this.clearSession();
+      return this.setSession({
+        cancelers: [],
+        key: sessionKey,
+        requestedIds: activeFeatureIds.slice(),
+      });
+    },
+
+    /**
+     * Track a cancel function for in-flight feature restore waiting.
+     * @param {Function} cancel Cancel function returned by a waiter.
+     * @param {object} session The restore session that owns the waiter.
+     * @since 0.0.0
+     */
+    addWaiter(cancel, session = this.getSession()) {
+      if (typeof cancel !== "function" || !session) return;
+      if (this.getSession() !== session) {
+        cancel();
+        return;
+      }
+
+      session.cancelers.push(cancel);
+    },
+
+    /**
+     * Check whether a restore session is still active.
+     * @param {object} session The restore session to check.
+     * @returns {boolean} True if the session is still current.
+     * @since 0.0.0
+     */
+    isActiveSession(session) {
+      return this.getSession() === session;
+    },
+
+    /**
+     * Search all layers for features matching the given ids and return
+     * feature attribute objects ready to be passed to selectFeatures().
+     * @param {string[]} ids Feature ids to search for.
+     * @returns {object[]} Matching feature attribute objects.
+     * @since 0.0.0
+     */
+    findFeatureAttributesByIds(ids) {
+      const allLayers = this.mapModel.getAllLayers();
+
+      return ids.reduce((result, id) => {
+        const featureAttrs = allLayers.reduce((foundAttrs, layer) => {
+          if (foundAttrs || typeof layer.getFeatureById !== "function") {
+            return foundAttrs;
+          }
+
+          const feature = layer.getFeatureById(id);
+          if (!feature) return foundAttrs;
+
+          return layer.getFeatureAttributes(feature) || foundAttrs;
+        }, null);
+
+        if (featureAttrs) result.push(featureAttrs);
+        return result;
+      }, []);
+    },
+
+    /**
+     * Open the feature info panel for any feature ids stored in restoreState.
+     * Called after other state is restored so the feature panel appears last.
+     * Searches all map layers for a matching feature and selects it directly
+     * without simulating a user click. If entities are not yet loaded,
+     * waits for each layer's status to become 'ready' before retrying.
+     * @since 0.0.0
+     */
+    applyRestoreState() {
+      const { mapModel } = this;
+      if (!mapModel.shouldSyncUrlState()) {
+        this.clearSession();
+        return;
+      }
+
+      const restoreState = mapModel.get("restoreState") || {};
+      const { activeFeatureIds = [] } = restoreState;
+      if (!activeFeatureIds.length) {
+        this.clearSession();
+        return;
+      }
+
+      const selectedFeatures = mapModel.getSelectedFeatures();
+      const selectedRequestedIds = (selectedFeatures?.models || [])
+        .map((feature) => getFeatureId(feature))
+        .filter((id) => activeFeatureIds.includes(id));
+      const allSearchableLayers = mapModel.getAllLayers().filter(
+        (layer) => typeof layer.getFeatureById === "function",
+      );
+      const featureAttrs = this.findFeatureAttributesByIds(activeFeatureIds);
+      const resolvedIds = new Set(selectedRequestedIds);
+
+      featureAttrs.forEach((feature) => {
+        const featureId = getFeatureId(feature);
+        if (typeof featureId === "string" && featureId.length) {
+          resolvedIds.add(featureId);
+        }
+      });
+
+      const unresolvedIds = activeFeatureIds.filter(
+        (id) => !resolvedIds.has(id),
+      );
+      const restoreKey = activeFeatureIds.join(",");
+      const canResolveAsynchronously = allSearchableLayers.some(
+        (layer) =>
+          layer.get("status") !== "ready" ||
+          typeof layer.waitForFeatureById === "function",
+      );
+      const existingSession = this.getSession();
+      let restoreSession = existingSession;
+
+      if (
+        unresolvedIds.length &&
+        canResolveAsynchronously &&
+        existingSession?.key !== restoreKey
+      ) {
+        restoreSession = this.beginSession(activeFeatureIds);
+      }
+
+      if (featureAttrs.length) {
+        mapModel.selectFeatures(
+          mergeFeatureSelections(selectedFeatures?.models || [], featureAttrs),
+        );
+      }
+
+      if (!unresolvedIds.length) {
+        this.clearSession();
+        return;
+      }
+
+      if (!canResolveAsynchronously) {
+        this.clearSession();
+        mapModel.syncSelectedFeaturesToUrl();
+        return;
+      }
+
+      if (this.getSession()?.key === restoreKey && existingSession?.key === restoreKey) {
+        return;
+      }
+
+      const selectIfFound = () => {
+        if (!this.isActiveSession(restoreSession)) return;
+
+        const selectedIds = (mapModel.getSelectedFeatures()?.models || [])
+          .map((feature) => getFeatureId(feature))
+          .filter((id) => activeFeatureIds.includes(id));
+        const selectedIdSet = new Set(selectedIds);
+        if (activeFeatureIds.every((id) => selectedIdSet.has(id))) {
+          this.clearSession();
+          return;
+        }
+
+        const attrs = this.findFeatureAttributesByIds(activeFeatureIds);
+        if (attrs.length) {
+          mapModel.selectFeatures(
+            mergeFeatureSelections(
+              mapModel.getSelectedFeatures()?.models || [],
+              attrs,
+            ),
+          );
+        }
+
+        const resolvedAfterRetry = new Set(
+          (mapModel.getSelectedFeatures()?.models || [])
+            .map((feature) => getFeatureId(feature))
+            .filter((id) => activeFeatureIds.includes(id)),
+        );
+        if (activeFeatureIds.every((id) => resolvedAfterRetry.has(id))) {
+          this.clearSession();
+        }
+      };
+
+      const registerTileWaiters = (layer) => {
+        if (!this.isActiveSession(restoreSession)) return;
+        if (typeof layer.waitForFeatureById !== "function") return;
+
+        const selectedIds = (mapModel.getSelectedFeatures()?.models || []).map(
+          (feature) => getFeatureId(feature),
+        );
+        const missingIds = activeFeatureIds.filter(
+          (id) => !selectedIds.includes(id),
+        );
+
+        missingIds.forEach((id) => {
+          const cancel = layer.waitForFeatureById(id, () => selectIfFound());
+          this.addWaiter(cancel, restoreSession);
+        });
+      };
+
+      if (!allSearchableLayers.length) return;
+
+      allSearchableLayers.forEach((layer) => {
+        if (layer.get("status") !== "ready") {
+          const statusListener = () => {
+            if (!this.isActiveSession(restoreSession)) {
+              mapModel.stopListening(layer, "change:status", statusListener);
+              return;
+            }
+            if (layer.get("status") !== "ready") return;
+
+            mapModel.stopListening(layer, "change:status", statusListener);
+            selectIfFound();
+            registerTileWaiters(layer);
+          };
+
+          mapModel.listenTo(layer, "change:status", statusListener);
+          this.addWaiter(() => {
+            mapModel.stopListening(layer, "change:status", statusListener);
+          }, restoreSession);
+        } else if (typeof layer.waitForFeatureById === "function") {
+          registerTileWaiters(layer);
+        }
+      });
+    },
+  };
+
+  return MapFeatureRestoreController;
+});

--- a/src/js/models/maps/Map.js
+++ b/src/js/models/maps/Map.js
@@ -169,6 +169,43 @@ define([
   }
 
   /**
+   * Extract a feature id from either a Feature model or plain attrs object.
+   * @param {Backbone.Model|object} feature Feature model or attrs object.
+   * @returns {string|undefined} Stable feature id when present.
+   * @since 0.0.0
+   */
+  function getFeatureId(feature) {
+    if (feature instanceof Backbone.Model) {
+      return feature.get("featureID");
+    }
+    return feature?.featureID;
+  }
+
+  /**
+   * Merge current and newly found features without duplicating feature ids.
+   * @param {Array<Backbone.Model|object>} currentFeatures Currently selected features.
+   * @param {Array<Backbone.Model|object>} newFeatures Newly resolved features.
+   * @returns {Array<Backbone.Model|object>} Merged feature list.
+   * @since 0.0.0
+   */
+  function mergeFeatureSelections(currentFeatures = [], newFeatures = []) {
+    const merged = [];
+    const seenIds = new Set();
+
+    currentFeatures.concat(newFeatures).forEach((feature) => {
+      if (!feature) return;
+      const featureId = getFeatureId(feature);
+      if (typeof featureId === "string" && featureId.length) {
+        if (seenIds.has(featureId)) return;
+        seenIds.add(featureId);
+      }
+      merged.push(feature);
+    });
+
+    return merged;
+  }
+
+  /**
    * @class MapModel
    * @classdesc The Map Model contains all of the settings and options for a
    * required to render a map view.
@@ -724,9 +761,19 @@ define([
        */
       syncSelectedFeaturesToUrl() {
         if (!this.shouldSyncUrlState()) return;
-        SearchParams.updateActiveFeatureIds(
-          this.getSelectedFeatureIdsForUrlState(),
-        );
+        const selectedIds = this.getSelectedFeatureIdsForUrlState();
+        const restoringIds = this.featureRestoreSession?.requestedIds;
+
+        if (restoringIds?.length) {
+          const mergedIds = restoringIds.slice();
+          selectedIds.forEach((id) => {
+            if (!mergedIds.includes(id)) mergedIds.push(id);
+          });
+          SearchParams.updateActiveFeatureIds(mergedIds);
+          return;
+        }
+
+        SearchParams.updateActiveFeatureIds(selectedIds);
       },
 
       /**
@@ -759,6 +806,7 @@ define([
         this.featureRestoreSession = {
           cancelers: [],
           key: sessionKey,
+          requestedIds: activeFeatureIds.slice(),
         };
         return this.featureRestoreSession;
       },
@@ -846,45 +894,88 @@ define([
         }
 
         const selectedFeatures = this.getSelectedFeatures();
-        const alreadySelected = selectedFeatures?.models.some((f) =>
-          activeFeatureIds.includes(f.get("featureID")),
+        const selectedRequestedIds = (selectedFeatures?.models || [])
+          .map((feature) => getFeatureId(feature))
+          .filter((id) => activeFeatureIds.includes(id));
+        const allSearchableLayers = this.getAllLayers().filter(
+          (layer) => typeof layer.getFeatureById === "function",
         );
-        if (alreadySelected) {
-          this.clearFeatureRestoreSession();
-          return;
-        }
-
         const featureAttrs = this.findFeatureAttributesByIds(activeFeatureIds);
+        const resolvedIds = new Set(selectedRequestedIds);
+        featureAttrs.forEach((feature) => {
+          const featureId = getFeatureId(feature);
+          if (typeof featureId === "string" && featureId.length) {
+            resolvedIds.add(featureId);
+          }
+        });
+        const unresolvedIds = activeFeatureIds.filter(
+          (id) => !resolvedIds.has(id),
+        );
+        const restoreKey = activeFeatureIds.join(",");
+        const canResolveAsynchronously = allSearchableLayers.some(
+          (layer) =>
+            layer.get("status") !== "ready" ||
+            typeof layer.waitForFeatureById === "function",
+        );
+        const existingSession = this.featureRestoreSession;
+        let restoreSession = existingSession;
+
+        if (
+          unresolvedIds.length &&
+          canResolveAsynchronously &&
+          existingSession?.key !== restoreKey
+        ) {
+          restoreSession = this.beginFeatureRestoreSession(activeFeatureIds);
+        }
+
         if (featureAttrs.length) {
-          this.selectFeatures(featureAttrs);
+          this.selectFeatures(
+            mergeFeatureSelections(selectedFeatures?.models || [], featureAttrs),
+          );
+        }
+
+        if (!unresolvedIds.length) {
           this.clearFeatureRestoreSession();
           return;
         }
 
-        const restoreKey = activeFeatureIds.join(",");
-        if (this.featureRestoreSession?.key === restoreKey) {
+        if (!canResolveAsynchronously) {
+          this.clearFeatureRestoreSession();
+          this.syncSelectedFeaturesToUrl();
           return;
         }
 
-        const restoreSession =
-          this.beginFeatureRestoreSession(activeFeatureIds);
+        if (this.featureRestoreSession?.key === restoreKey) {
+          if (existingSession?.key === restoreKey) return;
+        }
         const mapModel = this;
 
         const selectIfFound = () => {
           if (!mapModel.isActiveFeatureRestoreSession(restoreSession)) return;
-          if (
-            mapModel
-              .getSelectedFeatures()
-              ?.models.some((f) =>
-                activeFeatureIds.includes(f.get("featureID")),
-              )
-          ) {
+          const selectedIds = (mapModel.getSelectedFeatures()?.models || [])
+            .map((feature) => getFeatureId(feature))
+            .filter((id) => activeFeatureIds.includes(id));
+          const selectedIdSet = new Set(selectedIds);
+          if (activeFeatureIds.every((id) => selectedIdSet.has(id))) {
             mapModel.clearFeatureRestoreSession();
             return;
           }
           const attrs = mapModel.findFeatureAttributesByIds(activeFeatureIds);
           if (attrs.length) {
-            mapModel.selectFeatures(attrs);
+            mapModel.selectFeatures(
+              mergeFeatureSelections(
+                mapModel.getSelectedFeatures()?.models || [],
+                attrs,
+              ),
+            );
+          }
+
+          const resolvedAfterRetry = new Set(
+            (mapModel.getSelectedFeatures()?.models || [])
+              .map((feature) => getFeatureId(feature))
+              .filter((id) => activeFeatureIds.includes(id)),
+          );
+          if (activeFeatureIds.every((id) => resolvedAfterRetry.has(id))) {
             mapModel.clearFeatureRestoreSession();
           }
         };
@@ -892,15 +983,17 @@ define([
         const registerTileWaiters = (layer) => {
           if (!mapModel.isActiveFeatureRestoreSession(restoreSession)) return;
           if (typeof layer.waitForFeatureById !== "function") return;
-          activeFeatureIds.forEach((id) => {
+          const missingIds = activeFeatureIds.filter((id) => {
+            const selectedId = (mapModel.getSelectedFeatures()?.models || [])
+              .map((feature) => getFeatureId(feature));
+            return !selectedId.includes(id);
+          });
+          missingIds.forEach((id) => {
             const cancel = layer.waitForFeatureById(id, () => selectIfFound());
             mapModel.addFeatureRestoreWaiter(cancel, restoreSession);
           });
         };
 
-        const allSearchableLayers = this.getAllLayers().filter(
-          (layer) => typeof layer.getFeatureById === "function",
-        );
         if (!allSearchableLayers.length) return;
 
         allSearchableLayers.forEach((layer) => {

--- a/src/js/models/maps/Map.js
+++ b/src/js/models/maps/Map.js
@@ -590,6 +590,54 @@ define([
       },
 
       /**
+       * Find a feature by id, optionally scoped to a single layer id.
+       * @param {string} featureId Feature id to find.
+       * @param {string} [layerId] Optional layer id to constrain search.
+       * @returns {{layer: MapAsset, feature: object, attributes: object}|null}
+       * Matching feature result or null when not found.
+       * @since 0.0.0
+       */
+      findFeature(featureId, layerId) {
+        const normalizedFeatureId =
+          typeof featureId === "string" ? featureId.trim() : "";
+        if (!normalizedFeatureId.length) return null;
+
+        const normalizedLayerId =
+          typeof layerId === "string" && layerId.trim().length
+            ? layerId.trim()
+            : null;
+
+        const searchableLayers = this.getAllLayers().filter(
+          (layer) => typeof layer.getFeatureById === "function",
+        );
+        const candidateLayers = normalizedLayerId
+          ? searchableLayers.filter(
+              (layer) => layer.get("layerId") === normalizedLayerId,
+            )
+          : searchableLayers;
+
+        return (
+          candidateLayers.reduce((match, layer) => {
+            if (match) return match;
+
+            const feature = layer.getFeatureById(normalizedFeatureId);
+            if (!feature || typeof layer.getFeatureAttributes !== "function") {
+              return match;
+            }
+
+            const attributes = layer.getFeatureAttributes(feature);
+            if (!attributes) return match;
+
+            return {
+              layer,
+              feature,
+              attributes,
+            };
+          }, null) || null
+        );
+      },
+
+      /**
        * Returns true when the map should sync URL state.
        * @returns {boolean} Whether URL sync is enabled.
        * @since 0.0.0
@@ -709,16 +757,43 @@ define([
       },
 
       /**
-       * Get selected feature ids from the current map interaction state for URL
-       * state sync.
-       * @returns {string[]} Feature ids of all currently selected features.
+       * Get selected feature/layer entries from current map interaction state
+       * for URL sync.
+       * @returns {{featureId: string, layerId: (string|null)}[]}
+       * Selected feature state entries.
        * @since 0.0.0
        */
-      getSelectedFeatureIdsForUrlState() {
+      getSelectedFeatureStateForUrlState() {
         const selectedFeatures = this.getSelectedFeatures();
-        return (selectedFeatures?.models || [])
-          .map((f) => f.get("featureID"))
-          .filter((id) => typeof id === "string" && id.length > 0);
+        const seen = new Set();
+        const selected = [];
+
+        (selectedFeatures?.models || []).forEach((feature) => {
+          const featureId = feature?.get("featureID");
+          if (typeof featureId !== "string" || !featureId.trim().length) {
+            return;
+          }
+
+          const mapAsset = feature.get("mapAsset");
+          const layerId =
+            mapAsset && typeof mapAsset.get === "function"
+              ? mapAsset.get("layerId")
+              : null;
+          const entry = {
+            featureId: featureId.trim(),
+            layerId:
+              typeof layerId === "string" && layerId.trim().length
+                ? layerId.trim()
+                : null,
+          };
+          const dedupeKey = JSON.stringify(entry);
+          if (seen.has(dedupeKey)) return;
+
+          seen.add(dedupeKey);
+          selected.push(entry);
+        });
+
+        return selected;
       },
 
       /**
@@ -729,9 +804,11 @@ define([
        */
       syncSelectedFeaturesToUrl() {
         if (!this.shouldSyncUrlState()) return;
-        const selectedIds = this.getSelectedFeatureIdsForUrlState();
-        SearchParams.updateActiveFeatureIds(
-          this.featureRestoreController.getRequestedIdsForUrlSync(selectedIds),
+        const selectedFeatures = this.getSelectedFeatureStateForUrlState();
+        SearchParams.updateActiveFeatures(
+          this.featureRestoreController.getRequestedFeaturesForUrlSync(
+            selectedFeatures,
+          ),
         );
       },
 

--- a/src/js/models/maps/Map.js
+++ b/src/js/models/maps/Map.js
@@ -10,6 +10,7 @@ define([
   "collections/maps/AssetCategories",
   "collections/maps/viewfinder/ViewfinderCardCategories",
   "common/SearchParams",
+  "models/maps/featureIdHelpers",
 ], (
   $,
   _,
@@ -20,6 +21,7 @@ define([
   AssetCategories,
   ViewfinderCardCategories,
   SearchParams,
+  { getIdFromProperties },
 ) => {
   /**
    * Determine if array is empty.
@@ -769,8 +771,8 @@ define([
         const selected = [];
 
         (selectedFeatures?.models || []).forEach((feature) => {
-          const featureId = feature?.get("featureID");
-          if (typeof featureId !== "string" || !featureId.trim().length) {
+          const featureId = getIdFromProperties(feature?.get("properties"));
+          if (!featureId) {
             return;
           }
 
@@ -780,7 +782,7 @@ define([
               ? mapAsset.get("layerId")
               : null;
           const entry = {
-            featureId: featureId.trim(),
+            featureId,
             layerId:
               typeof layerId === "string" && layerId.trim().length
                 ? layerId.trim()

--- a/src/js/models/maps/Map.js
+++ b/src/js/models/maps/Map.js
@@ -615,10 +615,12 @@ define([
           !this.shouldSyncUrlState() ||
           !isCompletePosition(restoreState.destination)
         ) {
+          this.applyFeatureRestoreState();
           return;
         }
 
         this.zoomTo(restoreState.destination);
+        this.applyFeatureRestoreState();
       },
 
       /**

--- a/src/js/models/maps/Map.js
+++ b/src/js/models/maps/Map.js
@@ -770,22 +770,44 @@ define([
           return;
         }
 
-        // Entities not loaded yet — wait for each relevant layer to become ready
-        const pendingLayers = this.getAllLayers().filter(
-          (layer) =>
-            typeof layer.getFeatureById === "function" &&
-            layer.get("status") !== "ready",
-        );
-        if (!pendingLayers.length) return;
+        const mapModel = this;
+        const selectIfFound = () => {
+          if (
+            mapModel
+              .getSelectedFeatures()
+              ?.models.some((f) => activeFeatureIds.includes(f.get("featureID")))
+          )
+            return;
+          const attrs = mapModel.findFeatureAttributesByIds(activeFeatureIds);
+          if (attrs.length) mapModel.selectFeatures(attrs);
+        };
 
-        pendingLayers.forEach((layer) => {
-          this.listenTo(layer, "change:status", () => {
-            if (layer.get("status") !== "ready") return;
-            const attrs = this.findFeatureAttributesByIds(activeFeatureIds);
-            if (!attrs.length) return;
-            pendingLayers.forEach((l) => this.stopListening(l, "change:status"));
-            this.selectFeatures(attrs);
-          });
+        const allSearchableLayers = this.getAllLayers().filter(
+          (layer) => typeof layer.getFeatureById === "function",
+        );
+        if (!allSearchableLayers.length) return;
+
+        allSearchableLayers.forEach((layer) => {
+          if (layer.get("status") !== "ready") {
+            // Wait for entities/tileset root to load, then try synchronous search.
+            // For tilesets, also register tile-level waiting after root is ready.
+            this.listenTo(layer, "change:status", () => {
+              if (layer.get("status") !== "ready") return;
+              this.stopListening(layer, "change:status");
+              selectIfFound();
+              if (typeof layer.waitForFeatureById === "function") {
+                activeFeatureIds.forEach((id) =>
+                  layer.waitForFeatureById(id, () => selectIfFound()),
+                );
+              }
+            });
+          } else if (typeof layer.waitForFeatureById === "function") {
+            // Tileset root is already ready; specific building tile may not be
+            // rendered yet — subscribe to tileVisible for deferred lookup.
+            activeFeatureIds.forEach((id) =>
+              layer.waitForFeatureById(id, () => selectIfFound()),
+            );
+          }
         });
       },
 

--- a/src/js/models/maps/Map.js
+++ b/src/js/models/maps/Map.js
@@ -5,6 +5,7 @@ define([
   "underscore",
   "backbone",
   "collections/maps/MapAssets",
+  "models/maps/ActiveFeatureRestoreController",
   "models/maps/MapInteraction",
   "collections/maps/AssetCategories",
   "collections/maps/viewfinder/ViewfinderCardCategories",
@@ -14,6 +15,7 @@ define([
   _,
   Backbone,
   MapAssets,
+  ActiveFeatureRestoreController,
   Interactions,
   AssetCategories,
   ViewfinderCardCategories,
@@ -166,43 +168,6 @@ define([
       typeof position.latitude === "number" &&
       typeof position.height === "number"
     );
-  }
-
-  /**
-   * Extract a feature id from either a Feature model or plain attrs object.
-   * @param {Backbone.Model|object} feature Feature model or attrs object.
-   * @returns {string|undefined} Stable feature id when present.
-   * @since 0.0.0
-   */
-  function getFeatureId(feature) {
-    if (feature instanceof Backbone.Model) {
-      return feature.get("featureID");
-    }
-    return feature?.featureID;
-  }
-
-  /**
-   * Merge current and newly found features without duplicating feature ids.
-   * @param {Array<Backbone.Model|object>} currentFeatures Currently selected features.
-   * @param {Array<Backbone.Model|object>} newFeatures Newly resolved features.
-   * @returns {Array<Backbone.Model|object>} Merged feature list.
-   * @since 0.0.0
-   */
-  function mergeFeatureSelections(currentFeatures = [], newFeatures = []) {
-    const merged = [];
-    const seenIds = new Set();
-
-    currentFeatures.concat(newFeatures).forEach((feature) => {
-      if (!feature) return;
-      const featureId = getFeatureId(feature);
-      if (typeof featureId === "string" && featureId.length) {
-        if (seenIds.has(featureId)) return;
-        seenIds.add(featureId);
-      }
-      merged.push(feature);
-    });
-
-    return merged;
   }
 
   /**
@@ -573,6 +538,9 @@ define([
         this.debouncedUpdateSearchParams = _.debounce(() => {
           this.updateSearchParams();
         }, 150 /* milliseconds */);
+        this.featureRestoreController = new ActiveFeatureRestoreController({
+          mapModel: this,
+        });
         this.featureRestoreSession = null;
         this.setUpUrlStateListeners();
         this.applyRestoreState();
@@ -762,18 +730,9 @@ define([
       syncSelectedFeaturesToUrl() {
         if (!this.shouldSyncUrlState()) return;
         const selectedIds = this.getSelectedFeatureIdsForUrlState();
-        const restoringIds = this.featureRestoreSession?.requestedIds;
-
-        if (restoringIds?.length) {
-          const mergedIds = restoringIds.slice();
-          selectedIds.forEach((id) => {
-            if (!mergedIds.includes(id)) mergedIds.push(id);
-          });
-          SearchParams.updateActiveFeatureIds(mergedIds);
-          return;
-        }
-
-        SearchParams.updateActiveFeatureIds(selectedIds);
+        SearchParams.updateActiveFeatureIds(
+          this.featureRestoreController.getRequestedIdsForUrlSync(selectedIds),
+        );
       },
 
       /**
@@ -781,60 +740,7 @@ define([
        * @since 0.0.0
        */
       clearFeatureRestoreSession() {
-        const session = this.featureRestoreSession;
-        if (!session) return;
-
-        this.featureRestoreSession = null;
-        session.cancelers.forEach((cancel) => {
-          if (typeof cancel === "function") cancel();
-        });
-      },
-
-      /**
-       * Start a new feature restore session, canceling any previous one.
-       * @param {string[]} activeFeatureIds The ids being restored.
-       * @returns {object} The active restore session.
-       * @since 0.0.0
-       */
-      beginFeatureRestoreSession(activeFeatureIds) {
-        const sessionKey = activeFeatureIds.join(",");
-        if (this.featureRestoreSession?.key === sessionKey) {
-          return this.featureRestoreSession;
-        }
-
-        this.clearFeatureRestoreSession();
-        this.featureRestoreSession = {
-          cancelers: [],
-          key: sessionKey,
-          requestedIds: activeFeatureIds.slice(),
-        };
-        return this.featureRestoreSession;
-      },
-
-      /**
-       * Track a cancel function for in-flight feature restore waiting.
-       * @param {Function} cancel Cancel function returned by a waiter.
-       * @param {object} session The restore session that owns the waiter.
-       * @since 0.0.0
-       */
-      addFeatureRestoreWaiter(cancel, session = this.featureRestoreSession) {
-        if (typeof cancel !== "function" || !session) return;
-        if (this.featureRestoreSession !== session) {
-          cancel();
-          return;
-        }
-
-        session.cancelers.push(cancel);
-      },
-
-      /**
-       * Check whether a restore session is still active.
-       * @param {object} session The restore session to check.
-       * @returns {boolean} True if the session is still current.
-       * @since 0.0.0
-       */
-      isActiveFeatureRestoreSession(session) {
-        return this.featureRestoreSession === session;
+        this.featureRestoreController.clearSession();
       },
 
       /**
@@ -882,171 +788,7 @@ define([
        * @since 0.0.0
        */
       applyFeatureRestoreState() {
-        if (!this.shouldSyncUrlState()) {
-          this.clearFeatureRestoreSession();
-          return;
-        }
-        const restoreState = this.get("restoreState") || {};
-        const activeFeatureIds = restoreState.activeFeatureIds || [];
-        if (!activeFeatureIds.length) {
-          this.clearFeatureRestoreSession();
-          return;
-        }
-
-        const selectedFeatures = this.getSelectedFeatures();
-        const selectedRequestedIds = (selectedFeatures?.models || [])
-          .map((feature) => getFeatureId(feature))
-          .filter((id) => activeFeatureIds.includes(id));
-        const allSearchableLayers = this.getAllLayers().filter(
-          (layer) => typeof layer.getFeatureById === "function",
-        );
-        const featureAttrs = this.findFeatureAttributesByIds(activeFeatureIds);
-        const resolvedIds = new Set(selectedRequestedIds);
-        featureAttrs.forEach((feature) => {
-          const featureId = getFeatureId(feature);
-          if (typeof featureId === "string" && featureId.length) {
-            resolvedIds.add(featureId);
-          }
-        });
-        const unresolvedIds = activeFeatureIds.filter(
-          (id) => !resolvedIds.has(id),
-        );
-        const restoreKey = activeFeatureIds.join(",");
-        const canResolveAsynchronously = allSearchableLayers.some(
-          (layer) =>
-            layer.get("status") !== "ready" ||
-            typeof layer.waitForFeatureById === "function",
-        );
-        const existingSession = this.featureRestoreSession;
-        let restoreSession = existingSession;
-
-        if (
-          unresolvedIds.length &&
-          canResolveAsynchronously &&
-          existingSession?.key !== restoreKey
-        ) {
-          restoreSession = this.beginFeatureRestoreSession(activeFeatureIds);
-        }
-
-        if (featureAttrs.length) {
-          this.selectFeatures(
-            mergeFeatureSelections(selectedFeatures?.models || [], featureAttrs),
-          );
-        }
-
-        if (!unresolvedIds.length) {
-          this.clearFeatureRestoreSession();
-          return;
-        }
-
-        if (!canResolveAsynchronously) {
-          this.clearFeatureRestoreSession();
-          this.syncSelectedFeaturesToUrl();
-          return;
-        }
-
-        if (this.featureRestoreSession?.key === restoreKey) {
-          if (existingSession?.key === restoreKey) return;
-        }
-        const mapModel = this;
-
-        const selectIfFound = () => {
-          if (!mapModel.isActiveFeatureRestoreSession(restoreSession)) return;
-          const selectedIds = (mapModel.getSelectedFeatures()?.models || [])
-            .map((feature) => getFeatureId(feature))
-            .filter((id) => activeFeatureIds.includes(id));
-          const selectedIdSet = new Set(selectedIds);
-          if (activeFeatureIds.every((id) => selectedIdSet.has(id))) {
-            mapModel.clearFeatureRestoreSession();
-            return;
-          }
-          const attrs = mapModel.findFeatureAttributesByIds(activeFeatureIds);
-          if (attrs.length) {
-            mapModel.selectFeatures(
-              mergeFeatureSelections(
-                mapModel.getSelectedFeatures()?.models || [],
-                attrs,
-              ),
-            );
-          }
-
-          const resolvedAfterRetry = new Set(
-            (mapModel.getSelectedFeatures()?.models || [])
-              .map((feature) => getFeatureId(feature))
-              .filter((id) => activeFeatureIds.includes(id)),
-          );
-          if (activeFeatureIds.every((id) => resolvedAfterRetry.has(id))) {
-            mapModel.clearFeatureRestoreSession();
-          }
-        };
-
-        const registerTileWaiters = (layer) => {
-          if (!mapModel.isActiveFeatureRestoreSession(restoreSession)) return;
-          if (typeof layer.waitForFeatureById !== "function") return;
-          const missingIds = activeFeatureIds.filter((id) => {
-            const selectedId = (mapModel.getSelectedFeatures()?.models || [])
-              .map((feature) => getFeatureId(feature));
-            return !selectedId.includes(id);
-          });
-          missingIds.forEach((id) => {
-            const cancel = layer.waitForFeatureById(id, () => selectIfFound());
-            mapModel.addFeatureRestoreWaiter(cancel, restoreSession);
-          });
-        };
-
-        if (!allSearchableLayers.length) return;
-
-        allSearchableLayers.forEach((layer) => {
-          if (layer.get("status") !== "ready") {
-            // Wait for entities/tileset root to load, then try synchronous search.
-            // For tilesets, also register tile-level waiting after root is ready.
-            const statusListener = () => {
-              if (!mapModel.isActiveFeatureRestoreSession(restoreSession)) {
-                this.stopListening(layer, "change:status", statusListener);
-                return;
-              }
-              if (layer.get("status") !== "ready") return;
-              this.stopListening(layer, "change:status", statusListener);
-              selectIfFound();
-              registerTileWaiters(layer);
-            };
-            this.listenTo(layer, "change:status", statusListener);
-            this.addFeatureRestoreWaiter(() => {
-              this.stopListening(layer, "change:status", statusListener);
-            }, restoreSession);
-          } else if (typeof layer.waitForFeatureById === "function") {
-            // Tileset root is already ready; specific building tile may not be
-            // rendered yet — subscribe to tileVisible for deferred lookup.
-            registerTileWaiters(layer);
-          }
-        });
-      },
-
-      /**
-       * Search all layers for features matching the given ids and return
-       * feature attribute objects ready to be passed to selectFeatures().
-       * @param {string[]} ids Feature ids to search for.
-       * @returns {object[]} Matching feature attribute objects.
-       * @since 0.0.0
-       */
-      findFeatureAttributesByIds(ids) {
-        const allLayers = this.getAllLayers();
-
-        return ids.reduce((result, id) => {
-          const featureAttrs = allLayers.reduce((foundAttrs, layer) => {
-            if (foundAttrs || typeof layer.getFeatureById !== "function") {
-              return foundAttrs;
-            }
-
-            const feature = layer.getFeatureById(id);
-            if (!feature) return foundAttrs;
-
-            return layer.getFeatureAttributes(feature) || foundAttrs;
-          }, null);
-
-          if (featureAttrs) result.push(featureAttrs);
-          return result;
-        }, []);
+        this.featureRestoreController.applyRestoreState();
       },
 
       /**

--- a/src/js/models/maps/Map.js
+++ b/src/js/models/maps/Map.js
@@ -671,6 +671,39 @@ define([
             );
           }
         });
+
+        const selectedFeatures = interactions.get("selectedFeatures");
+        if (selectedFeatures) {
+          this.listenTo(
+            selectedFeatures,
+            "update",
+            this.syncSelectedFeaturesToUrl,
+          );
+        }
+      },
+
+      /**
+       * Get selected feature ids from the current map interaction state for URL
+       * state sync.
+       * @returns {string[]} Feature ids of all currently selected features.
+       * @since 0.0.0
+       */
+      getSelectedFeatureIdsForUrlState() {
+        const selectedFeatures = this.getSelectedFeatures();
+        return (selectedFeatures?.models || [])
+          .map((f) => f.get("featureID"))
+          .filter((id) => typeof id === "string" && id.length > 0);
+      },
+
+      /**
+       * Write the currently selected feature ids to the URL. Called when
+       * selectedFeatures changes. Managed independently from updateSearchParams
+       * so that camera/layer syncs cannot inadvertently clear the f param.
+       * @since 0.0.0
+       */
+      syncSelectedFeaturesToUrl() {
+        if (!this.shouldSyncUrlState()) return;
+        SearchParams.updateActiveFeatureIds(this.getSelectedFeatureIdsForUrlState());
       },
 
       /**
@@ -707,6 +740,78 @@ define([
         }
 
         SearchParams.updateStateInUrl(partialState);
+      },
+
+      /**
+       * Open the feature info panel for any feature ids stored in restoreState.
+       * Called after other state is restored so the feature panel appears last.
+       * Searches all map layers for a matching feature and selects it directly
+       * without simulating a user click. If entities are not yet loaded,
+       * waits for each layer's status to become 'ready' before retrying.
+       * @since 0.0.0
+       */
+      applyFeatureRestoreState() {
+        if (!this.shouldSyncUrlState()) return;
+        const restoreState = this.get("restoreState") || {};
+        const activeFeatureIds = restoreState.activeFeatureIds || [];
+        if (!activeFeatureIds.length) return;
+
+        const selectedFeatures = this.getSelectedFeatures();
+        const alreadySelected = selectedFeatures?.models.some((f) =>
+          activeFeatureIds.includes(f.get("featureID")),
+        );
+        if (alreadySelected) return;
+
+        const featureAttrs = this.findFeatureAttributesByIds(activeFeatureIds);
+        if (featureAttrs.length) {
+          this.selectFeatures(featureAttrs);
+          return;
+        }
+
+        // Entities not loaded yet — wait for each relevant layer to become ready
+        const pendingLayers = this.getAllLayers().filter(
+          (layer) =>
+            typeof layer.getFeatureById === "function" &&
+            layer.get("status") !== "ready",
+        );
+        if (!pendingLayers.length) return;
+
+        pendingLayers.forEach((layer) => {
+          this.listenTo(layer, "change:status", () => {
+            if (layer.get("status") !== "ready") return;
+            const attrs = this.findFeatureAttributesByIds(activeFeatureIds);
+            if (!attrs.length) return;
+            pendingLayers.forEach((l) => this.stopListening(l, "change:status"));
+            this.selectFeatures(attrs);
+          });
+        });
+      },
+
+      /**
+       * Search all layers for features matching the given ids and return
+       * feature attribute objects ready to be passed to selectFeatures().
+       * @param {string[]} ids Feature ids to search for.
+       * @returns {object[]} Matching feature attribute objects.
+       * @since 0.0.0
+       */
+      findFeatureAttributesByIds(ids) {
+        const allLayers = this.getAllLayers();
+
+        return ids.reduce((result, id) => {
+          const featureAttrs = allLayers.reduce((foundAttrs, layer) => {
+            if (foundAttrs || typeof layer.getFeatureById !== "function") {
+              return foundAttrs;
+            }
+
+            const feature = layer.getFeatureById(id);
+            if (!feature) return foundAttrs;
+
+            return layer.getFeatureAttributes(feature) || foundAttrs;
+          }, null);
+
+          if (featureAttrs) result.push(featureAttrs);
+          return result;
+        }, []);
       },
 
       /**

--- a/src/js/models/maps/Map.js
+++ b/src/js/models/maps/Map.js
@@ -536,6 +536,7 @@ define([
         this.debouncedUpdateSearchParams = _.debounce(() => {
           this.updateSearchParams();
         }, 150 /* milliseconds */);
+        this.featureRestoreSession = null;
         this.setUpUrlStateListeners();
         this.applyRestoreState();
       },
@@ -601,8 +602,10 @@ define([
       handleShowShareUrlChange(_model, showShareUrl) {
         if (showShareUrl) {
           this.applyRestoreState();
-          this.setUpUrlStateListeners();
+        } else {
+          this.clearFeatureRestoreSession();
         }
+        this.setUpUrlStateListeners();
       },
 
       /**
@@ -629,6 +632,7 @@ define([
        */
       setUpUrlStateListeners() {
         const interactions = this.get("interactions");
+        const selectedFeatures = interactions?.get("selectedFeatures");
 
         this.stopListening(
           this,
@@ -646,6 +650,22 @@ define([
           });
         }
         this.urlStateLayerGroups = [];
+
+        if (interactions) {
+          this.stopListening(
+            interactions,
+            "change:cameraPosition",
+            this.debouncedUpdateSearchParams,
+          );
+        }
+
+        if (selectedFeatures) {
+          this.stopListening(
+            selectedFeatures,
+            "update",
+            this.syncSelectedFeaturesToUrl,
+          );
+        }
 
         if (!this.shouldSyncUrlState() || !interactions) {
           return;
@@ -674,7 +694,6 @@ define([
           }
         });
 
-        const selectedFeatures = interactions.get("selectedFeatures");
         if (selectedFeatures) {
           this.listenTo(
             selectedFeatures,
@@ -706,6 +725,66 @@ define([
       syncSelectedFeaturesToUrl() {
         if (!this.shouldSyncUrlState()) return;
         SearchParams.updateActiveFeatureIds(this.getSelectedFeatureIdsForUrlState());
+      },
+
+      /**
+       * Cancel and clear any in-flight asynchronous feature restore waiters.
+       * @since 0.0.0
+       */
+      clearFeatureRestoreSession() {
+        const session = this.featureRestoreSession;
+        if (!session) return;
+
+        this.featureRestoreSession = null;
+        session.cancelers.forEach((cancel) => {
+          if (typeof cancel === "function") cancel();
+        });
+      },
+
+      /**
+       * Start a new feature restore session, canceling any previous one.
+       * @param {string[]} activeFeatureIds The ids being restored.
+       * @returns {object} The active restore session.
+       * @since 0.0.0
+       */
+      beginFeatureRestoreSession(activeFeatureIds) {
+        const sessionKey = activeFeatureIds.join(",");
+        if (this.featureRestoreSession?.key === sessionKey) {
+          return this.featureRestoreSession;
+        }
+
+        this.clearFeatureRestoreSession();
+        this.featureRestoreSession = {
+          cancelers: [],
+          key: sessionKey,
+        };
+        return this.featureRestoreSession;
+      },
+
+      /**
+       * Track a cancel function for in-flight feature restore waiting.
+       * @param {Function} cancel Cancel function returned by a waiter.
+       * @param {object} session The restore session that owns the waiter.
+       * @since 0.0.0
+       */
+      addFeatureRestoreWaiter(cancel, session = this.featureRestoreSession) {
+        if (typeof cancel !== "function" || !session) return;
+        if (this.featureRestoreSession !== session) {
+          cancel();
+          return;
+        }
+
+        session.cancelers.push(cancel);
+      },
+
+      /**
+       * Check whether a restore session is still active.
+       * @param {object} session The restore session to check.
+       * @returns {boolean} True if the session is still current.
+       * @since 0.0.0
+       */
+      isActiveFeatureRestoreSession(session) {
+        return this.featureRestoreSession === session;
       },
 
       /**
@@ -753,33 +832,64 @@ define([
        * @since 0.0.0
        */
       applyFeatureRestoreState() {
-        if (!this.shouldSyncUrlState()) return;
+        if (!this.shouldSyncUrlState()) {
+          this.clearFeatureRestoreSession();
+          return;
+        }
         const restoreState = this.get("restoreState") || {};
         const activeFeatureIds = restoreState.activeFeatureIds || [];
-        if (!activeFeatureIds.length) return;
+        if (!activeFeatureIds.length) {
+          this.clearFeatureRestoreSession();
+          return;
+        }
 
         const selectedFeatures = this.getSelectedFeatures();
         const alreadySelected = selectedFeatures?.models.some((f) =>
           activeFeatureIds.includes(f.get("featureID")),
         );
-        if (alreadySelected) return;
+        if (alreadySelected) {
+          this.clearFeatureRestoreSession();
+          return;
+        }
 
         const featureAttrs = this.findFeatureAttributesByIds(activeFeatureIds);
         if (featureAttrs.length) {
           this.selectFeatures(featureAttrs);
+          this.clearFeatureRestoreSession();
           return;
         }
 
+        const restoreKey = activeFeatureIds.join(",");
+        if (this.featureRestoreSession?.key === restoreKey) {
+          return;
+        }
+
+        const restoreSession = this.beginFeatureRestoreSession(activeFeatureIds);
         const mapModel = this;
+        const registerTileWaiters = (layer) => {
+          if (!mapModel.isActiveFeatureRestoreSession(restoreSession)) return;
+          if (typeof layer.waitForFeatureById !== "function") return;
+          activeFeatureIds.forEach((id) => {
+            const cancel = layer.waitForFeatureById(id, () => selectIfFound());
+            mapModel.addFeatureRestoreWaiter(cancel, restoreSession);
+          });
+        };
+
         const selectIfFound = () => {
+          if (!mapModel.isActiveFeatureRestoreSession(restoreSession)) return;
           if (
             mapModel
               .getSelectedFeatures()
               ?.models.some((f) => activeFeatureIds.includes(f.get("featureID")))
-          )
+          ) {
+            mapModel.clearFeatureRestoreSession();
             return;
+          }
           const attrs = mapModel.findFeatureAttributesByIds(activeFeatureIds);
-          if (attrs.length) mapModel.selectFeatures(attrs);
+          if (attrs.length) {
+            mapModel.selectFeatures(attrs);
+            mapModel.clearFeatureRestoreSession();
+          }
         };
 
         const allSearchableLayers = this.getAllLayers().filter(
@@ -791,22 +901,24 @@ define([
           if (layer.get("status") !== "ready") {
             // Wait for entities/tileset root to load, then try synchronous search.
             // For tilesets, also register tile-level waiting after root is ready.
-            this.listenTo(layer, "change:status", () => {
-              if (layer.get("status") !== "ready") return;
-              this.stopListening(layer, "change:status");
-              selectIfFound();
-              if (typeof layer.waitForFeatureById === "function") {
-                activeFeatureIds.forEach((id) =>
-                  layer.waitForFeatureById(id, () => selectIfFound()),
-                );
+            const statusListener = () => {
+              if (!mapModel.isActiveFeatureRestoreSession(restoreSession)) {
+                this.stopListening(layer, "change:status", statusListener);
+                return;
               }
-            });
+              if (layer.get("status") !== "ready") return;
+              this.stopListening(layer, "change:status", statusListener);
+              selectIfFound();
+              registerTileWaiters(layer);
+            };
+            this.listenTo(layer, "change:status", statusListener);
+            this.addFeatureRestoreWaiter(() => {
+              this.stopListening(layer, "change:status", statusListener);
+            }, restoreSession);
           } else if (typeof layer.waitForFeatureById === "function") {
             // Tileset root is already ready; specific building tile may not be
             // rendered yet — subscribe to tileVisible for deferred lookup.
-            activeFeatureIds.forEach((id) =>
-              layer.waitForFeatureById(id, () => selectIfFound()),
-            );
+            registerTileWaiters(layer);
           }
         });
       },

--- a/src/js/models/maps/Map.js
+++ b/src/js/models/maps/Map.js
@@ -724,7 +724,9 @@ define([
        */
       syncSelectedFeaturesToUrl() {
         if (!this.shouldSyncUrlState()) return;
-        SearchParams.updateActiveFeatureIds(this.getSelectedFeatureIdsForUrlState());
+        SearchParams.updateActiveFeatureIds(
+          this.getSelectedFeatureIdsForUrlState(),
+        );
       },
 
       /**
@@ -864,7 +866,8 @@ define([
           return;
         }
 
-        const restoreSession = this.beginFeatureRestoreSession(activeFeatureIds);
+        const restoreSession =
+          this.beginFeatureRestoreSession(activeFeatureIds);
         const mapModel = this;
         const registerTileWaiters = (layer) => {
           if (!mapModel.isActiveFeatureRestoreSession(restoreSession)) return;
@@ -880,7 +883,9 @@ define([
           if (
             mapModel
               .getSelectedFeatures()
-              ?.models.some((f) => activeFeatureIds.includes(f.get("featureID")))
+              ?.models.some((f) =>
+                activeFeatureIds.includes(f.get("featureID")),
+              )
           ) {
             mapModel.clearFeatureRestoreSession();
             return;

--- a/src/js/models/maps/Map.js
+++ b/src/js/models/maps/Map.js
@@ -869,14 +869,6 @@ define([
         const restoreSession =
           this.beginFeatureRestoreSession(activeFeatureIds);
         const mapModel = this;
-        const registerTileWaiters = (layer) => {
-          if (!mapModel.isActiveFeatureRestoreSession(restoreSession)) return;
-          if (typeof layer.waitForFeatureById !== "function") return;
-          activeFeatureIds.forEach((id) => {
-            const cancel = layer.waitForFeatureById(id, () => selectIfFound());
-            mapModel.addFeatureRestoreWaiter(cancel, restoreSession);
-          });
-        };
 
         const selectIfFound = () => {
           if (!mapModel.isActiveFeatureRestoreSession(restoreSession)) return;
@@ -895,6 +887,15 @@ define([
             mapModel.selectFeatures(attrs);
             mapModel.clearFeatureRestoreSession();
           }
+        };
+
+        const registerTileWaiters = (layer) => {
+          if (!mapModel.isActiveFeatureRestoreSession(restoreSession)) return;
+          if (typeof layer.waitForFeatureById !== "function") return;
+          activeFeatureIds.forEach((id) => {
+            const cancel = layer.waitForFeatureById(id, () => selectIfFound());
+            mapModel.addFeatureRestoreWaiter(cancel, restoreSession);
+          });
         };
 
         const allSearchableLayers = this.getAllLayers().filter(

--- a/src/js/models/maps/assets/Cesium3DTileset.js
+++ b/src/js/models/maps/assets/Cesium3DTileset.js
@@ -405,21 +405,34 @@ define([
         const model = this;
         const cesiumModel = model.get("cesiumModel");
         if (!cesiumModel) return () => {};
+
         let removeListener = null;
+        let isDone = false;
+
+        const cleanup = () => {
+          if (isDone) return;
+          isDone = true;
+          if (removeListener) removeListener();
+        };
+
         const tryTile = (tile) => {
+          if (isDone) return;
           if (!tile?.contentReady || !tile.content?.featuresLength) return;
+
           for (let i = 0; i < tile.content.featuresLength; i++) {
             const feature = tile.content.getFeature(i);
             if (propertyMatchesId(model.getPropertiesFromFeature(feature), id)) {
-              if (removeListener) removeListener();
+              cleanup();
               onFound(feature);
               return;
             }
           }
         };
+
         removeListener = cesiumModel.tileVisible.addEventListener(tryTile);
+
         return () => {
-          if (removeListener) removeListener();
+          cleanup();
         };
       },
 

--- a/src/js/models/maps/assets/Cesium3DTileset.js
+++ b/src/js/models/maps/assets/Cesium3DTileset.js
@@ -5,7 +5,8 @@ define([
   "models/maps/assets/MapAsset",
   "models/maps/AssetColorPalette",
   "collections/maps/VectorFilters",
-], function (Cesium, MapAsset, AssetColorPalette, VectorFilters) {
+  "models/maps/featureIdHelpers",
+], function (Cesium, MapAsset, AssetColorPalette, VectorFilters, { getIdFromProperties, propertyMatchesId }) {
   // Don't allow full 1 opacity for Cesium 3D tiles. Otherwise, overlapping
   // polygons will not render correctly, and will cause z-fighting. 0.996 shows
   // as 100% in the slider, but 0.999 still results in z-fighting.
@@ -357,7 +358,69 @@ define([
        */
       getIDFromFeature: function (feature) {
         if (!this.usesFeatureType(feature)) return null;
-        return feature.pickId ? feature.pickId.key : null;
+        // Use property-based ID; pickId.key is a session-scoped number that gets
+        // filtered out of URL state by the typeof === 'string' guard.
+        return getIdFromProperties(this.getPropertiesFromFeature(feature));
+      },
+
+      /**
+       * Search all currently-loaded tile content for a feature whose property
+       * value (checked against the same key priority as getIDFromFeature) matches
+       * the given id string.
+       * @param {string} id The stable property-based feature ID.
+       * @returns {Cesium.Cesium3DTileFeature|null} The matching feature, or null.
+       * @since 0.0.0
+       */
+      getFeatureById: function (id) {
+        const cesiumModel = this.get("cesiumModel");
+        if (!cesiumModel?.root) return null;
+        let found = null;
+        const searchTile = (tile) => {
+          if (found || !tile) return;
+          if (tile.contentReady && tile.content?.featuresLength > 0) {
+            for (let i = 0; i < tile.content.featuresLength; i++) {
+              const feature = tile.content.getFeature(i);
+              if (propertyMatchesId(this.getPropertiesFromFeature(feature), id)) {
+                found = feature;
+                return;
+              }
+            }
+          }
+          tile.children?.forEach(searchTile);
+        };
+        searchTile(cesiumModel.root);
+        return found;
+      },
+
+      /**
+       * Subscribe to the tileset's tileVisible event and call onFound the first
+       * time a tile is rendered that contains a feature matching the given id.
+       * Searches only the newly-visible tile on each event for efficiency.
+       * @param {string} id The stable property-based feature ID.
+       * @param {Function} onFound Callback invoked with the Cesium3DTileFeature.
+       * @returns {Function} Cancel function that removes the tileVisible listener.
+       * @since 0.0.0
+       */
+      waitForFeatureById: function (id, onFound) {
+        const model = this;
+        const cesiumModel = model.get("cesiumModel");
+        if (!cesiumModel) return () => {};
+        let removeListener = null;
+        const tryTile = (tile) => {
+          if (!tile?.contentReady || !tile.content?.featuresLength) return;
+          for (let i = 0; i < tile.content.featuresLength; i++) {
+            const feature = tile.content.getFeature(i);
+            if (propertyMatchesId(model.getPropertiesFromFeature(feature), id)) {
+              if (removeListener) removeListener();
+              onFound(feature);
+              return;
+            }
+          }
+        };
+        removeListener = cesiumModel.tileVisible.addEventListener(tryTile);
+        return () => {
+          if (removeListener) removeListener();
+        };
       },
 
       /**

--- a/src/js/models/maps/assets/Cesium3DTileset.js
+++ b/src/js/models/maps/assets/Cesium3DTileset.js
@@ -6,7 +6,13 @@ define([
   "models/maps/AssetColorPalette",
   "collections/maps/VectorFilters",
   "models/maps/featureIdHelpers",
-], function (Cesium, MapAsset, AssetColorPalette, VectorFilters, { getIdFromProperties, propertyMatchesId }) {
+], function (
+  Cesium,
+  MapAsset,
+  AssetColorPalette,
+  VectorFilters,
+  { getIdFromProperties, propertyMatchesId },
+) {
   // Don't allow full 1 opacity for Cesium 3D tiles. Otherwise, overlapping
   // polygons will not render correctly, and will cause z-fighting. 0.996 shows
   // as 100% in the slider, but 0.999 still results in z-fighting.
@@ -380,7 +386,9 @@ define([
           if (tile.contentReady && tile.content?.featuresLength > 0) {
             for (let i = 0; i < tile.content.featuresLength; i++) {
               const feature = tile.content.getFeature(i);
-              if (propertyMatchesId(this.getPropertiesFromFeature(feature), id)) {
+              if (
+                propertyMatchesId(this.getPropertiesFromFeature(feature), id)
+              ) {
                 found = feature;
                 return;
               }
@@ -421,7 +429,9 @@ define([
 
           for (let i = 0; i < tile.content.featuresLength; i++) {
             const feature = tile.content.getFeature(i);
-            if (propertyMatchesId(model.getPropertiesFromFeature(feature), id)) {
+            if (
+              propertyMatchesId(model.getPropertiesFromFeature(feature), id)
+            ) {
               cleanup();
               onFound(feature);
               return;

--- a/src/js/models/maps/assets/CesiumVectorData.js
+++ b/src/js/models/maps/assets/CesiumVectorData.js
@@ -318,8 +318,8 @@ define([
         return (
           (this.getEntities() || []).find((entity) =>
             propertyMatchesId(this.getPropertiesFromFeature(entity), id),
-        ) ??
-        this.getEntityCollection()?.getById(id) ??
+          ) ??
+          this.getEntityCollection()?.getById(id) ??
           null
         );
       },

--- a/src/js/models/maps/assets/CesiumVectorData.js
+++ b/src/js/models/maps/assets/CesiumVectorData.js
@@ -316,10 +316,10 @@ define([
        */
       getFeatureById: function (id) {
         return (
-          this.getEntityCollection()?.getById(id) ??
           (this.getEntities() || []).find((entity) =>
             propertyMatchesId(this.getPropertiesFromFeature(entity), id),
-          ) ??
+        ) ??
+        this.getEntityCollection()?.getById(id) ??
           null
         );
       },

--- a/src/js/models/maps/assets/CesiumVectorData.js
+++ b/src/js/models/maps/assets/CesiumVectorData.js
@@ -401,6 +401,22 @@ define([
       getIDFromFeature: function (feature) {
         feature = this.getEntityFromMapObject(feature);
         if (!feature) return null;
+        // Prefer a stable property-based ID over Cesium's auto-generated entity
+        // UUID (which changes on every page load). This ensures that feature IDs
+        // encoded in the URL remain valid across sessions.
+        const props = this.getPropertiesFromFeature(feature);
+        // Only use properties that are intended as unique identifiers
+        const idKeys = ["id", "identifier"];
+        const propsLower = {};
+        Object.keys(props || {}).forEach((k) => {
+          propsLower[k.toLowerCase()] = props[k];
+        });
+        for (let i = 0; i < idKeys.length; i++) {
+          const val = propsLower[idKeys[i]];
+          if (val != null && String(val).trim().length > 0) {
+            return String(val);
+          }
+        }
         return feature.id;
       },
 

--- a/src/js/models/maps/assets/CesiumVectorData.js
+++ b/src/js/models/maps/assets/CesiumVectorData.js
@@ -8,6 +8,7 @@ define([
   "models/maps/AssetColorPalette",
   "collections/maps/VectorFilters",
   "common/IconUtilities",
+  "models/maps/featureIdHelpers",
 ], function (
   _,
   Cesium,
@@ -16,6 +17,7 @@ define([
   AssetColorPalette,
   VectorFilters,
   IconUtilities,
+  { getIdFromProperties, propertyMatchesId },
 ) {
   // Source: https://fontawesome.com/v6/icons/location-dot?f=classic&s=solid
   const PIN_SVG_STRING =
@@ -313,26 +315,13 @@ define([
        * @since 2.35.0
        */
       getFeatureById: function (id) {
-        let feature = this.getEntityCollection()?.getById(id);
-        if (!feature) {
-          // get the propreties of all entities and see if any have an id
-          const entities = this.getEntities() || [];
-          for (let x = 0; x < entities.length; x++) {
-            const props = this.getPropertiesFromFeature(entities[x]);
-            const keys = Object.keys(props || {});
-            const keysLower = keys.map((k) => k.toLowerCase());
-            const keysToCheck = ["id", "identifier", "name", "title", "label"];
-            for (let y = 0; y < keysToCheck.length; y++) {
-              const index = keysLower.indexOf(keysToCheck[y]);
-              if (index > -1 && props[keys[index]] == id) {
-                feature = entities[x];
-                break;
-              }
-            }
-            if (feature) break;
-          }
-        }
-        return feature;
+        return (
+          this.getEntityCollection()?.getById(id) ??
+          (this.getEntities() || []).find((entity) =>
+            propertyMatchesId(this.getPropertiesFromFeature(entity), id),
+          ) ??
+          null
+        );
       },
 
       /**
@@ -402,22 +391,11 @@ define([
         feature = this.getEntityFromMapObject(feature);
         if (!feature) return null;
         // Prefer a stable property-based ID over Cesium's auto-generated entity
-        // UUID (which changes on every page load). This ensures that feature IDs
-        // encoded in the URL remain valid across sessions.
-        const props = this.getPropertiesFromFeature(feature);
-        // Only use properties that are intended as unique identifiers
-        const idKeys = ["id", "identifier"];
-        const propsLower = {};
-        Object.keys(props || {}).forEach((k) => {
-          propsLower[k.toLowerCase()] = props[k];
-        });
-        for (let i = 0; i < idKeys.length; i++) {
-          const val = propsLower[idKeys[i]];
-          if (val != null && String(val).trim().length > 0) {
-            return String(val);
-          }
-        }
-        return feature.id;
+        // UUID (which changes on every page load).
+        return (
+          getIdFromProperties(this.getPropertiesFromFeature(feature)) ??
+          feature.id
+        );
       },
 
       /**

--- a/src/js/models/maps/featureIdHelpers.js
+++ b/src/js/models/maps/featureIdHelpers.js
@@ -1,0 +1,64 @@
+"use strict";
+
+/**
+ * Pure helpers for extracting stable identifiers from feature property objects.
+ * Used by map asset models (CesiumVectorData, Cesium3DTileset) to encode feature
+ * IDs in the URL and restore them on page load.
+ * @module featureIdHelpers
+ * @classcategory Models/Maps
+ * @since 0.0.0
+ */
+define([], () => {
+  /** Property keys checked in priority order when deriving a stable feature ID. */
+  const FEATURE_ID_KEYS = [
+    "id",
+    "identifier",
+    "uuid",
+    "name",
+    "title",
+    "label",
+  ];
+
+  /** 
+   * Convert all keys in an object to lowercase.
+   * @param {object} props The object to convert.
+   * @returns {object} copy with all keys lowercased 
+   */
+  function toLowerCaseProps(props) {
+    const lower = {};
+    Object.keys(props || {}).forEach((k) => {
+      lower[k.toLowerCase()] = props[k];
+    });
+    return lower;
+  }
+
+  /**
+   * Return the first non-empty string value found under a FEATURE_ID_KEYS key.
+   * @param {object} props Feature properties (any key casing).
+   * @returns {string|null} The feature ID, or null if none is found.
+   */
+  function getIdFromProperties(props) {
+    const lower = toLowerCaseProps(props);
+    const key = FEATURE_ID_KEYS.find((k) => {
+      const val = lower[k];
+      return val != null && String(val).trim().length > 0;
+    });
+    return key != null ? String(lower[key]) : null;
+  }
+
+  /**
+   * Return true if any FEATURE_ID_KEYS property in props equals id.
+   * @param {object} props Feature properties (any key casing).
+   * @param {string} id The feature ID to match.
+   * @returns {boolean} True if a match is found, false otherwise.
+   */
+  function propertyMatchesId(props, id) {
+    const lower = toLowerCaseProps(props);
+    return FEATURE_ID_KEYS.some((key) => {
+      const val = lower[key];
+      return val != null && String(val) === id;
+    });
+  }
+
+  return { FEATURE_ID_KEYS, getIdFromProperties, propertyMatchesId };
+});

--- a/src/js/models/maps/featureIdHelpers.js
+++ b/src/js/models/maps/featureIdHelpers.js
@@ -43,7 +43,7 @@ define([], () => {
       const val = lower[k];
       return val != null && String(val).trim().length > 0;
     });
-    return key != null ? String(lower[key]) : null;
+    return key != null ? String(lower[key]).trim() : null;
   }
 
   /**
@@ -53,10 +53,15 @@ define([], () => {
    * @returns {boolean} True if a match is found, false otherwise.
    */
   function propertyMatchesId(props, id) {
+    const normalizedId = id != null ? String(id).trim() : "";
+    if (!normalizedId) {
+      return false;
+    }
+
     const lower = toLowerCaseProps(props);
     return FEATURE_ID_KEYS.some((key) => {
       const val = lower[key];
-      return val != null && String(val) === id;
+      return val != null && String(val).trim() === normalizedId;
     });
   }
 

--- a/src/js/models/maps/featureIdHelpers.js
+++ b/src/js/models/maps/featureIdHelpers.js
@@ -47,7 +47,7 @@ define([], () => {
   }
 
   /**
-   * Return true if any FEATURE_ID_KEYS property in props equals id.
+   * Return true if props resolves to the same canonical ID as id.
    * @param {object} props Feature properties (any key casing).
    * @param {string} id The feature ID to match.
    * @returns {boolean} True if a match is found, false otherwise.
@@ -58,11 +58,7 @@ define([], () => {
       return false;
     }
 
-    const lower = toLowerCaseProps(props);
-    return FEATURE_ID_KEYS.some((key) => {
-      const val = lower[key];
-      return val != null && String(val).trim() === normalizedId;
-    });
+    return getIdFromProperties(props) === normalizedId;
   }
 
   return { FEATURE_ID_KEYS, getIdFromProperties, propertyMatchesId };

--- a/src/js/models/maps/featureIdHelpers.js
+++ b/src/js/models/maps/featureIdHelpers.js
@@ -19,10 +19,10 @@ define([], () => {
     "label",
   ];
 
-  /** 
+  /**
    * Convert all keys in an object to lowercase.
    * @param {object} props The object to convert.
-   * @returns {object} copy with all keys lowercased 
+   * @returns {object} copy with all keys lowercased
    */
   function toLowerCaseProps(props) {
     const lower = {};

--- a/src/js/models/maps/featureIdHelpers.js
+++ b/src/js/models/maps/featureIdHelpers.js
@@ -61,5 +61,9 @@ define([], () => {
     return getIdFromProperties(props) === normalizedId;
   }
 
-  return { FEATURE_ID_KEYS, getIdFromProperties, propertyMatchesId };
+  return {
+    FEATURE_ID_KEYS,
+    getIdFromProperties,
+    propertyMatchesId,
+  };
 });

--- a/src/js/views/maps/FeatureInfoView.js
+++ b/src/js/views/maps/FeatureInfoView.js
@@ -213,6 +213,11 @@ define([
           zoomButton: view.el.querySelector(`.${classes.zoomButton}`),
         };
 
+        // Start collapsed so the panel does not flash at the browser's default
+        // iframe height before content is rendered.
+        iFrame.style.height = 0;
+        iFrame.style.opacity = 0;
+
         view.update();
 
         // Ensure the view's main element has the given class name
@@ -226,8 +231,11 @@ define([
 
       /**
        * Updates the view with information from the current Feature model
+       * @param {object} [options] - Options that control content update behavior
+       * @param {boolean} [options.collapseBeforeLoad] - Whether to collapse the
+       * content iframe before loading new content
        */
-      updateContent() {
+      updateContent({ collapseBeforeLoad = false } = {}) {
         const view = this;
 
         // Elements to update
@@ -250,11 +258,18 @@ define([
         // Insert the title into the title element
         this.elements.title.innerHTML = title;
 
+        // Collapse only when opening from a closed state. When switching between
+        // selected features, keep the current height and transition directly to the
+        // new content height.
+        if (collapseBeforeLoad) {
+          iFrame.style.height = 0;
+          iFrame.style.opacity = 0;
+        }
+
         // Update the iFrame content
         this.getContent().then((html) => {
           iFrameDiv.innerHTML = html;
-          iFrame.style.height = 0;
-          iFrame.style.opacity = 0;
+          iFrame.style.opacity = 1;
           // Not the ideal solution, but check the height of the iFrame
           // again after some time to allow external content to load. This
           // is necessary for content that loads asynchronously, like
@@ -478,8 +493,9 @@ define([
             this.close();
           }
         } else {
+          const wasOpen = this.isOpen;
           this.open();
-          this.updateContent();
+          this.updateContent({ collapseBeforeLoad: !wasOpen });
         }
       },
 

--- a/src/js/views/maps/FeatureInfoView.js
+++ b/src/js/views/maps/FeatureInfoView.js
@@ -136,6 +136,20 @@ define([
       isOpen: false,
 
       /**
+       * Collapses the iframe by setting its height to 0 and opacity to 0. 
+       * This is used when the feature info box opens for the first time so
+       * the iFrame doesn't flash empty before it's ready.
+       * @since 0.0.0
+       */
+      collapseiFrame() { 
+        const iFrame = this.elements?.iFrame;
+        if (iFrame) {
+          iFrame.style.height = "0";
+          iFrame.style.opacity = "0";
+        }
+      },
+
+      /**
        * Executed when a new FeatureInfoView is created
        * @param {object} [options] - A literal object with options to pass to the view
        */
@@ -216,8 +230,7 @@ define([
 
         // Start collapsed so the panel does not flash at the browser's default
         // iframe height before content is rendered.
-        iFrame.style.height = 0;
-        iFrame.style.opacity = 0;
+        this.collapseiFrame()
 
         view.update();
 
@@ -263,8 +276,7 @@ define([
         // selected features, keep the current height and transition directly to the
         // new content height.
         if (collapseBeforeLoad) {
-          iFrame.style.height = 0;
-          iFrame.style.opacity = 0;
+          this.collapseiFrame();
         }
 
         // Update the iFrame content
@@ -278,7 +290,7 @@ define([
           // may be from a different domain.
           setTimeout(() => {
             view.updateIFrameHeight();
-          }, 500);
+          }, 250);
         });
 
         // Show or hide the layer details button, update the text

--- a/src/js/views/maps/FeatureInfoView.js
+++ b/src/js/views/maps/FeatureInfoView.js
@@ -136,12 +136,12 @@ define([
       isOpen: false,
 
       /**
-       * Collapses the iframe by setting its height to 0 and opacity to 0. 
+       * Collapses the iframe by setting its height to 0 and opacity to 0.
        * This is used when the feature info box opens for the first time so
        * the iFrame doesn't flash empty before it's ready.
        * @since 0.0.0
        */
-      collapseiFrame() { 
+      collapseiFrame() {
         const iFrame = this.elements?.iFrame;
         if (iFrame) {
           iFrame.style.height = "0";
@@ -230,7 +230,7 @@ define([
 
         // Start collapsed so the panel does not flash at the browser's default
         // iframe height before content is rendered.
-        this.collapseiFrame()
+        this.collapseiFrame();
 
         view.update();
 
@@ -409,9 +409,7 @@ define([
           if (!name) {
             title = "Feature";
 
-            const searchKeys = FEATURE_ID_KEYS.map((key) =>
-              key.toLowerCase(),
-            );
+            const searchKeys = FEATURE_ID_KEYS.map((key) => key.toLowerCase());
             const propKeys = Object.keys(properties);
             const propKeysLower = propKeys.map((key) => key.toLowerCase());
 

--- a/src/js/views/maps/FeatureInfoView.js
+++ b/src/js/views/maps/FeatureInfoView.js
@@ -396,7 +396,14 @@ define([
           if (!name) {
             title = "Feature";
 
-            let searchKeys = ["name", "title", "label", "uuid", "id", "identifier"];
+            let searchKeys = [
+              "name",
+              "title",
+              "label",
+              "uuid",
+              "id",
+              "identifier",
+            ];
             searchKeys = searchKeys.map((key) => key.toLowerCase());
             const propKeys = Object.keys(properties);
             const propKeysLower = propKeys.map((key) => key.toLowerCase());

--- a/src/js/views/maps/FeatureInfoView.js
+++ b/src/js/views/maps/FeatureInfoView.js
@@ -381,7 +381,7 @@ define([
           if (!name) {
             title = "Feature";
 
-            let searchKeys = ["name", "title", "id", "identifier"];
+            let searchKeys = ["name", "title", "label", "uuid", "id", "identifier"];
             searchKeys = searchKeys.map((key) => key.toLowerCase());
             const propKeys = Object.keys(properties);
             const propKeysLower = propKeys.map((key) => key.toLowerCase());

--- a/src/js/views/maps/FeatureInfoView.js
+++ b/src/js/views/maps/FeatureInfoView.js
@@ -5,8 +5,9 @@ define([
   "underscore",
   "backbone",
   "models/maps/Feature",
+  "models/maps/featureIdHelpers",
   "text!templates/maps/feature-info/feature-info.html",
-], ($, _, Backbone, Feature, Template) => {
+], ($, _, Backbone, Feature, { FEATURE_ID_KEYS }, Template) => {
   /**
    * @class FeatureInfoView
    * @classdesc An info-box / panel that shows more details about a specific geo-spatial
@@ -396,15 +397,9 @@ define([
           if (!name) {
             title = "Feature";
 
-            let searchKeys = [
-              "name",
-              "title",
-              "label",
-              "uuid",
-              "id",
-              "identifier",
-            ];
-            searchKeys = searchKeys.map((key) => key.toLowerCase());
+            const searchKeys = FEATURE_ID_KEYS.map((key) =>
+              key.toLowerCase(),
+            );
             const propKeys = Object.keys(properties);
             const propKeysLower = propKeys.map((key) => key.toLowerCase());
 

--- a/test/config/tests.json
+++ b/test/config/tests.json
@@ -70,6 +70,7 @@
     "./js/specs/unit/models/connectors/GeoPoints-CesiumPolygon.spec.js",
     "./js/specs/unit/models/maps/GeoBoundingBox.spec.js",
     "./js/specs/unit/models/maps/GeoUtilities.spec.js",
+    "./js/specs/unit/models/maps/featureIdHelpers.spec.js",
     "./js/specs/unit/models/maps/MapInteraction.spec.js",
     "./js/specs/unit/models/connectors/Filters-Map.spec.js",
     "./js/specs/unit/models/connectors/Filters-Search.spec.js",

--- a/test/js/specs/unit/common/SearchParams.spec.js
+++ b/test/js/specs/unit/common/SearchParams.spec.js
@@ -479,8 +479,8 @@ define(["common/SearchParams"], (SearchParams) => {
         expect(state.activeFeatureIds).to.deep.equal([]);
       });
 
-      it("parses multiple feature ids from comma-separated f param", () => {
-        window.history.replaceState(null, "", "?sv=1&f=id-one,id-two,id-three");
+      it("parses repeated f params as activeFeatureIds when sv=1", () => {
+        window.history.replaceState(null, "", "?sv=1&f=id-one&f=id-two&f=id-three");
 
         const state = SearchParams.parseStateFromUrl();
         expect(state.activeFeatureIds).to.deep.equal([
@@ -490,21 +490,30 @@ define(["common/SearchParams"], (SearchParams) => {
         ]);
       });
 
-      it("writes activeFeatureIds as f param and bumps schema to 1", () => {
+      it("writes activeFeatureIds as repeated f params and bumps schema to 1", () => {
         SearchParams.updateStateInUrl({ activeFeatureIds: ["feat-xyz"] });
 
         const url = new URL(window.location.href);
-        expect(url.searchParams.get("f")).to.equal("feat-xyz");
+        expect(url.searchParams.getAll("f")).to.deep.equal(["feat-xyz"]);
         expect(url.searchParams.get("sv")).to.equal("1");
       });
 
-      it("writes multiple feature ids as comma-separated f param", () => {
+      it("writes multiple feature ids as repeated f params", () => {
         SearchParams.updateStateInUrl({
           activeFeatureIds: ["id-a", "id-b"],
         });
 
         const url = new URL(window.location.href);
-        expect(url.searchParams.get("f")).to.equal("id-a,id-b");
+        expect(url.searchParams.getAll("f")).to.deep.equal(["id-a", "id-b"]);
+      });
+
+      it("round-trips feature ids containing commas", () => {
+        SearchParams.updateStateInUrl({
+          activeFeatureIds: ["Washington, DC", "id-b"],
+        });
+
+        const state = SearchParams.parseStateFromUrl();
+        expect(state.activeFeatureIds).to.deep.equal(["Washington, DC", "id-b"]);
       });
 
       it("omits f param when activeFeatureIds is empty", () => {
@@ -538,7 +547,7 @@ define(["common/SearchParams"], (SearchParams) => {
 
         const url = new URL(window.location.href);
         expect(url.searchParams.get("unrelated")).to.equal("keep");
-        expect(url.searchParams.get("f")).to.equal("feat-1");
+        expect(url.searchParams.getAll("f")).to.deep.equal(["feat-1"]);
       });
 
       it("round-trips activeFeatureIds through updateStateInUrl and parseStateFromUrl", () => {

--- a/test/js/specs/unit/common/SearchParams.spec.js
+++ b/test/js/specs/unit/common/SearchParams.spec.js
@@ -466,11 +466,7 @@ define(["common/SearchParams"], (SearchParams) => {
       });
 
       it("parses f param as activeFeatureIds when sv=1", () => {
-        window.history.replaceState(
-          null,
-          "",
-          "?sv=1&f=feature-abc-123",
-        );
+        window.history.replaceState(null, "", "?sv=1&f=feature-abc-123");
 
         const state = SearchParams.parseStateFromUrl();
         expect(state.activeFeatureIds).to.deep.equal(["feature-abc-123"]);
@@ -484,14 +480,14 @@ define(["common/SearchParams"], (SearchParams) => {
       });
 
       it("parses multiple feature ids from comma-separated f param", () => {
-        window.history.replaceState(
-          null,
-          "",
-          "?sv=1&f=id-one,id-two,id-three",
-        );
+        window.history.replaceState(null, "", "?sv=1&f=id-one,id-two,id-three");
 
         const state = SearchParams.parseStateFromUrl();
-        expect(state.activeFeatureIds).to.deep.equal(["id-one", "id-two", "id-three"]);
+        expect(state.activeFeatureIds).to.deep.equal([
+          "id-one",
+          "id-two",
+          "id-three",
+        ]);
       });
 
       it("writes activeFeatureIds as f param and bumps schema to 1", () => {
@@ -546,7 +542,9 @@ define(["common/SearchParams"], (SearchParams) => {
       });
 
       it("round-trips activeFeatureIds through updateStateInUrl and parseStateFromUrl", () => {
-        SearchParams.updateStateInUrl({ activeFeatureIds: ["uuid-1", "uuid-2"] });
+        SearchParams.updateStateInUrl({
+          activeFeatureIds: ["uuid-1", "uuid-2"],
+        });
 
         const state = SearchParams.parseStateFromUrl();
         expect(state.activeFeatureIds).to.deep.equal(["uuid-1", "uuid-2"]);

--- a/test/js/specs/unit/common/SearchParams.spec.js
+++ b/test/js/specs/unit/common/SearchParams.spec.js
@@ -459,67 +459,108 @@ define(["common/SearchParams"], (SearchParams) => {
       });
     });
 
-    describe("activeFeatureIds", () => {
-      it("returns empty array by default", () => {
+    describe("activeFeatures", () => {
+      const encodeFeature = ({ featureId, layerId = null }) =>
+        encodeURIComponent(JSON.stringify({ featureId, layerId }));
+
+      it("returns empty activeFeatures by default", () => {
         const state = SearchParams.parseStateFromUrl();
-        expect(state.activeFeatureIds).to.deep.equal([]);
+        expect(state.activeFeatures).to.deep.equal([]);
       });
 
-      it("parses f param as activeFeatureIds when sv=1", () => {
-        window.history.replaceState(null, "", "?sv=1&f=feature-abc-123");
+      it("parses encoded f entries as activeFeatures when sv=1", () => {
+        window.history.replaceState(
+          null,
+          "",
+          `?sv=1&f=${encodeFeature({ featureId: "feature-abc-123" })}`,
+        );
 
         const state = SearchParams.parseStateFromUrl();
-        expect(state.activeFeatureIds).to.deep.equal(["feature-abc-123"]);
-      });
-
-      it("ignores f param when sv is absent (schema 0)", () => {
-        window.history.replaceState(null, "", "?f=feature-abc-123");
-
-        const state = SearchParams.parseStateFromUrl();
-        expect(state.activeFeatureIds).to.deep.equal([]);
-      });
-
-      it("parses repeated f params as activeFeatureIds when sv=1", () => {
-        window.history.replaceState(null, "", "?sv=1&f=id-one&f=id-two&f=id-three");
-
-        const state = SearchParams.parseStateFromUrl();
-        expect(state.activeFeatureIds).to.deep.equal([
-          "id-one",
-          "id-two",
-          "id-three",
+        expect(state.activeFeatures).to.deep.equal([
+          { featureId: "feature-abc-123", layerId: null },
         ]);
       });
 
-      it("writes activeFeatureIds as repeated f params and bumps schema to 1", () => {
-        SearchParams.updateStateInUrl({ activeFeatureIds: ["feat-xyz"] });
+      it("ignores encoded f entries when sv is absent", () => {
+        window.history.replaceState(
+          null,
+          "",
+          `?f=${encodeFeature({ featureId: "feature-abc-123" })}`,
+        );
 
-        const url = new URL(window.location.href);
-        expect(url.searchParams.getAll("f")).to.deep.equal(["feat-xyz"]);
-        expect(url.searchParams.get("sv")).to.equal("1");
+        const state = SearchParams.parseStateFromUrl();
+        expect(state.activeFeatures).to.deep.equal([]);
       });
 
-      it("writes multiple feature ids as repeated f params", () => {
+      it("ignores non-JSON f entries", () => {
+        window.history.replaceState(null, "", "?f=legacy-id-1&f=legacy-id-2");
+
+        const state = SearchParams.parseStateFromUrl();
+        expect(state.activeFeatures).to.deep.equal([]);
+      });
+
+      it("parses repeated encoded f params as activeFeatures when sv=1", () => {
+        window.history.replaceState(
+          null,
+          "",
+          `?sv=1&f=${encodeFeature({ featureId: "id-one" })}&f=${encodeFeature({ featureId: "id-two" })}&f=${encodeFeature({ featureId: "id-three" })}`,
+        );
+
+        const state = SearchParams.parseStateFromUrl();
+        expect(state.activeFeatures).to.deep.equal([
+          { featureId: "id-one", layerId: null },
+          { featureId: "id-two", layerId: null },
+          { featureId: "id-three", layerId: null },
+        ]);
+      });
+
+      it("writes activeFeatures as repeated f params", () => {
         SearchParams.updateStateInUrl({
-          activeFeatureIds: ["id-a", "id-b"],
+          activeFeatures: [{ featureId: "feat-xyz", layerId: null }],
         });
 
         const url = new URL(window.location.href);
-        expect(url.searchParams.getAll("f")).to.deep.equal(["id-a", "id-b"]);
+        expect(url.searchParams.getAll("f")).to.deep.equal([
+          JSON.stringify({ featureId: "feat-xyz", layerId: null }),
+        ]);
+        expect(url.searchParams.get("sv")).to.equal("1");
+      });
+
+      it("writes multiple activeFeatures as repeated f params", () => {
+        SearchParams.updateStateInUrl({
+          activeFeatures: [
+            { featureId: "id-a", layerId: null },
+            { featureId: "id-b", layerId: null },
+          ],
+        });
+
+        const url = new URL(window.location.href);
+        expect(url.searchParams.getAll("f")).to.deep.equal([
+          JSON.stringify({ featureId: "id-a", layerId: null }),
+          JSON.stringify({ featureId: "id-b", layerId: null }),
+        ]);
+        expect(url.searchParams.get("sv")).to.equal("1");
       });
 
       it("round-trips feature ids containing commas", () => {
         SearchParams.updateStateInUrl({
-          activeFeatureIds: ["Washington, DC", "id-b"],
+          activeFeatures: [
+            { featureId: "Washington, DC", layerId: null },
+            { featureId: "id-b", layerId: null },
+          ],
         });
 
         const state = SearchParams.parseStateFromUrl();
-        expect(state.activeFeatureIds).to.deep.equal(["Washington, DC", "id-b"]);
+        expect(state.activeFeatures).to.deep.equal([
+          { featureId: "Washington, DC", layerId: null },
+          { featureId: "id-b", layerId: null },
+        ]);
       });
 
-      it("omits f param when activeFeatureIds is empty", () => {
+      it("omits f param when activeFeatures is empty", () => {
         SearchParams.updateStateInUrl({
           openPanel: "viewfinder",
-          activeFeatureIds: [],
+          activeFeatures: [],
         });
 
         const url = new URL(window.location.href);
@@ -540,23 +581,65 @@ define(["common/SearchParams"], (SearchParams) => {
         expect(url.searchParams.has("op")).to.equal(false);
       });
 
-      it("preserves unrelated params when writing activeFeatureIds", () => {
+      it("preserves unrelated params when writing activeFeatures", () => {
         window.history.replaceState(null, "", "?unrelated=keep");
 
-        SearchParams.updateStateInUrl({ activeFeatureIds: ["feat-1"] });
+        SearchParams.updateStateInUrl({
+          activeFeatures: [{ featureId: "feat-1", layerId: null }],
+        });
 
         const url = new URL(window.location.href);
         expect(url.searchParams.get("unrelated")).to.equal("keep");
-        expect(url.searchParams.getAll("f")).to.deep.equal(["feat-1"]);
+        expect(url.searchParams.get("sv")).to.equal("1");
+        expect(url.searchParams.getAll("f")).to.deep.equal([
+          JSON.stringify({ featureId: "feat-1", layerId: null }),
+        ]);
       });
 
-      it("round-trips activeFeatureIds through updateStateInUrl and parseStateFromUrl", () => {
+      it("round-trips activeFeatures through updateStateInUrl and parseStateFromUrl", () => {
         SearchParams.updateStateInUrl({
-          activeFeatureIds: ["uuid-1", "uuid-2"],
+          activeFeatures: [
+            { featureId: "uuid-1", layerId: null },
+            { featureId: "uuid-2", layerId: null },
+          ],
         });
 
         const state = SearchParams.parseStateFromUrl();
-        expect(state.activeFeatureIds).to.deep.equal(["uuid-1", "uuid-2"]);
+        expect(state.activeFeatures).to.deep.equal([
+          { featureId: "uuid-1", layerId: null },
+          { featureId: "uuid-2", layerId: null },
+        ]);
+      });
+
+      it("writes feature-layer pairs as repeated encoded f params", () => {
+        SearchParams.updateActiveFeatures([
+          { featureId: "feat-1", layerId: "layer-a" },
+          { featureId: "feat-1", layerId: "layer-b" },
+          { featureId: "feat-2", layerId: null },
+        ]);
+
+        const url = new URL(window.location.href);
+        expect(url.searchParams.getAll("f")).to.deep.equal([
+          JSON.stringify({ featureId: "feat-1", layerId: "layer-a" }),
+          JSON.stringify({ featureId: "feat-1", layerId: "layer-b" }),
+          JSON.stringify({ featureId: "feat-2", layerId: null }),
+        ]);
+        expect(url.searchParams.get("sv")).to.equal("1");
+      });
+
+      it("parses feature-layer pairs into activeFeatures when sv=1", () => {
+        window.history.replaceState(
+          null,
+          "",
+          `?sv=1&f=${encodeFeature({ featureId: "feat-1", layerId: "layer-a" })}&f=${encodeFeature({ featureId: "feat-1", layerId: "layer-b" })}&f=${encodeFeature({ featureId: "feat-2" })}`,
+        );
+
+        const state = SearchParams.parseStateFromUrl();
+        expect(state.activeFeatures).to.deep.equal([
+          { featureId: "feat-1", layerId: "layer-a" },
+          { featureId: "feat-1", layerId: "layer-b" },
+          { featureId: "feat-2", layerId: null },
+        ]);
       });
     });
   });

--- a/test/js/specs/unit/common/SearchParams.spec.js
+++ b/test/js/specs/unit/common/SearchParams.spec.js
@@ -458,5 +458,99 @@ define(["common/SearchParams"], (SearchParams) => {
         expect(url.searchParams.get("wt-lat")).to.be.null;
       });
     });
+
+    describe("activeFeatureIds", () => {
+      it("returns empty array by default", () => {
+        const state = SearchParams.parseStateFromUrl();
+        expect(state.activeFeatureIds).to.deep.equal([]);
+      });
+
+      it("parses f param as activeFeatureIds when sv=1", () => {
+        window.history.replaceState(
+          null,
+          "",
+          "?sv=1&f=feature-abc-123",
+        );
+
+        const state = SearchParams.parseStateFromUrl();
+        expect(state.activeFeatureIds).to.deep.equal(["feature-abc-123"]);
+      });
+
+      it("ignores f param when sv is absent (schema 0)", () => {
+        window.history.replaceState(null, "", "?f=feature-abc-123");
+
+        const state = SearchParams.parseStateFromUrl();
+        expect(state.activeFeatureIds).to.deep.equal([]);
+      });
+
+      it("parses multiple feature ids from comma-separated f param", () => {
+        window.history.replaceState(
+          null,
+          "",
+          "?sv=1&f=id-one,id-two,id-three",
+        );
+
+        const state = SearchParams.parseStateFromUrl();
+        expect(state.activeFeatureIds).to.deep.equal(["id-one", "id-two", "id-three"]);
+      });
+
+      it("writes activeFeatureIds as f param and bumps schema to 1", () => {
+        SearchParams.updateStateInUrl({ activeFeatureIds: ["feat-xyz"] });
+
+        const url = new URL(window.location.href);
+        expect(url.searchParams.get("f")).to.equal("feat-xyz");
+        expect(url.searchParams.get("sv")).to.equal("1");
+      });
+
+      it("writes multiple feature ids as comma-separated f param", () => {
+        SearchParams.updateStateInUrl({
+          activeFeatureIds: ["id-a", "id-b"],
+        });
+
+        const url = new URL(window.location.href);
+        expect(url.searchParams.get("f")).to.equal("id-a,id-b");
+      });
+
+      it("omits f param when activeFeatureIds is empty", () => {
+        SearchParams.updateStateInUrl({
+          openPanel: "viewfinder",
+          activeFeatureIds: [],
+        });
+
+        const url = new URL(window.location.href);
+        expect(url.searchParams.has("f")).to.equal(false);
+      });
+
+      it("clears f param via clearStateInUrl", () => {
+        window.history.replaceState(
+          null,
+          "",
+          "?sv=1&f=feature-abc-123&op=viewfinder",
+        );
+
+        SearchParams.clearStateInUrl();
+
+        const url = new URL(window.location.href);
+        expect(url.searchParams.has("f")).to.equal(false);
+        expect(url.searchParams.has("op")).to.equal(false);
+      });
+
+      it("preserves unrelated params when writing activeFeatureIds", () => {
+        window.history.replaceState(null, "", "?unrelated=keep");
+
+        SearchParams.updateStateInUrl({ activeFeatureIds: ["feat-1"] });
+
+        const url = new URL(window.location.href);
+        expect(url.searchParams.get("unrelated")).to.equal("keep");
+        expect(url.searchParams.get("f")).to.equal("feat-1");
+      });
+
+      it("round-trips activeFeatureIds through updateStateInUrl and parseStateFromUrl", () => {
+        SearchParams.updateStateInUrl({ activeFeatureIds: ["uuid-1", "uuid-2"] });
+
+        const state = SearchParams.parseStateFromUrl();
+        expect(state.activeFeatureIds).to.deep.equal(["uuid-1", "uuid-2"]);
+      });
+    });
   });
 });

--- a/test/js/specs/unit/models/maps/Map.spec.js
+++ b/test/js/specs/unit/models/maps/Map.spec.js
@@ -347,5 +347,117 @@ define([
         expect(state.model.getLayerGroups()).to.have.lengthOf(2);
       });
     });
+
+    describe("applyFeatureRestoreState", () => {
+      const makeLayer = (overrides = {}) =>
+        Object.assign(
+          {
+            status: "ready",
+            get(key) {
+              return this[key];
+            },
+            set(key, val) {
+              this[key] = val;
+            },
+            getFeatureById: () => null,
+          },
+          overrides,
+        );
+
+      it("does nothing when activeFeatureIds is empty", () => {
+        const map = new Map({ showShareUrl: true });
+        map.set("restoreState", { activeFeatureIds: [] });
+        map.applyFeatureRestoreState();
+        expect(map.getSelectedFeatures()?.models).to.have.lengthOf(0);
+      });
+
+      it("does nothing when showShareUrl is false", () => {
+        const map = new Map({ showShareUrl: false });
+        map.set("restoreState", { activeFeatureIds: ["feat-1"] });
+        map.applyFeatureRestoreState();
+        expect(map.getSelectedFeatures()?.models).to.have.lengthOf(0);
+      });
+
+      it("selects a feature when a ready layer finds it immediately", () => {
+        const map = new Map({ showShareUrl: true });
+        const fakeFeature = {};
+        const fakeAttrs = {
+          featureID: "feat-1",
+          properties: {},
+          mapAsset: null,
+          featureObject: fakeFeature,
+          label: null,
+        };
+
+        const layer = makeLayer({
+          getFeatureById: (id) => (id === "feat-1" ? fakeFeature : null),
+          getFeatureAttributes: () => fakeAttrs,
+        });
+
+        map.getAllLayers = () => [layer];
+        map.set("restoreState", { activeFeatureIds: ["feat-1"] });
+        map.applyFeatureRestoreState();
+
+        const selected = map.getSelectedFeatures()?.models || [];
+        expect(selected.some((f) => f.get("featureID") === "feat-1")).to.equal(
+          true,
+        );
+      });
+
+      it("uses waitForFeatureById when a ready tileset layer doesn't find the feature immediately", (done) => {
+        const map = new Map({ showShareUrl: true });
+        const fakeFeature = {};
+        const fakeAttrs = {
+          featureID: "building-42",
+          properties: {},
+          mapAsset: null,
+          featureObject: fakeFeature,
+          label: null,
+        };
+
+        let tileAvailable = false;
+        let tileCallback = null;
+        const layer = makeLayer({
+          // Returns the feature only once the tile is "loaded"
+          getFeatureById: () => (tileAvailable ? fakeFeature : null),
+          getFeatureAttributes: () => fakeAttrs,
+          waitForFeatureById: (_id, cb) => {
+            tileCallback = cb;
+            return () => {};
+          },
+        });
+
+        map.getAllLayers = () => [layer];
+        map.set("restoreState", { activeFeatureIds: ["building-42"] });
+        map.applyFeatureRestoreState();
+
+        expect(
+          (map.getSelectedFeatures()?.models || []).some(
+            (f) => f.get("featureID") === "building-42",
+          ),
+        ).to.equal(false);
+
+        // Simulate tile becoming visible: mark feature available then fire callback
+        tileAvailable = true;
+        tileCallback();
+
+        setTimeout(() => {
+          const selected = map.getSelectedFeatures()?.models || [];
+          expect(
+            selected.some((f) => f.get("featureID") === "building-42"),
+          ).to.equal(true);
+          done();
+        }, 0);
+      });
+
+      it("skips layers without getFeatureById", () => {
+        const map = new Map({ showShareUrl: true });
+        const layer = { get: () => "ready" };
+        map.getAllLayers = () => [layer];
+        map.set("restoreState", { activeFeatureIds: ["feat-x"] });
+        map.applyFeatureRestoreState();
+        expect(map.getSelectedFeatures()?.models).to.have.lengthOf(0);
+      });
+    });
   });
 });

--- a/test/js/specs/unit/models/maps/Map.spec.js
+++ b/test/js/specs/unit/models/maps/Map.spec.js
@@ -483,6 +483,108 @@ define([
         }, 0);
       });
 
+      it("keeps the restore session active across partial feature resolution", (done) => {
+        const map = new Map({ showShareUrl: true });
+        const originalUpdateActiveFeatureIds =
+          SearchParams.updateActiveFeatureIds;
+        const urlUpdates = [];
+        const fakeFeatureA = {};
+        const fakeFeatureB = {};
+        const fakeAttrsA = {
+          featureID: "feature-a",
+          properties: {},
+          mapAsset: null,
+          featureObject: fakeFeatureA,
+          label: null,
+        };
+        const fakeAttrsB = {
+          featureID: "feature-b",
+          properties: {},
+          mapAsset: null,
+          featureObject: fakeFeatureB,
+          label: null,
+        };
+
+        let tileAvailable = false;
+        let tileCallback = null;
+
+        SearchParams.updateActiveFeatureIds = (ids) => {
+          urlUpdates.push(ids.slice());
+        };
+
+        const layer = makeLayer({
+          getFeatureById: (id) => {
+            if (id === "feature-a") return fakeFeatureA;
+            if (id === "feature-b" && tileAvailable) return fakeFeatureB;
+            return null;
+          },
+          getFeatureAttributes: (feature) => {
+            if (feature === fakeFeatureA) return fakeAttrsA;
+            if (feature === fakeFeatureB) return fakeAttrsB;
+            return null;
+          },
+          waitForFeatureById: (id, cb) => {
+            if (id === "feature-b") tileCallback = cb;
+            return () => {};
+          },
+        });
+
+        map.getAllLayers = () => [layer];
+        map.set("restoreState", {
+          activeFeatureIds: ["feature-a", "feature-b"],
+        });
+
+        try {
+          map.applyFeatureRestoreState();
+
+          expect(
+            (map.getSelectedFeatures()?.models || []).some(
+              (f) => f.get("featureID") === "feature-a",
+            ),
+          ).to.equal(true);
+          expect(
+            (map.getSelectedFeatures()?.models || []).some(
+              (f) => f.get("featureID") === "feature-b",
+            ),
+          ).to.equal(false);
+          expect(map.featureRestoreSession?.requestedIds).to.deep.equal([
+            "feature-a",
+            "feature-b",
+          ]);
+          expect(urlUpdates.at(-1)).to.deep.equal(["feature-a", "feature-b"]);
+
+          tileAvailable = true;
+          tileCallback();
+
+          setTimeout(() => {
+            try {
+              const selected = map.getSelectedFeatures()?.models || [];
+              expect(
+                selected.some((f) => f.get("featureID") === "feature-a"),
+              ).to.equal(true);
+              expect(
+                selected.some((f) => f.get("featureID") === "feature-b"),
+              ).to.equal(true);
+              expect(map.featureRestoreSession).to.equal(null);
+              expect(urlUpdates.at(-1)).to.deep.equal([
+                "feature-a",
+                "feature-b",
+              ]);
+              SearchParams.updateActiveFeatureIds =
+                originalUpdateActiveFeatureIds;
+              done();
+            } catch (error) {
+              SearchParams.updateActiveFeatureIds =
+                originalUpdateActiveFeatureIds;
+              done(error);
+            }
+          }, 0);
+        } catch (error) {
+          SearchParams.updateActiveFeatureIds = originalUpdateActiveFeatureIds;
+          done(error);
+        }
+      });
+
       it("cancels pending feature restore waiters when showShareUrl turns off", () => {
         const map = new Map({ showShareUrl: true });
         let cancelCount = 0;

--- a/test/js/specs/unit/models/maps/Map.spec.js
+++ b/test/js/specs/unit/models/maps/Map.spec.js
@@ -378,6 +378,43 @@ define([
           SearchParams.updateActiveFeatures = originalUpdateActiveFeatures;
         }
       });
+
+      it("syncs only stable property-based feature ids to URL state", () => {
+        const map = new Map({ showShareUrl: true });
+        const originalUpdateActiveFeatures = SearchParams.updateActiveFeatures;
+        let latestFeatures = null;
+
+        SearchParams.updateActiveFeatures = (features) => {
+          latestFeatures = features;
+        };
+
+        try {
+          map.selectFeatures([
+            {
+              featureID: "cesium-generated-uuid",
+              properties: {
+                id: "stable-feature-id",
+              },
+              mapAsset: null,
+              featureObject: {},
+              label: null,
+            },
+            {
+              featureID: "another-unstable-uuid",
+              properties: {},
+              mapAsset: null,
+              featureObject: {},
+              label: null,
+            },
+          ]);
+
+          expect(latestFeatures).to.deep.equal([
+            { featureId: "stable-feature-id", layerId: null },
+          ]);
+        } finally {
+          SearchParams.updateActiveFeatures = originalUpdateActiveFeatures;
+        }
+      });
     });
 
     describe("applyFeatureRestoreState", () => {
@@ -501,14 +538,14 @@ define([
         const mapAsset = new Backbone.Model({ layerId: "layer-main" });
         const fakeAttrsA = {
           featureID: "feature-a",
-          properties: {},
+          properties: { id: "feature-a" },
           mapAsset,
           featureObject: fakeFeatureA,
           label: null,
         };
         const fakeAttrsB = {
           featureID: "feature-b",
-          properties: {},
+          properties: { id: "feature-b" },
           mapAsset,
           featureObject: fakeFeatureB,
           label: null,
@@ -586,12 +623,10 @@ define([
                 { featureId: "feature-a", layerId: "layer-main" },
                 { featureId: "feature-b", layerId: "layer-main" },
               ]);
-              SearchParams.updateActiveFeatures =
-                originalUpdateActiveFeatures;
+              SearchParams.updateActiveFeatures = originalUpdateActiveFeatures;
               done();
             } catch (error) {
-              SearchParams.updateActiveFeatures =
-                originalUpdateActiveFeatures;
+              SearchParams.updateActiveFeatures = originalUpdateActiveFeatures;
               done(error);
             }
           }, 0);

--- a/test/js/specs/unit/models/maps/Map.spec.js
+++ b/test/js/specs/unit/models/maps/Map.spec.js
@@ -348,6 +348,38 @@ define([
       });
     });
 
+    describe("setUpUrlStateListeners", () => {
+      it("does not duplicate selectedFeatures URL sync listeners on repeated setup", () => {
+        const map = new Map({ showShareUrl: true });
+        const originalUpdateActiveFeatureIds = SearchParams.updateActiveFeatureIds;
+        let updateActiveFeatureIdsCallCount = 0;
+
+        SearchParams.updateActiveFeatureIds = () => {
+          updateActiveFeatureIdsCallCount += 1;
+        };
+
+        try {
+          map.setUpUrlStateListeners();
+          map.setUpUrlStateListeners();
+          map.setUpUrlStateListeners();
+
+          map.selectFeatures([
+            {
+              featureID: "feat-1",
+              properties: {},
+              mapAsset: null,
+              featureObject: {},
+              label: null,
+            },
+          ]);
+
+          expect(updateActiveFeatureIdsCallCount).to.equal(1);
+        } finally {
+          SearchParams.updateActiveFeatureIds = originalUpdateActiveFeatureIds;
+        }
+      });
+    });
+
     describe("applyFeatureRestoreState", () => {
       const makeLayer = (overrides = {}) =>
         Object.assign(
@@ -450,6 +482,30 @@ define([
         }, 0);
       });
 
+      it("cancels pending feature restore waiters when showShareUrl turns off", () => {
+        const map = new Map({ showShareUrl: true });
+        let cancelCount = 0;
+
+        const layer = makeLayer({
+          getFeatureById: () => null,
+          waitForFeatureById: () => {
+            return () => {
+              cancelCount += 1;
+            };
+          },
+        });
+
+        map.getAllLayers = () => [layer];
+        map.set("restoreState", { activeFeatureIds: ["feature-slow"] });
+        map.applyFeatureRestoreState();
+
+        expect(cancelCount).to.equal(0);
+
+        map.handleShowShareUrlChange(map, false);
+
+        expect(cancelCount).to.equal(1);
+      });
+
       it("skips layers without getFeatureById", () => {
         const map = new Map({ showShareUrl: true });
         const layer = { get: () => "ready" };
@@ -457,6 +513,53 @@ define([
         map.set("restoreState", { activeFeatureIds: ["feat-x"] });
         map.applyFeatureRestoreState();
         expect(map.getSelectedFeatures()?.models).to.have.lengthOf(0);
+      });
+
+      it("cancels stale async waiters before starting a new restore", () => {
+        const map = new Map({ showShareUrl: true });
+
+        let waitCallCount = 0;
+        let cancelCallCount = 0;
+        const layer = makeLayer({
+          getFeatureById: () => null,
+          waitForFeatureById: () => {
+            waitCallCount += 1;
+            return () => {
+              cancelCallCount += 1;
+            };
+          },
+        });
+
+        map.getAllLayers = () => [layer];
+        map.set("restoreState", { activeFeatureIds: ["feature-a"] });
+        map.applyFeatureRestoreState();
+
+        map.set("restoreState", { activeFeatureIds: ["feature-b"] });
+        map.applyFeatureRestoreState();
+
+        expect(waitCallCount).to.equal(2);
+        expect(cancelCallCount).to.equal(1);
+      });
+
+      it("does not create duplicate async waiters for repeated restores of same ids", () => {
+        const map = new Map({ showShareUrl: true });
+
+        let waitCallCount = 0;
+        const layer = makeLayer({
+          getFeatureById: () => null,
+          waitForFeatureById: () => {
+            waitCallCount += 1;
+            return () => {};
+          },
+        });
+
+        map.getAllLayers = () => [layer];
+        map.set("restoreState", { activeFeatureIds: ["feature-a"] });
+        map.applyFeatureRestoreState();
+        map.applyFeatureRestoreState();
+        map.applyFeatureRestoreState();
+
+        expect(waitCallCount).to.equal(1);
       });
     });
   });

--- a/test/js/specs/unit/models/maps/Map.spec.js
+++ b/test/js/specs/unit/models/maps/Map.spec.js
@@ -351,7 +351,8 @@ define([
     describe("setUpUrlStateListeners", () => {
       it("does not duplicate selectedFeatures URL sync listeners on repeated setup", () => {
         const map = new Map({ showShareUrl: true });
-        const originalUpdateActiveFeatureIds = SearchParams.updateActiveFeatureIds;
+        const originalUpdateActiveFeatureIds =
+          SearchParams.updateActiveFeatureIds;
         let updateActiveFeatureIdsCallCount = 0;
 
         SearchParams.updateActiveFeatureIds = () => {

--- a/test/js/specs/unit/models/maps/Map.spec.js
+++ b/test/js/specs/unit/models/maps/Map.spec.js
@@ -351,12 +351,11 @@ define([
     describe("setUpUrlStateListeners", () => {
       it("does not duplicate selectedFeatures URL sync listeners on repeated setup", () => {
         const map = new Map({ showShareUrl: true });
-        const originalUpdateActiveFeatureIds =
-          SearchParams.updateActiveFeatureIds;
-        let updateActiveFeatureIdsCallCount = 0;
+        const originalUpdateActiveFeatures = SearchParams.updateActiveFeatures;
+        let updateActiveFeaturesCallCount = 0;
 
-        SearchParams.updateActiveFeatureIds = () => {
-          updateActiveFeatureIdsCallCount += 1;
+        SearchParams.updateActiveFeatures = () => {
+          updateActiveFeaturesCallCount += 1;
         };
 
         try {
@@ -374,9 +373,9 @@ define([
             },
           ]);
 
-          expect(updateActiveFeatureIdsCallCount).to.equal(1);
+          expect(updateActiveFeaturesCallCount).to.equal(1);
         } finally {
-          SearchParams.updateActiveFeatureIds = originalUpdateActiveFeatureIds;
+          SearchParams.updateActiveFeatures = originalUpdateActiveFeatures;
         }
       });
     });
@@ -397,16 +396,18 @@ define([
           overrides,
         );
 
-      it("does nothing when activeFeatureIds is empty", () => {
+      it("does nothing when activeFeatures is empty", () => {
         const map = new Map({ showShareUrl: true });
-        map.set("restoreState", { activeFeatureIds: [] });
+        map.set("restoreState", { activeFeatures: [] });
         map.applyFeatureRestoreState();
         expect(map.getSelectedFeatures()?.models).to.have.lengthOf(0);
       });
 
       it("does nothing when showShareUrl is false", () => {
         const map = new Map({ showShareUrl: false });
-        map.set("restoreState", { activeFeatureIds: ["feat-1"] });
+        map.set("restoreState", {
+          activeFeatures: [{ featureId: "feat-1", layerId: null }],
+        });
         map.applyFeatureRestoreState();
         expect(map.getSelectedFeatures()?.models).to.have.lengthOf(0);
       });
@@ -414,21 +415,25 @@ define([
       it("selects a feature when a ready layer finds it immediately", () => {
         const map = new Map({ showShareUrl: true });
         const fakeFeature = {};
+        const mapAsset = new Backbone.Model({ layerId: "layer-a" });
         const fakeAttrs = {
           featureID: "feat-1",
           properties: {},
-          mapAsset: null,
+          mapAsset,
           featureObject: fakeFeature,
           label: null,
         };
 
         const layer = makeLayer({
+          layerId: "layer-a",
           getFeatureById: (id) => (id === "feat-1" ? fakeFeature : null),
           getFeatureAttributes: () => fakeAttrs,
         });
 
         map.getAllLayers = () => [layer];
-        map.set("restoreState", { activeFeatureIds: ["feat-1"] });
+        map.set("restoreState", {
+          activeFeatures: [{ featureId: "feat-1", layerId: null }],
+        });
         map.applyFeatureRestoreState();
 
         const selected = map.getSelectedFeatures()?.models || [];
@@ -440,10 +445,11 @@ define([
       it("uses waitForFeatureById when a ready tileset layer doesn't find the feature immediately", (done) => {
         const map = new Map({ showShareUrl: true });
         const fakeFeature = {};
+        const mapAsset = new Backbone.Model({ layerId: "buildings" });
         const fakeAttrs = {
           featureID: "building-42",
           properties: {},
-          mapAsset: null,
+          mapAsset,
           featureObject: fakeFeature,
           label: null,
         };
@@ -451,6 +457,7 @@ define([
         let tileAvailable = false;
         let tileCallback = null;
         const layer = makeLayer({
+          layerId: "buildings",
           // Returns the feature only once the tile is "loaded"
           getFeatureById: () => (tileAvailable ? fakeFeature : null),
           getFeatureAttributes: () => fakeAttrs,
@@ -461,7 +468,9 @@ define([
         });
 
         map.getAllLayers = () => [layer];
-        map.set("restoreState", { activeFeatureIds: ["building-42"] });
+        map.set("restoreState", {
+          activeFeatures: [{ featureId: "building-42", layerId: null }],
+        });
         map.applyFeatureRestoreState();
 
         expect(
@@ -485,22 +494,22 @@ define([
 
       it("keeps the restore session active across partial feature resolution", (done) => {
         const map = new Map({ showShareUrl: true });
-        const originalUpdateActiveFeatureIds =
-          SearchParams.updateActiveFeatureIds;
+        const originalUpdateActiveFeatures = SearchParams.updateActiveFeatures;
         const urlUpdates = [];
         const fakeFeatureA = {};
         const fakeFeatureB = {};
+        const mapAsset = new Backbone.Model({ layerId: "layer-main" });
         const fakeAttrsA = {
           featureID: "feature-a",
           properties: {},
-          mapAsset: null,
+          mapAsset,
           featureObject: fakeFeatureA,
           label: null,
         };
         const fakeAttrsB = {
           featureID: "feature-b",
           properties: {},
-          mapAsset: null,
+          mapAsset,
           featureObject: fakeFeatureB,
           label: null,
         };
@@ -508,11 +517,12 @@ define([
         let tileAvailable = false;
         let tileCallback = null;
 
-        SearchParams.updateActiveFeatureIds = (ids) => {
-          urlUpdates.push(ids.slice());
+        SearchParams.updateActiveFeatures = (features) => {
+          urlUpdates.push(features.map((feature) => ({ ...feature })));
         };
 
         const layer = makeLayer({
+          layerId: "layer-main",
           getFeatureById: (id) => {
             if (id === "feature-a") return fakeFeatureA;
             if (id === "feature-b" && tileAvailable) return fakeFeatureB;
@@ -531,7 +541,10 @@ define([
 
         map.getAllLayers = () => [layer];
         map.set("restoreState", {
-          activeFeatureIds: ["feature-a", "feature-b"],
+          activeFeatures: [
+            { featureId: "feature-a", layerId: null },
+            { featureId: "feature-b", layerId: null },
+          ],
         });
 
         try {
@@ -547,11 +560,14 @@ define([
               (f) => f.get("featureID") === "feature-b",
             ),
           ).to.equal(false);
-          expect(map.featureRestoreSession?.requestedIds).to.deep.equal([
-            "feature-a",
-            "feature-b",
+          expect(map.featureRestoreSession?.requestedFeatures).to.deep.equal([
+            { featureId: "feature-a", layerId: null },
+            { featureId: "feature-b", layerId: null },
           ]);
-          expect(urlUpdates.at(-1)).to.deep.equal(["feature-a", "feature-b"]);
+          expect(urlUpdates.at(-1)).to.deep.equal([
+            { featureId: "feature-a", layerId: "layer-main" },
+            { featureId: "feature-b", layerId: null },
+          ]);
 
           tileAvailable = true;
           tileCallback();
@@ -567,22 +583,76 @@ define([
               ).to.equal(true);
               expect(map.featureRestoreSession).to.equal(null);
               expect(urlUpdates.at(-1)).to.deep.equal([
-                "feature-a",
-                "feature-b",
+                { featureId: "feature-a", layerId: "layer-main" },
+                { featureId: "feature-b", layerId: "layer-main" },
               ]);
-              SearchParams.updateActiveFeatureIds =
-                originalUpdateActiveFeatureIds;
+              SearchParams.updateActiveFeatures =
+                originalUpdateActiveFeatures;
               done();
             } catch (error) {
-              SearchParams.updateActiveFeatureIds =
-                originalUpdateActiveFeatureIds;
+              SearchParams.updateActiveFeatures =
+                originalUpdateActiveFeatures;
               done(error);
             }
           }, 0);
         } catch (error) {
-          SearchParams.updateActiveFeatureIds = originalUpdateActiveFeatureIds;
+          SearchParams.updateActiveFeatures = originalUpdateActiveFeatures;
           done(error);
         }
+      });
+
+      it("restores the matching layer when feature ids collide", () => {
+        const map = new Map({ showShareUrl: true });
+        const layerAAsset = new Backbone.Model({ layerId: "layer-a" });
+        const layerBAsset = new Backbone.Model({ layerId: "layer-b" });
+        const sharedFeatureId = "row-1";
+        const featureA = { source: "a" };
+        const featureB = { source: "b" };
+
+        const layerA = makeLayer({
+          layerId: "layer-a",
+          getFeatureById: (id) => (id === sharedFeatureId ? featureA : null),
+          getFeatureAttributes: (feature) =>
+            feature === featureA
+              ? {
+                  featureID: sharedFeatureId,
+                  properties: { source: "a" },
+                  mapAsset: layerAAsset,
+                  featureObject: featureA,
+                  label: null,
+                }
+              : null,
+        });
+        const layerB = makeLayer({
+          layerId: "layer-b",
+          getFeatureById: (id) => (id === sharedFeatureId ? featureB : null),
+          getFeatureAttributes: (feature) =>
+            feature === featureB
+              ? {
+                  featureID: sharedFeatureId,
+                  properties: { source: "b" },
+                  mapAsset: layerBAsset,
+                  featureObject: featureB,
+                  label: null,
+                }
+              : null,
+        });
+
+        map.getAllLayers = () => [layerA, layerB];
+        map.set("restoreState", {
+          activeFeatures: [
+            {
+              featureId: sharedFeatureId,
+              layerId: "layer-b",
+            },
+          ],
+        });
+
+        map.applyFeatureRestoreState();
+
+        const selected = map.getSelectedFeatures()?.models || [];
+        expect(selected).to.have.lengthOf(1);
+        expect(selected[0].get("mapAsset").get("layerId")).to.equal("layer-b");
       });
 
       it("cancels pending feature restore waiters when showShareUrl turns off", () => {
@@ -599,7 +669,9 @@ define([
         });
 
         map.getAllLayers = () => [layer];
-        map.set("restoreState", { activeFeatureIds: ["feature-slow"] });
+        map.set("restoreState", {
+          activeFeatures: [{ featureId: "feature-slow", layerId: null }],
+        });
         map.applyFeatureRestoreState();
 
         expect(cancelCount).to.equal(0);
@@ -613,7 +685,9 @@ define([
         const map = new Map({ showShareUrl: true });
         const layer = { get: () => "ready" };
         map.getAllLayers = () => [layer];
-        map.set("restoreState", { activeFeatureIds: ["feat-x"] });
+        map.set("restoreState", {
+          activeFeatures: [{ featureId: "feat-x", layerId: null }],
+        });
         map.applyFeatureRestoreState();
         expect(map.getSelectedFeatures()?.models).to.have.lengthOf(0);
       });
@@ -634,10 +708,14 @@ define([
         });
 
         map.getAllLayers = () => [layer];
-        map.set("restoreState", { activeFeatureIds: ["feature-a"] });
+        map.set("restoreState", {
+          activeFeatures: [{ featureId: "feature-a", layerId: null }],
+        });
         map.applyFeatureRestoreState();
 
-        map.set("restoreState", { activeFeatureIds: ["feature-b"] });
+        map.set("restoreState", {
+          activeFeatures: [{ featureId: "feature-b", layerId: null }],
+        });
         map.applyFeatureRestoreState();
 
         expect(waitCallCount).to.equal(2);
@@ -657,7 +735,9 @@ define([
         });
 
         map.getAllLayers = () => [layer];
-        map.set("restoreState", { activeFeatureIds: ["feature-a"] });
+        map.set("restoreState", {
+          activeFeatures: [{ featureId: "feature-a", layerId: null }],
+        });
         map.applyFeatureRestoreState();
         map.applyFeatureRestoreState();
         map.applyFeatureRestoreState();

--- a/test/js/specs/unit/models/maps/featureIdHelpers.spec.js
+++ b/test/js/specs/unit/models/maps/featureIdHelpers.spec.js
@@ -1,0 +1,52 @@
+define(["models/maps/featureIdHelpers"], ({
+  getIdFromProperties,
+  propertyMatchesId,
+}) => {
+  const expect = chai.expect;
+
+  describe("featureIdHelpers", () => {
+    describe("getIdFromProperties", () => {
+      it("prefers id over lower-priority keys", () => {
+        const props = { id: "A", name: "B" };
+
+        expect(getIdFromProperties(props)).to.equal("A");
+      });
+    });
+
+    describe("propertyMatchesId", () => {
+      it("matches only the canonical derived ID when multiple ID-like keys exist", () => {
+        const props = { id: "A", name: "B" };
+
+        expect(propertyMatchesId(props, "A")).to.equal(true);
+        expect(propertyMatchesId(props, "B")).to.equal(false);
+      });
+
+      it("does not match lower-priority key collisions when id is present", () => {
+        const collisionCases = [
+          { id: "A", identifier: "B" },
+          { id: "A", uuid: "B" },
+          { id: "A", name: "B" },
+          { id: "A", title: "B" },
+          { id: "A", label: "B" },
+        ];
+
+        collisionCases.forEach((props) => {
+          expect(propertyMatchesId(props, "A")).to.equal(true);
+          expect(propertyMatchesId(props, "B")).to.equal(false);
+        });
+      });
+
+      it("still matches name/title/label when they are the canonical ID", () => {
+        expect(propertyMatchesId({ name: "B" }, "B")).to.equal(true);
+        expect(propertyMatchesId({ title: "C" }, "C")).to.equal(true);
+        expect(propertyMatchesId({ label: "D" }, "D")).to.equal(true);
+      });
+
+      it("trims both compared values", () => {
+        expect(propertyMatchesId({ identifier: "  feat-1  " }, "feat-1")).to.equal(
+          true,
+        );
+      });
+    });
+  });
+});

--- a/test/js/specs/unit/models/maps/featureIdHelpers.spec.js
+++ b/test/js/specs/unit/models/maps/featureIdHelpers.spec.js
@@ -43,9 +43,9 @@ define(["models/maps/featureIdHelpers"], ({
       });
 
       it("trims both compared values", () => {
-        expect(propertyMatchesId({ identifier: "  feat-1  " }, "feat-1")).to.equal(
-          true,
-        );
+        expect(
+          propertyMatchesId({ identifier: "  feat-1  " }, "feat-1"),
+        ).to.equal(true);
       });
     });
   });


### PR DESCRIPTION
## What

This PR adds URL-based persistence for selected map features so a user can reload or share a portal and return to the same feature context. The change is centered on a schema-versioned restore-state flow in SearchParams.js, plus feature ID normalization for Cesium vector and 3D tiles layers so matches can be restored reliably across page loads. It also updates the feature info panel styling so the height adjusts smoothly across selection instead of closing and re-opening every time. Closes #2636.

## Why

The URL state already tracked camera position, enabled layers, and viewfinder panel state, but it did not include selected feature IDs. That made feature selection ephemeral and made it difficult to preserve the user’s place when a map was reloaded or shared. The problem was especially noticeable for Cesium data because generated feature IDs can be session-scoped or not stable across loads, so restoring selection by raw ID was unreliable.

## How (MAI Code 1.1 Flash)

### Production file edits
- `ActiveFeatureRestoreController` new module for handling async feature restore session lifecycle, feature lookup/merge logic, deferred layer waiting, and URL-sync restore-state coordination
- `SearchParams.js` adds the restore-state contract for active features encoded as json with their layer ids, and preserves unrelated URL params while writing/reading this state.
- `Map.js` still owns map state and public entrypoints like applyFeatureRestoreState() and clearFeatureRestoreSession().
- `featureIdHelpers.js` introduces shared helper logic to derive a stable, property-based feature identifier from common fields such as id, identifier, uuid, name, title, and label.
- `Cesium3DTileset.js` switches to property-based feature matching and supports deferred lookup for tiles that become visible after the layer loads. (_Did not fix all the eslint errors to minimize diff_)
- `CesiumVectorData.js` uses the same stable ID approach when looking up entities and restores selection by matching on feature properties instead of relying on Cesium-generated IDs. (_Did not fix all the eslint errors to minimize diff_)
- `FeatureInfoView.js` is updated so feature info continues to render properly when a feature is restored via the normalized ID flow.

### Test file edits

- `SearchParams.spec.js` adds coverage for restore-state parsing, URL round-tripping, and active feature ID handling.
- `Map.spec.js` covers feature selection sync to URL and feature restore behavior when layers are not yet ready.

## Testing

- `npm run test` results in 1447 passes and no failures.
- Manual testing of urls with pdg embed vis portal show reliable feature re-selection for roads, communities, local stories, virtual permafrost tours, and buildings. 

Verified with targeted branch checks:
- Ran: `npm test -- --runInBand --testPathPattern='(SearchParams|VisualizationPanelView)\.spec\.js'`
  - Result: exit code 0
- Ran: `npm test -- --runInBand --testPathPattern='models/maps/Map\.spec\.js'`
  - Result: exit code 0

## Documentation

- All new functions have since 0.0.0
- The restored state contract is documented inline in SearchParams.js.
- The stable feature-ID behavior is documented in the helper and map asset implementation files:
  - featureIdHelpers.js
  - Cesium3DTileset.js
  - CesiumVectorData.js