### PR TITLE
Map Editor in Portals - Part 2 - Add/Remove Map page in Portal Editor

### DIFF
--- a/src/js/models/portals/PortalModel.js
+++ b/src/js/models/portals/PortalModel.js
@@ -1460,6 +1460,8 @@ define([
             // Check whether markdown matches the content that's auto-filled or
             // whether it's empty currentMarkdown === this.markdownExample ||
             (currentMarkdown === "" || currentMarkdown == null) &&
+            sectionModel.get("visualizationType") ===
+              defaults.visualizationType &&
             sectionModel.get("image") === defaults.image &&
             sectionModel.get("introduction") === defaults.introduction &&
             // Check whether label starts with the default new page name, or
@@ -2017,57 +2019,77 @@ define([
        * sections in the portals are not tied to PortalSectionModels, because
        * they are created from other parts of the Portal document. For example,
        * the Data, Metrics, and Members sections.
+       * @returns {(PortalSectionModel|null)} The section that was added if it
+       * was a markdown or cesium section, or null if it was a data, metrics, or
+       * members section.
        */
       addSection(section) {
-        try {
-          // If this section is a string, add it by adding custom options
-          if (typeof section === "string") {
-            switch (section.toLowerCase()) {
-              case "data":
-                this.set("hideData", null);
-                break;
-              case "metrics":
-                this.set("hideMetrics", null);
-                break;
-              case "members":
-                this.set("hideMembers", null);
-                break;
-              case "freeform": {
-                // Add a new, blank markdown section with a default image
-                const sectionModels = [...this.get("sections")];
-                const newSection = new PortalSectionModel({
-                  portalModel: this,
-                  // Include a default image if some are configured.
-                  image: this.getRandomSectionImage(),
-                });
-
-                sectionModels.push(newSection);
-                this.set("sections", sectionModels);
-                // Trigger event manually so we can just pass newSection
-                this.trigger("addSection", newSection);
-                break;
-              }
-              default:
-                break;
+        let addedSection = null;
+        // If this section is a string, add it by adding custom options
+        if (typeof section === "string") {
+          switch (section.toLowerCase()) {
+            case "data":
+              this.set("hideData", null);
+              break;
+            case "metrics":
+              this.set("hideMetrics", null);
+              break;
+            case "members":
+              this.set("hideMembers", null);
+              break;
+            case "freeform": {
+              // Add a new, blank markdown section with a default image
+              const newSection = new PortalSectionModel({
+                portalModel: this,
+                // Include a default image if some are configured.
+                image: this.getRandomSectionImage(),
+              });
+              this.pushSectionToSectionsArray(newSection);
+              addedSection = newSection;
+              break;
             }
+            case "cesium": {
+              const newSection = new PortalVizSectionModel({
+                portalModel: this,
+                visualizationType: "cesium",
+              });
+              this.pushSectionToSectionsArray(newSection);
+              addedSection = newSection;
+              break;
+            }
+            default:
+              break;
           }
-          // If this section is a section model, add it to this Portal
-          else if (
-            Object.prototype.isPrototypeOf.call(
-              PortalSectionModel.prototype,
-              section,
-            )
-          ) {
-            const sectionModels = [...this.get("sections")];
-            sectionModels.push(section);
-            this.set({ sections: sectionModels });
-            // trigger event manually so we can just pass newSection
-            this.trigger("addSection", section);
-          }
-        } catch (e) {
-          // eslint-disable-next-line no-console
-          console.error(e);
         }
+        // If this section is a section model, add it to this Portal
+        else if (
+          Object.prototype.isPrototypeOf.call(
+            PortalSectionModel.prototype,
+            section,
+          )
+        ) {
+          this.pushSectionToSectionsArray(section);
+          addedSection = section;
+        }
+        return addedSection;
+      },
+
+      /**
+       * Adds the given section to the sections array on the model and triggers
+       * an "addSection" event with the new section as an argument. Necessary
+       * because Backbone doesn't trigger a "change" event when an array is
+       * updated. Sections should be a collection instead of an array, but this
+       * is a workaround for now.
+       * @param {PortalSectionModel} newSection - The section to add to the
+       * sections array on the model.
+       * @since 0.0.0
+       */
+      pushSectionToSectionsArray(newSection) {
+        const sectionModels = [...this.get("sections")];
+        sectionModels.push(newSection);
+        this.set("sections", sectionModels);
+        // Trigger event manually so we can just pass newSection
+        this.trigger("addSection", newSection);
       },
 
       /**

--- a/src/js/models/portals/PortalVizSectionModel.js
+++ b/src/js/models/portals/PortalVizSectionModel.js
@@ -97,14 +97,23 @@ define(["jquery", "models/portals/PortalSectionModel", "models/maps/Map"], (
           // Or create a new DOM
         } else {
           // create an XML section element from scratch
-          const xmlText =
-            "<section>  <content>FEVer visualization</content><option><optionName>sectionType</optionName><optionValue>visualization</optionValue>" +
-            "</option><option><optionName>visualizationType</optionName><optionValue>fever</optionValue></option></section>";
+          const xmlText = `
+            <section>
+              <label></label>
+                <content>Visualization</content>
+                <option>
+                  <optionName>sectionType</optionName>
+                  <optionValue>visualization</optionValue>
+                </option>
+                <option>
+                  <optionName>visualizationType</optionName>
+                  <optionValue>${this.get("visualizationType")}</optionValue>
+                </option></section>`;
           const xmlDocument = new DOMParser().parseFromString(
             xmlText,
             "text/xml",
           );
-          [objectDOM] = $(xmlDocument).children();
+          [objectDOM] = $(xmlDocument).children().toArray();
         }
 
         // Update the required label

--- a/src/js/models/portals/PortalVizSectionModel.js
+++ b/src/js/models/portals/PortalVizSectionModel.js
@@ -26,6 +26,28 @@ define(["jquery", "models/portals/PortalSectionModel", "models/maps/Map"], (
       },
 
       /**
+       * Initializes a PortalVizSectionModel instance.
+       * @param {object} [attributes] - The attributes to set on the model
+       * @param {object} [attributes.mapConfig] - The map configuration to
+       * initialize the map model with
+       * @param {object} [options] - Options to pass to the model
+       * @since 0.0.0
+       */
+      initialize(attributes = {}, options = {}) {
+        PortalSectionModel.prototype.initialize.call(this, attributes, options);
+
+        // If this is a Cesium map section, initialize the map model
+        const isCesium =
+          this.get("visualizationType") === "cesium" ||
+          attributes?.visualizationType === "cesium";
+        const mapConfig = attributes?.mapConfig || this.get("mapConfig");
+        const mapModel = attributes?.mapModel || this.get("mapModel");
+        if (isCesium) {
+          this.initializeCesiumMap(mapConfig || mapModel);
+        }
+      },
+
+      /**
        * Parses a <section> element from a portal document
        *  @param {XMLElement} objectDOM - A ContentSectionType XML element from
        *  a portal document
@@ -69,15 +91,29 @@ define(["jquery", "models/portals/PortalSectionModel", "models/maps/Map"], (
             let mapConfig = {};
             if (mapConfigNode.length) {
               mapConfig = mapConfigNode.first().siblings("optionValue").text();
-              if (mapConfig && mapConfig.length) {
+              if (mapConfig?.length) {
                 mapConfig = JSON.parse(mapConfig);
               }
             }
-            modelJSON.mapModel = new Map(mapConfig);
+            this.initializeCesiumMap(mapConfig);
           }
         }
 
         return modelJSON;
+      },
+
+      /**
+       * Initializes a Cesium map model for this portal section.
+       * @param {object|Map} [mapConfigOrModel] The map to initialize the map
+       * model with
+       * @since 0.0.0
+       */
+      initializeCesiumMap(mapConfigOrModel = {}) {
+        const mapModel =
+          mapConfigOrModel instanceof Map
+            ? mapConfigOrModel
+            : new Map(mapConfigOrModel || {});
+        this.set("mapModel", mapModel);
       },
 
       /**

--- a/src/js/templates/portals/editor/portEditorSectionOptionImgs/cesiumViewer.svg
+++ b/src/js/templates/portals/editor/portEditorSectionOptionImgs/cesiumViewer.svg
@@ -1,0 +1,37 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 165 180" width="165" height="180">
+  <defs>
+    <clipPath id="cesium-viewer-globe-clip">
+      <circle cx="82.5" cy="111" r="72"/>
+    </clipPath>
+  </defs>
+
+  <g transform="translate(0 -8)">
+    <circle cx="82.5" cy="114" r="72" fill="#e0e0e0" opacity=".45"/>
+    <circle cx="82.5" cy="111" r="72" class="theme-primary-fill" opacity=".5"/>
+
+    <g clip-path="url(#cesium-viewer-globe-clip)">
+      <g fill="none" stroke="#fafafa" stroke-width="1.4" opacity=".65" transform="rotate(-10 82.5 111)">
+        <ellipse cx="82.5" cy="111" rx="28" ry="72"/>
+        <ellipse cx="82.5" cy="111" rx="52" ry="72"/>
+        <path d="M10.5 111h144M15.5 85c35 15 99 15 134 0M15.5 137c35-15 99-15 134 0"/>
+      </g>
+
+      <path fill="#e0e0e0" d="M8 78c12-8 26-10 38-5l12-3 12 10-5 11-10 4-4 9-8 2-2 13-10 5-10-8-1-12-9-6z"/>
+      <path class="theme-secondary-fill" d="M84 50c13-9 30-6 43 3l14 12 14 15-4 13-14 3-8 11-14-2-7-11-10-5-6-13-10-8z" opacity=".8"/>
+      <path class="theme-secondary-fill" d="M96 91l18 5 8 13-7 14-3 17-10 10-7-14-5-16-5-13z" opacity=".8"/>
+      <path fill="#c7c7c7" d="M123 139c9-7 23-6 31 2l-4 13-15 6-12-8z"/>
+      <path fill="#e0e0e0" d="M14 164c23-9 45-5 66 3 24 9 51 6 74-3l10 23H2z"/>
+
+      <g fill="none" stroke="#fafafa" stroke-width="1.4" opacity=".35" transform="rotate(-10 82.5 111)">
+        <ellipse cx="82.5" cy="111" rx="28" ry="72"/>
+        <ellipse cx="82.5" cy="111" rx="52" ry="72"/>
+        <path d="M10.5 111h144M15.5 85c35 15 99 15 134 0M15.5 137c35-15 99-15 134 0"/>
+      </g>
+    </g>
+
+    <circle cx="82.5" cy="111" r="72" fill="none" stroke="#c7c7c7" stroke-width="2"/>
+
+    <path class="theme-accent-fill" d="M105 57a14 14 0 0 0-14 14c0 10 14 26 14 26s14-16 14-26a14 14 0 0 0-14-14z"/>
+    <circle cx="105" cy="71" r="5.5" fill="#fafafa"/>
+  </g>
+</svg>

--- a/src/js/views/maps/mapEditor/MapEditorView.js
+++ b/src/js/views/maps/mapEditor/MapEditorView.js
@@ -1,0 +1,77 @@
+"use strict";
+
+define(["backbone", "models/maps/Map"], (Backbone, Map) => {
+  /**
+   * @class MapEditorView
+   * @classdesc Displays a map configuration for editing.
+   * @classcategory Views/Maps/MapEditor
+   * @augments Backbone.View
+   * @screenshot views/maps/mapEditor/MapEditorView.png
+   * @since 0.0.0
+   */
+  const MapEditorView = Backbone.View.extend(
+    /** @lends MapEditorView.prototype */ {
+      /**
+       * The map configuration model.
+       * @type {Map}
+       */
+      model: null,
+
+      /**
+       * The HTML classes to use for this view's element.
+       * @type {string}
+       */
+      className: "map-editor",
+
+      /**
+       * The HTML attributes to set on this view's element.
+       * @type {object}
+       */
+      attributes: {
+        "data-category": "map",
+      },
+
+      /**
+       * Create the HTML for this view.
+       * @param {object} variables The variables to use in the template.
+       * @returns {string} The HTML for this view.
+       */
+      template(variables) {
+        const { layerNames } = variables;
+        const layerItems = layerNames
+          .map((name) => `<li>${name}</li>`)
+          .join("");
+        return `<div class="map-editor">
+          <h3>Map Editor</h3>
+          <p>Layers in this map:</p>
+          <ul>${layerItems}</ul>
+        </div>`;
+      },
+
+      /** @inheritdoc */
+      initialize(options = {}) {
+        this.model = options.model || new Map();
+      },
+
+      /**
+       * Displays the map configuration as JSON.
+       * @returns {MapEditorView} This view
+       */
+      render() {
+        const layers = this.model.getAllLayers();
+        const layerNames = layers.map((layer) => layer.get("label"));
+        this.el.innerHTML = this.template({ layerNames });
+        return this;
+      },
+
+      /**
+       * Cleans up the view and stops listening to events.
+       */
+      onClose() {
+        this.stopListening();
+      },
+    },
+  );
+
+  return MapEditorView;
+});

--- a/src/js/views/portals/editor/PortEditorMapSectionView.js
+++ b/src/js/views/portals/editor/PortEditorMapSectionView.js
@@ -1,0 +1,21 @@
+define(["views/portals/editor/PortEditorSectionView"], (
+  PortEditorSectionView,
+) => {
+  const PortEditorMapSectionView = PortEditorSectionView.extend(
+    /** @lends PortEditorMapSectionView.prototype */ {
+      type: "PortEditorMapSection",
+      className: `${PortEditorSectionView.prototype.className} port-editor-map port-editor-viz`,
+      attributes: {
+        "data-category": "sections",
+      },
+      sectionType: "cesium",
+      events: {},
+      render() {
+        this.$el.data("view", this);
+        return this;
+      },
+    },
+  );
+
+  return PortEditorMapSectionView;
+});

--- a/src/js/views/portals/editor/PortEditorMapSectionView.js
+++ b/src/js/views/portals/editor/PortEditorMapSectionView.js
@@ -1,18 +1,98 @@
-define(["views/portals/editor/PortEditorSectionView"], (
-  PortEditorSectionView,
-) => {
+define([
+  "views/portals/editor/PortEditorSectionView",
+  "views/maps/mapEditor/MapEditorView",
+], (PortEditorSectionView, MapEditorView) => {
+  const CLASS_NAMES = {};
+
+  /**
+   * @class PortEditorMapSectionView
+   * @classdesc A Portal Editor section representing a Cesium map page.
+   * @classcategory Views/Maps/MapEditor
+   * @augments PortEditorSectionView
+   * @screenshot views/maps/mapEditor/PortEditorMapSectionView.png // TODO
+   * @since 0.0.0
+   */
   const PortEditorMapSectionView = PortEditorSectionView.extend(
     /** @lends PortEditorMapSectionView.prototype */ {
+      /**
+       * The type of view this is.
+       * @type {string}
+       * @readonly
+       */
       type: "PortEditorMapSection",
+
+      /**
+       * The HTML classes to use for this view's element.
+       * @type {string}
+       */
       className: `${PortEditorSectionView.prototype.className} port-editor-map port-editor-viz`,
+
+      /**
+       * The HTML attributes to set on this view's element.
+       * @type {object}
+       */
       attributes: {
         "data-category": "sections",
       },
+
+      /**
+       * The type of section view this is.
+       * @type {string}
+       * @readonly
+       */
       sectionType: "cesium",
+
+      /**
+       * The events this view listens to and their associated handlers.
+       * @type {object}
+       */
       events: {},
+
+      /**
+       * Creates the HTML for this view.
+       * @param {object} variables The variables to use in the template.
+       * @returns {string} The HTML for this view.
+       */
+      template(variables) {
+        const { title } = variables;
+        const CN = CLASS_NAMES;
+        return `<h2>${title}</h2>
+          <div class="${CN.mapContainer}"></div>`;
+      },
+
+      /**
+       * Attaches this view to its element for lookup by the portal editor.
+       * @returns {PortEditorMapSectionView} This view
+       */
       render() {
         this.$el.data("view", this);
+        const vars = {
+          title: this.model.get("title"),
+        };
+        this.$el.html(this.template(vars));
+        const mapContainer = this.el.querySelector(
+          `.${CLASS_NAMES.mapContainer}`,
+        );
+        this.mapEditorView = new MapEditorView({
+          model: this.model.get("mapModel"),
+          el: mapContainer,
+        });
+        this.mapEditorView.render();
         return this;
+      },
+
+      onClose() {
+        if (this.mapEditorView) {
+          this.mapEditorView.onClose();
+          this.mapEditorView.remove();
+          this.mapEditorView = null;
+        }
+        this.stopListening();
+      },
+
+      remove() {
+        this.onClose();
+        return PortEditorSectionView.prototype.remove.call(this);
       },
     },
   );

--- a/src/js/views/portals/editor/PortEditorSectionView.js
+++ b/src/js/views/portals/editor/PortEditorSectionView.js
@@ -6,6 +6,7 @@ define([
   "text!templates/portals/editor/portEditorSectionOption.html",
   "text!templates/portals/editor/portEditorSectionOptionImgs/freeform.svg",
   "text!templates/portals/editor/portEditorSectionOptionImgs/metrics.svg",
+  "text!templates/portals/editor/portEditorSectionOptionImgs/cesiumViewer.svg",
 ], (
   _,
   $,
@@ -14,6 +15,7 @@ define([
   SectionOptionTemplate,
   FreeformSVG,
   MetricsSVG,
+  CesiumSVG,
 ) => {
   /**
    * @class PortEditorSectionView
@@ -117,6 +119,12 @@ define([
           limiter: "hideMetrics",
           svg: MetricsSVG,
         },
+        cesium: {
+          title: "3D Map",
+          description: "Show your data on a 3D map",
+          limiter: 1,
+          svg: CesiumSVG,
+        },
       },
 
       /**
@@ -163,6 +171,13 @@ define([
           _.each(
             this.sectionsOptions,
             function renderSectionOption(sectionData, sectionType) {
+              if (
+                sectionType === "cesium" &&
+                !MetacatUI.appModel.get("enableCesium")
+              ) {
+                return;
+              }
+
               this.$(this.sectionsOptionsContainer).append(
                 this.sectionOptionTemplate({
                   id: `section-option-${sectionType}`,
@@ -198,6 +213,14 @@ define([
                     }
                   },
                 );
+              } else if (
+                typeof sectionData.limiter === "number" ||
+                sectionData.limiter instanceof Number
+              ) {
+                this.stopListening(this.model, "change:sections");
+                this.listenTo(this.model, "change:sections", () => {
+                  this.toggleDisableSectionOption(sectionType);
+                });
               }
             },
             this,
@@ -238,7 +261,16 @@ define([
             // If limiter's a number, compare it to the count of sections in the
             // model
           } else if (typeof limiter === "number" || limiter instanceof Number) {
-            if (this.model.get("sections").length < limiter) {
+            const sections = this.model.get("sections");
+            const sectionCount =
+              sectionType === "cesium"
+                ? sections.filter(
+                    (section) =>
+                      section.get("visualizationType") === sectionType,
+                  ).length
+                : sections.length;
+
+            if (sectionCount < limiter) {
               this.enableSectionOption(sectionType);
             } else {
               this.disableSectionOption(sectionType);

--- a/src/js/views/portals/editor/PortEditorSectionsView.js
+++ b/src/js/views/portals/editor/PortEditorSectionsView.js
@@ -9,6 +9,7 @@ define([
   "views/portals/editor/PortEditorSettingsView",
   "views/portals/editor/PortEditorDataView",
   "views/portals/editor/PortEditorMdSectionView",
+  "views/portals/editor/PortEditorMapSectionView",
   "text!templates/portals/editor/portEditorSections.html",
   "text!templates/portals/editor/portEditorMetrics.html",
   "text!templates/portals/editor/portEditorSectionLink.html",
@@ -24,6 +25,7 @@ define([
   PortEditorSettingsView,
   PortEditorDataView,
   PortEditorMdSectionView,
+  PortEditorMapSectionView,
   Template,
   MetricsSectionTemplate,
   SectionLinkTemplate,
@@ -364,8 +366,7 @@ define([
         // Get the sections from the Portal
         const sections = this.model.get("sections");
 
-        // Render each markdown (aka "freeform") section already in the
-        // PortalModel
+        // Render each content section already in the PortalModel
         _.each(
           sections,
           function renderSection(section) {
@@ -385,51 +386,54 @@ define([
       },
 
       /**
-       * Render a single markdown section in the editor (sectionView + link)
+       * Render a single content section in the editor (sectionView + link)
        * @param {PortalSectionModel} section - The section to render
        * @param {boolean} isNew - If true, this section will be rendered as a
        * section that was just added by the user
        */
       renderContentSection(section, isNew) {
         try {
-          const isNewSection =
-            typeof isNew === "undefined" || isNew === null ? false : isNew;
+          if (!section) return;
+          const isNewSection = isNew === true;
+          const sectionType = section.get("sectionType");
+          const vizType = section.get("visualizationType");
 
-          if (section) {
-            // Create and render and markdown section view
-            const sectionView = new PortEditorMdSectionView({
+          let sectionView = null;
+          if (sectionType === "visualization" && vizType === "cesium") {
+            sectionView = new PortEditorMapSectionView({
               model: section,
             });
-
-            // Pass the portal editor view onto the section
-            sectionView.editorView = this.editorView;
-
-            // Create a unique label for this section and save it
-            const uniqueLabel = this.getUniqueSectionLabel(section);
-
-            // Set the unique section label for this view
-            sectionView.uniqueSectionLabel = uniqueLabel;
-
-            this.updateSectionLabelsList(uniqueLabel);
-
-            sectionView.$el.attr("id", uniqueLabel);
-
-            // Insert the PortEditorMdSectionView element into this view
-            this.$(this.sectionsContainer).append(sectionView.$el);
-
-            // Render the PortEditorMdSectionView
-            sectionView.render();
-
-            // Add the tab to the tab navigation
-            this.addSectionLink(
-              sectionView,
-              ["Rename", "Delete"],
-              isNewSection,
-            );
-
-            // Add the sections to the list of subviews
-            this.subviews.push(sectionView);
+          } else {
+            // Create and render and markdown section view
+            sectionView = new PortEditorMdSectionView({
+              model: section,
+            });
           }
+
+          // Pass the portal editor view onto the section
+          sectionView.editorView = this.editorView;
+
+          // Create a unique label for this section and save it
+          const uniqueLabel = this.getUniqueSectionLabel(section);
+
+          // Set the unique section label for this view
+          sectionView.uniqueSectionLabel = uniqueLabel;
+
+          this.updateSectionLabelsList(uniqueLabel);
+
+          sectionView.$el.attr("id", uniqueLabel);
+
+          // Insert the section view element into this view
+          this.$(this.sectionsContainer).append(sectionView.$el);
+
+          // Render the section view
+          sectionView.render();
+
+          // Add the tab to the tab navigation
+          this.addSectionLink(sectionView, ["Rename", "Delete"], isNewSection);
+
+          // Add the sections to the list of subviews
+          this.subviews.push(sectionView);
         } catch (e) {
           // Preserve the diagnostic when a section cannot be rendered.
           // eslint-disable-next-line no-console
@@ -833,6 +837,10 @@ define([
           const newLink = this.createSectionLink(sectionView, menuOptions);
           const isMarkdownSection =
             $(newLink).data("view").type === "PortEditorMdSection";
+          const isContentSection = Object.prototype.isPrototypeOf.call(
+            PortalSection.prototype,
+            sectionView.model,
+          );
 
           // Make the tab hidden to start
           $(newLink)
@@ -852,27 +860,28 @@ define([
             `${this.sectionLinkContainer}[data-section-name='${this.addPageLabel}']`,
           )[0];
 
-          // If the new link is for a markdown section and there's no
-          // user-defined page order, then insert the markdown sections before
-          // the data and metrics section (this is the default order when there
-          // is no page ordering).
+          // If the new link is for a content section and there's no user-defined
+          // page order, then insert it before the data and metrics sections.
           if (
-            isMarkdownSection &&
+            isContentSection &&
             (!view.model.get("pageOrder") ||
               !view.model.get("pageOrder").length)
           ) {
-            // Find the last markdown section in the list of links
+            // Find the last content section in the list of links
             const currentLinks = this.$(this.sectionLinksContainer).find(
               this.sectionLinkContainer,
             );
-            const i = _.map(currentLinks, (li) =>
-              $(li).data("view") ? $(li).data("view").type : "",
-            ).lastIndexOf("PortEditorMdSection");
-            const lastMdSection = currentLinks[i];
-            // Append the new link after the last markdown section, or add it
-            // first.
-            if (lastMdSection) {
-              $(lastMdSection).after(newLink);
+            const lastContentSection = currentLinks
+              .filter((index, link) =>
+                Object.prototype.isPrototypeOf.call(
+                  PortalSection.prototype,
+                  $(link).data("model"),
+                ),
+              )
+              .last();
+            // Append the new link after the last content section, or add it first.
+            if (lastContentSection.length) {
+              lastContentSection.after(newLink);
             } else {
               this.$(this.sectionLinksContainer).prepend(newLink);
             }
@@ -1146,57 +1155,44 @@ define([
       addSection(sectionType) {
         try {
           // Create a new section to the Portal model
-          this.model.addSection(sectionType);
+          const newSection = this.model.addSection(sectionType);
+          if (!sectionType || typeof sectionType !== "string") return;
 
-          if (typeof sectionType === "string") {
-            switch (sectionType.toLowerCase()) {
-              case "data":
-                this.switchSection(this.dataView);
-                break;
-              case "metrics":
-                this.renderMetricsSection();
-                this.switchSection(this.metricsView);
-                break;
-              case "freeform": {
-                // Set up page ordering if it isn't already. This allows us to
-                // add a new freeform page at the end of the list of tabs,
-                // instead of before Data and Metrics (the default before page
-                // ordering was enabled).
-                const freeformPageOrder = this.model.get("pageOrder");
-                if (!freeformPageOrder || !freeformPageOrder.length) {
-                  this.updatePageOrder();
-                }
-                // Get the section model that was just added
-                const newestSection =
-                  this.model.get("sections")[
-                    this.model.get("sections").length - 1
-                  ];
-                // Render the content section view for it
-                this.renderContentSection(newestSection, true);
-                // Switch to that new view
-                this.switchSection(this.getSectionByModel(newestSection));
-                break;
+          switch (sectionType.toLowerCase()) {
+            case "data":
+              this.switchSection(this.dataView);
+              break;
+            case "metrics":
+              this.renderMetricsSection();
+              this.switchSection(this.metricsView);
+              break;
+            case "freeform":
+            case "cesium": {
+              if (!this.model.get("pageOrder")?.length) {
+                this.updatePageOrder();
               }
-              case "members":
-                // TODO this.switchSection(this.getSectionByLabel("Members"));
-                break;
-              default:
-                break;
+              // Render the content section view for it
+              this.renderContentSection(newSection, true);
+              // Switch to that new view
+              this.switchSection(this.getSectionByModel(newSection));
+              break;
             }
-
-            // If the section we just added is now one of two sections,
-            // re-enable the hide/delete button on the other section link.
-            this.toggleRemoveSectionOption();
-
-            this.editorView.showControls();
-
-            // Add the item to the the pageOrder option on the model, if it
-            // exists
-            const pageOrder = this.model.get("pageOrder");
-            if (pageOrder && pageOrder.length) {
-              this.updatePageOrder();
-            }
+            case "members":
+              // TODO this.switchSection(this.getSectionByLabel("Members"));
+              break;
+            default:
+              break;
           }
+
+          // If the section we just added is now one of two sections,
+          // re-enable the hide/delete button on the other section link.
+          this.toggleRemoveSectionOption();
+
+          this.editorView.showControls();
+
+          // Add the item to the the pageOrder option on the model, if it
+          // exists
+          if (this.model.get("pageOrder")?.length) this.updatePageOrder();
         } catch (e) {
           // Preserve the diagnostic when a section cannot be added.
           // eslint-disable-next-line no-console
@@ -1213,6 +1209,8 @@ define([
        */
       removeSection(event, sectionLink) {
         try {
+          if (event && $(event.currentTarget).hasClass("disabled")) return;
+
           let resolvedSectionLink = sectionLink;
           if (!resolvedSectionLink || !resolvedSectionLink.length) {
             const clickedEl = $(event.target);

--- a/test/js/specs/unit/models/portals/PortalVizSectionModel.spec.js
+++ b/test/js/specs/unit/models/portals/PortalVizSectionModel.spec.js
@@ -159,6 +159,25 @@ define([
       expect(portal.get("sections")[0]).to.equal(sectionToKeep);
     });
 
+    it("creates a Cesium section by type", () => {
+      const portal = new PortalModel({});
+      const section = portal.addSection("cesium");
+
+      expect(section).to.be.instanceof(PortalVizSectionModel);
+      expect(section.get("visualizationType")).to.equal("cesium");
+      expect(portal.sectionIsDefault(section)).to.equal(false);
+
+      section.set("label", "Map");
+      const sectionDOM = section.updateDOM();
+      expect(sectionDOM.getElementsByTagName("label")[0].textContent).to.equal(
+        "Map",
+      );
+      expect(sectionDOM.firstElementChild.tagName).to.equal("label");
+      expect(getOptionValue(sectionDOM, "visualizationType")).to.equal(
+        "cesium",
+      );
+    });
+
     it("round-trips freeform and Cesium sections through serialization", () => {
       const portal = createMixedPortal();
       const serializedPortal = portal.serialize();

--- a/test/js/specs/unit/models/portals/PortalVizSectionModel.spec.js
+++ b/test/js/specs/unit/models/portals/PortalVizSectionModel.spec.js
@@ -165,6 +165,7 @@ define([
 
       expect(section).to.be.instanceof(PortalVizSectionModel);
       expect(section.get("visualizationType")).to.equal("cesium");
+      expect(section.get("mapModel")).to.be.instanceof(Map);
       expect(portal.sectionIsDefault(section)).to.equal(false);
 
       section.set("label", "Map");

--- a/test/js/specs/unit/views/portals/editor/PortEditorSectionView.spec.js
+++ b/test/js/specs/unit/views/portals/editor/PortEditorSectionView.spec.js
@@ -1,14 +1,24 @@
 define([
   "jquery",
   "backbone",
+  "models/portals/PortalSectionModel",
+  "models/portals/PortalVizSectionModel",
   "views/portals/editor/PortEditorSectionView",
   "/test/js/specs/shared/clean-state.js",
-], ($, Backbone, PortEditorSectionView, cleanState) => {
+], (
+  $,
+  Backbone,
+  PortalSectionModel,
+  PortalVizSectionModel,
+  PortEditorSectionView,
+  cleanState,
+) => {
   const expect = chai.expect;
 
   describe("PortEditorSectionView Test Suite", () => {
     const state = cleanState(() => {
       const sandbox = sinon.createSandbox();
+      const enableCesium = MetacatUI.appModel.get("enableCesium");
       const originalTooltip = $.fn.tooltip;
       $.fn.tooltip = sandbox.stub().callsFake(function tooltipStub() {
         return this;
@@ -23,12 +33,19 @@ define([
       view.on("addNewSection", addNewSectionSpy);
       view.render();
 
-      return { addNewSectionSpy, originalTooltip, sandbox, view };
+      return {
+        addNewSectionSpy,
+        enableCesium,
+        originalTooltip,
+        sandbox,
+        view,
+      };
     }, beforeEach);
 
     afterEach(() => {
       state.view.off();
       state.view.remove();
+      MetacatUI.appModel.set("enableCesium", state.enableCesium);
       $.fn.tooltip = state.originalTooltip;
       state.sandbox.restore();
     });
@@ -48,6 +65,38 @@ define([
       option.find("h5").trigger("click");
 
       expect(state.addNewSectionSpy.called).to.equal(false);
+    });
+
+    it("tracks Cesium availability independently of other sections", () => {
+      const freeformSection = new PortalSectionModel();
+      const cesiumSection = new PortalVizSectionModel({
+        visualizationType: "cesium",
+      });
+      const model = new Backbone.Model({
+        hideMetrics: false,
+        sections: [freeformSection],
+      });
+      const view = new PortEditorSectionView({ model });
+      view.render();
+      const option = view.$("#section-option-cesium");
+
+      expect(option.hasClass("disabled")).to.equal(false);
+
+      model.set("sections", [freeformSection, cesiumSection]);
+      expect(option.hasClass("disabled")).to.equal(true);
+
+      model.set("sections", [freeformSection]);
+      expect(option.hasClass("disabled")).to.equal(false);
+
+      view.remove();
+    });
+
+    it("does not offer Cesium when it is disabled", () => {
+      MetacatUI.appModel.set("enableCesium", false);
+
+      state.view.render();
+
+      expect(state.view.$("#section-option-cesium")).to.have.length(0);
     });
   });
 });

--- a/test/js/specs/unit/views/portals/editor/PortEditorSectionsView.spec.js
+++ b/test/js/specs/unit/views/portals/editor/PortEditorSectionsView.spec.js
@@ -2,6 +2,7 @@ define([
   "jquery",
   "backbone",
   "models/portals/PortalSectionModel",
+  "models/portals/PortalVizSectionModel",
   "views/portals/editor/PortEditorMdSectionView",
   "views/portals/editor/PortEditorSectionsView",
   "/test/js/specs/shared/clean-state.js",
@@ -9,6 +10,7 @@ define([
   $,
   Backbone,
   PortalSectionModel,
+  PortalVizSectionModel,
   PortEditorMdSectionView,
   PortEditorSectionsView,
   cleanState,
@@ -23,12 +25,12 @@ define([
         sections: [],
       });
       model.addSection = (sectionType) => {
+        let section = null;
         if (sectionType === "freeform") {
-          model.set("sections", [
-            ...model.get("sections"),
-            new PortalSectionModel(),
-          ]);
+          section = new PortalSectionModel();
+          model.set("sections", [...model.get("sections"), section]);
         }
+        return section;
       };
       model.removeSection = (section) => {
         model.set(
@@ -68,6 +70,7 @@ define([
       expect(sectionView.model).to.equal(section);
       expect(state.view.el.contains(sectionView.el)).to.equal(true);
       expect(state.view.switchSection.calledWith(sectionView)).to.equal(true);
+      expect(state.view.updatePageOrder.calledOnce).to.equal(true);
     });
 
     it("removes a freeform section", () => {
@@ -84,6 +87,12 @@ define([
         .data("view", sectionView)
         .data("section-type", "freeform");
 
+      state.view.removeSection(
+        { currentTarget: $('<a class="disabled"></a>')[0] },
+        sectionLink,
+      );
+      expect(state.model.get("sections")).to.deep.equal([section]);
+
       state.view.removeSection(null, sectionLink);
 
       expect(state.model.get("sections")).to.deep.equal([]);
@@ -93,6 +102,37 @@ define([
       expect(state.view.removeSectionLink.calledWith(sectionView)).to.equal(
         true,
       );
+    });
+
+    it("places a Cesium section before non-content pages by default", () => {
+      state.view.addSectionLink.restore();
+      state.view.$el.html(`
+        <ul class="section-links-container">
+          <li class="section-link-container" data-section-name="Data"></li>
+          <li class="section-link-container" data-section-name="AddPage"></li>
+        </ul>
+      `);
+
+      const sectionView = new Backbone.View({
+        model: new PortalVizSectionModel({
+          label: "Map",
+          visualizationType: "cesium",
+        }),
+      });
+      sectionView.type = "PortEditorMapSection";
+      sectionView.sectionType = "cesium";
+      sectionView.uniqueSectionLabel = "Map";
+
+      state.view.addSectionLink(sectionView, [], false);
+
+      const sectionNames = state.view
+        .$(state.view.sectionLinksContainer)
+        .children()
+        .map((index, link) => $(link).data("section-name"))
+        .get();
+      expect(sectionNames).to.deep.equal(["Map", "Data", "AddPage"]);
+
+      sectionView.remove();
     });
   });
 });

--- a/test/js/specs/unit/views/portals/editor/PortEditorSectionsView.spec.js
+++ b/test/js/specs/unit/views/portals/editor/PortEditorSectionsView.spec.js
@@ -1,16 +1,20 @@
 define([
   "jquery",
   "backbone",
+  "models/maps/Map",
   "models/portals/PortalSectionModel",
   "models/portals/PortalVizSectionModel",
+  "views/portals/editor/PortEditorMapSectionView",
   "views/portals/editor/PortEditorMdSectionView",
   "views/portals/editor/PortEditorSectionsView",
   "/test/js/specs/shared/clean-state.js",
 ], (
   $,
   Backbone,
+  Map,
   PortalSectionModel,
   PortalVizSectionModel,
+  PortEditorMapSectionView,
   PortEditorMdSectionView,
   PortEditorSectionsView,
   cleanState,
@@ -71,6 +75,21 @@ define([
       expect(state.view.el.contains(sectionView.el)).to.equal(true);
       expect(state.view.switchSection.calledWith(sectionView)).to.equal(true);
       expect(state.view.updatePageOrder.calledOnce).to.equal(true);
+    });
+
+    it("uses the Cesium section map model in its map editor", () => {
+      const mapModel = new Map();
+      const section = new PortalVizSectionModel({
+        label: "Map",
+        visualizationType: "cesium",
+        mapModel,
+      });
+
+      state.view.renderContentSection(section);
+
+      const sectionView = state.view.getSectionByModel(section);
+      expect(sectionView).to.be.instanceof(PortEditorMapSectionView);
+      expect(sectionView.mapEditorView.model).to.equal(mapModel);
     });
 
     it("removes a freeform section", () => {


### PR DESCRIPTION
This PR will include the ability to simply add and remove a default map page in the Portal Editor. It will set up all of the basic infrastructure we will need for further editing - like a MapEditorView and pathways serialize the mapConfig into the portal xml.